### PR TITLE
docs: NRL endpoint reference + sample (closes #5)

### DIFF
--- a/docs/nrl-endpoints.md
+++ b/docs/nrl-endpoints.md
@@ -1,0 +1,69 @@
+# NRL endpoints
+
+Reference for the two `nrl.com` JSON endpoints this project depends on. No auth required; both are plain `GET` with no cookies or special headers.
+
+## Fixtures list (per round)
+
+```
+GET https://www.nrl.com/draw/data?competition=111&round={N}&season={YEAR}
+```
+
+Returns all matches in a given round, plus byes and dropdown filter metadata.
+
+**Params**
+
+| Name          | Example  | Notes                                                                |
+|---------------|----------|----------------------------------------------------------------------|
+| `competition` | `111`    | NRL Telstra Premiership. Other values available in `filterCompetitions` of the response (e.g. `161` Women's, `119` Pre-Season) |
+| `round`       | `1`–`27` | Regular season. `28+` returns finals weeks                           |
+| `season`      | `2024`   | Historically valid range per `filterSeasons` (1908–2026)             |
+
+**Key fields (per fixture)**
+
+- `matchCentreUrl` — `/draw/nrl-premiership/{year}/round-{n}/{home}-v-{away}/`. Append `/data` for the per-match endpoint below.
+- `homeTeam.teamId`, `awayTeam.teamId` — stable integer team IDs.
+- `homeTeam.theme.key`, `awayTeam.theme.key` — slug form of the team name (e.g. `wests-tigers`, `sea-eagles`). Matches the slug used in `matchCentreUrl`.
+- `homeTeam.nickName`, `awayTeam.nickName` — display names.
+- `homeTeam.odds`, `awayTeam.odds` — decimal bookmaker odds. **Populated only for upcoming fixtures in the current season; dropped once matches finish. Cannot be used as a historical training feature.**
+- `homeTeam.teamPosition`, `awayTeam.teamPosition` — ladder position at request time (e.g. `"3rd"`).
+- `clock.kickOffTimeLong` — ISO 8601 UTC timestamp.
+- `venue`, `venueCity`.
+- `matchState` — observed values: `Upcoming`, `Pre`, `Live`, `FullTime`. Likely others.
+
+**Finals rounds**
+
+For `round >= 28`, fixture slugs are numbered rather than team-based:
+
+```
+/draw/nrl-premiership/2024/finals-week-1/game-1/
+/draw/nrl-premiership/2024/finals-week-1/game-2/
+```
+
+Scrapers must handle both `round-{n}/{home}-v-{away}` and `finals-week-{n}/game-{m}` formats.
+
+**Byes**
+
+Returned in a separate top-level `byes` array, one entry per team on bye that round.
+
+## Per-match detail
+
+```
+GET https://www.nrl.com/draw/nrl-premiership/{year}/{round-slug}/{match-slug}/data
+```
+
+- `{round-slug}` = `round-{n}` or `finals-week-{n}`
+- `{match-slug}` = `{home}-v-{away}` for regular rounds, `game-{n}` for finals weeks
+
+Returns rich per-match JSON: `matchId`, `homeTeam`/`awayTeam` with player lists + stats, `timeline`, `officials`, `venue`, `stats`, etc.
+
+**Schema stability**: consistent between 2024 and 2026. 2026 adds a `weather` key absent in 2024 — treat optional keys defensively.
+
+**Slug ordering**: `home-v-away`, not alphabetical. Wrong order returns 404. Always source slugs from the fixtures endpoint rather than constructing them manually.
+
+## Rate limits
+
+No documented rate limit. No `robots.txt` permission statement for these endpoints. Throttle to ~1 req/sec out of politeness.
+
+## Samples
+
+- [`samples/draw-round-8-2026.json`](samples/draw-round-8-2026.json) — trimmed fixtures-endpoint response

--- a/docs/samples/draw-round-8-2026.json
+++ b/docs/samples/draw-round-8-2026.json
@@ -1,0 +1,97 @@
+{
+  "_source": "GET https://www.nrl.com/draw/data?competition=111&round=8&season=2026",
+  "_captured": "2026-04-20",
+  "_note": "Trimmed for documentation. Original response includes 8 fixtures, 1 bye, 23 competitions in filterCompetitions, 119 seasons in filterSeasons, 17 teams in filterTeams. This sample keeps 2 fixtures and 3 entries per filter list.",
+  "fixtures": [
+    {
+      "isCurrentRound": true,
+      "roundTitle": "Round 8",
+      "type": "Match",
+      "matchMode": "Pre",
+      "matchState": "Upcoming",
+      "venue": "Leichhardt Oval",
+      "venueCity": "Sydney",
+      "matchCentreUrl": "/draw/nrl-premiership/2026/round-8/wests-tigers-v-raiders/",
+      "homeTeam": {
+        "teamId": 500023,
+        "nickName": "Wests Tigers",
+        "odds": "1.56",
+        "teamPosition": "3rd",
+        "theme": { "key": "wests-tigers" }
+      },
+      "awayTeam": {
+        "teamId": 500013,
+        "nickName": "Raiders",
+        "odds": "2.42",
+        "teamPosition": "13th",
+        "theme": { "key": "raiders" }
+      },
+      "clock": {
+        "kickOffTimeLong": "2026-04-23T09:50:00Z",
+        "gameTime": "0:00"
+      }
+    },
+    {
+      "isCurrentRound": true,
+      "roundTitle": "Round 8",
+      "type": "Match",
+      "matchMode": "Pre",
+      "matchState": "Upcoming",
+      "venue": "Queensland Country Bank Stadium",
+      "venueCity": "Townsville",
+      "matchCentreUrl": "/draw/nrl-premiership/2026/round-8/cowboys-v-sharks/",
+      "homeTeam": {
+        "teamId": 500012,
+        "nickName": "Cowboys",
+        "odds": "2.12",
+        "teamPosition": "11th",
+        "theme": { "key": "cowboys" }
+      },
+      "awayTeam": {
+        "teamId": 500028,
+        "nickName": "Sharks",
+        "odds": "1.73",
+        "teamPosition": "7th",
+        "theme": { "key": "sharks" }
+      },
+      "clock": {
+        "kickOffTimeLong": "2026-04-24T08:00:00Z",
+        "gameTime": "0:00"
+      }
+    }
+  ],
+  "byes": [
+    {
+      "isCurrentRound": true,
+      "roundTitle": "Round 8",
+      "type": "Bye",
+      "teamNickName": "Titans",
+      "theme": { "key": "titans" }
+    }
+  ],
+  "filterCompetitions": [
+    { "name": "Telstra Premiership", "value": 111, "theme": { "key": "nrl-premiership" } },
+    { "name": "Telstra Women's Premiership", "value": 161, "theme": { "key": "nrl-womens-premiership" } },
+    { "name": "Witzer Pre-Season Challenge", "value": 119, "theme": { "key": "pre-season-challenge" } }
+  ],
+  "filterSeasons": [
+    { "name": "2026", "value": 2026 },
+    { "name": "2025", "value": 2025 },
+    { "name": "2024", "value": 2024 }
+  ],
+  "filterRounds": [
+    { "name": "Round 1", "value": 1 },
+    { "name": "Round 8", "value": 8 },
+    { "name": "Round 27", "value": 27 }
+  ],
+  "filterTeams": [
+    { "name": "Wests Tigers", "value": 500023, "theme": { "key": "wests-tigers" } },
+    { "name": "Raiders", "value": 500013, "theme": { "key": "raiders" } },
+    { "name": "Cowboys", "value": 500012, "theme": { "key": "cowboys" } }
+  ],
+  "selectedCompetitionId": 111,
+  "selectedSeasonId": 2026,
+  "selectedRoundId": 8,
+  "showOdds": true,
+  "showTeamPositions": true
+}


### PR DESCRIPTION
## Summary
- Documents the two `nrl.com` JSON endpoints the scraper will use: fixtures list and per-match detail
- Captures the finals-round slug convention (`finals-week-N/game-M` rather than `round-N/home-v-away`)
- Saves a trimmed sample response so future schema drift is easy to diff against
- Flags that bookmaker odds populate only for upcoming current-season fixtures — they are **not** a viable historical training feature (has implications for #26 "odds as a feature")

## Endpoint confirmed working
`GET https://www.nrl.com/draw/data?competition=111&round={N}&season={YEAR}` — verified for 2024, 2025, 2026. No auth, no special headers.

## Test plan
- [x] Endpoint returns JSON for current season (2026 Round 8)
- [x] Endpoint returns JSON for prior season (2024 Round 8, 2024 Round 1)
- [x] Endpoint returns JSON for season before that (2025 Round 15)
- [x] Finals-round shape verified (2024 round=28 returns `finals-week-1/game-N` slugs)
- [x] No auth / cookie / header requirements

## Unblocks
Closes #5. Unblocks #9 (backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)