### PR TITLE
feat: SQLite repository for MatchRow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ packages = ["src/fantasy_coach"]
 dev = [
     "pytest>=8.3",
     "pytest-cov>=5.0",
+    "respx>=0.21",
     "ruff>=0.7",
     "pre-commit>=4.0",
 ]

--- a/src/fantasy_coach/features.py
+++ b/src/fantasy_coach/features.py
@@ -1,0 +1,205 @@
+"""Feature extraction from raw NRL `/data` payloads.
+
+Architectural decision (see issue #7): we don't persist the raw JSON. We
+extract a narrow row of fields the model needs and discard the rest, so
+storage stays small and schema drift surfaces as failed extractions
+rather than as silent rot inside opaque blobs.
+
+Schema drift strategy: any top-level or per-team key the extractor
+doesn't recognize is logged at WARNING level (once per call), but is not
+fatal. Missing fields default to None — most match payloads in
+`Upcoming` state lack scores, players, and stats, and that's expected.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+_KNOWN_TOP_LEVEL_KEYS = {
+    "animateMatchClock",
+    "attendance",
+    "awayTeam",
+    "broadcastChannels",
+    "competition",
+    "gameSeconds",
+    "groundConditions",
+    "hasExtraTime",
+    "hasOnFieldTracking",
+    "homeTeam",
+    "imageUrl",
+    "matchId",
+    "matchMode",
+    "matchState",
+    "officials",
+    "positionGroups",
+    "roundNumber",
+    "roundTitle",
+    "segmentCount",
+    "segmentDuration",
+    "showPlayerPositions",
+    "showTeamPositions",
+    "startTime",
+    "stats",
+    "timeline",
+    "updated",
+    "url",
+    "venue",
+    "venueCity",
+    "videoProviders",
+    "weather",
+}
+
+_KNOWN_TEAM_KEYS = {
+    "captainPlayerId",
+    "coaches",
+    "name",
+    "nextOpponent",
+    "nickName",
+    "odds",
+    "players",
+    "recentForm",
+    "score",
+    "scoring",
+    "teamId",
+    "teamPosition",
+    "theme",
+    "url",
+}
+
+
+class PlayerRow(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    player_id: int
+    jersey_number: int | None
+    position: str | None
+    first_name: str | None
+    last_name: str | None
+
+
+class TeamRow(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    team_id: int
+    name: str
+    nick_name: str
+    score: int | None
+    players: list[PlayerRow]
+
+
+class TeamStat(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    title: str
+    type: str
+    units: str | None
+    home_value: float | None
+    away_value: float | None
+
+
+class MatchRow(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    match_id: int
+    season: int
+    round: int
+    start_time: datetime
+    match_state: str
+    venue: str | None
+    venue_city: str | None
+    weather: str | None
+    home: TeamRow
+    away: TeamRow
+    team_stats: list[TeamStat]
+
+
+def extract_match_features(raw: dict[str, Any]) -> MatchRow:
+    """Project raw `/data` JSON into a narrow `MatchRow` for storage."""
+
+    _log_unknown_keys("match", raw, _KNOWN_TOP_LEVEL_KEYS)
+
+    start_time = _parse_iso_utc(raw["startTime"])
+
+    return MatchRow(
+        match_id=int(raw["matchId"]),
+        season=start_time.year,
+        round=int(raw["roundNumber"]),
+        start_time=start_time,
+        match_state=str(raw["matchState"]),
+        venue=raw.get("venue"),
+        venue_city=raw.get("venueCity"),
+        weather=raw.get("weather"),
+        home=_extract_team(raw["homeTeam"]),
+        away=_extract_team(raw["awayTeam"]),
+        team_stats=_extract_team_stats(raw.get("stats") or {}),
+    )
+
+
+def _extract_team(raw: dict[str, Any]) -> TeamRow:
+    _log_unknown_keys("team", raw, _KNOWN_TEAM_KEYS)
+    return TeamRow(
+        team_id=int(raw["teamId"]),
+        name=str(raw["name"]),
+        nick_name=str(raw["nickName"]),
+        score=_optional_int(raw.get("score")),
+        players=[_extract_player(p) for p in raw.get("players") or []],
+    )
+
+
+def _extract_player(raw: dict[str, Any]) -> PlayerRow:
+    return PlayerRow(
+        player_id=int(raw["playerId"]),
+        jersey_number=_optional_int(raw.get("number")),
+        position=raw.get("position"),
+        first_name=raw.get("firstName"),
+        last_name=raw.get("lastName"),
+    )
+
+
+def _extract_team_stats(stats: dict[str, Any]) -> list[TeamStat]:
+    rows: list[TeamStat] = []
+    for group in stats.get("groups") or []:
+        for stat in group.get("stats") or []:
+            rows.append(
+                TeamStat(
+                    title=str(stat["title"]),
+                    type=str(stat["type"]),
+                    units=stat.get("units"),
+                    home_value=_stat_value(stat.get("homeValue")),
+                    away_value=_stat_value(stat.get("awayValue")),
+                )
+            )
+    return rows
+
+
+def _stat_value(raw: Any) -> float | None:
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        v = raw.get("value")
+        return float(v) if v is not None else None
+    return float(raw)
+
+
+def _optional_int(raw: Any) -> int | None:
+    if raw is None or raw == "":
+        return None
+    return int(raw)
+
+
+def _parse_iso_utc(raw: str) -> datetime:
+    # `2024-03-03T02:30:00Z` — fromisoformat handles `Z` from Python 3.11+.
+    return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+
+
+def _log_unknown_keys(scope: str, raw: dict[str, Any], known: set[str]) -> None:
+    unknown = sorted(set(raw.keys()) - known)
+    if unknown:
+        logger.warning("Unknown %s keys in payload: %s", scope, unknown)

--- a/src/fantasy_coach/scraper.py
+++ b/src/fantasy_coach/scraper.py
@@ -1,0 +1,153 @@
+"""NRL match /data scraper.
+
+Thin wrapper around the per-match endpoint documented in `docs/nrl-endpoints.md`.
+Throttled to be polite and retrying on transient failures; 404s return None
+because a wrong slug order (away-v-home vs home-v-away) is a common caller bug,
+not a server error worth crashing on.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import random
+import threading
+import time
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://www.nrl.com"
+USER_AGENT = (
+    "fantasy-coach/0.1 (+https://github.com/lopeztech/fantasy-coach; "
+    "research scraper; contact: joshua.lopez.tech@gmail.com)"
+)
+DEFAULT_TIMEOUT = 15.0
+DEFAULT_MAX_RETRIES = 3
+
+
+def _min_interval_seconds() -> float:
+    raw = os.getenv("FANTASY_COACH_SCRAPE_INTERVAL_SECONDS", "1.0")
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning("Invalid FANTASY_COACH_SCRAPE_INTERVAL_SECONDS=%r; using 1.0", raw)
+        return 1.0
+    return max(0.0, value)
+
+
+class _Throttle:
+    """Process-wide minimum interval between requests."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._last_request_at: float = 0.0
+
+    def wait(self, min_interval: float) -> None:
+        if min_interval <= 0:
+            return
+        with self._lock:
+            now = time.monotonic()
+            wait_for = self._last_request_at + min_interval - now
+            if wait_for > 0:
+                time.sleep(wait_for)
+                now = time.monotonic()
+            self._last_request_at = now
+
+
+_throttle = _Throttle()
+
+
+def _match_path(year: int, round_: int, home_slug: str, away_slug: str) -> str:
+    return f"/draw/nrl-premiership/{year}/round-{round_}/{home_slug}-v-{away_slug}/data"
+
+
+def fetch_match(
+    year: int,
+    round_: int,
+    home_slug: str,
+    away_slug: str,
+    *,
+    client: httpx.Client | None = None,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> dict[str, Any] | None:
+    """Fetch a single match's per-match JSON.
+
+    Returns the parsed JSON body on 200, or None on 404. Raises `httpx.HTTPError`
+    after exhausting retries on 5xx / network errors.
+
+    Slug order must be `home-v-away` (source from the fixtures endpoint —
+    wrong order returns 404 and is treated as a missing match, not an error).
+    """
+
+    path = _match_path(year, round_, home_slug, away_slug)
+    headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
+    interval = _min_interval_seconds()
+
+    owns_client = client is None
+    http = client or httpx.Client(base_url=BASE_URL, timeout=DEFAULT_TIMEOUT)
+    try:
+        for attempt in range(1, max_retries + 1):
+            _throttle.wait(interval)
+            try:
+                response = http.get(path, headers=headers)
+            except httpx.HTTPError as exc:
+                if attempt == max_retries:
+                    logger.error(
+                        "Network error fetching %s after %d attempts: %s",
+                        path,
+                        attempt,
+                        exc,
+                    )
+                    raise
+                delay = _backoff_delay(attempt)
+                logger.warning(
+                    "Network error fetching %s (attempt %d/%d): %s; retrying in %.2fs",
+                    path,
+                    attempt,
+                    max_retries,
+                    exc,
+                    delay,
+                )
+                time.sleep(delay)
+                continue
+
+            if response.status_code == 404:
+                logger.warning(
+                    "404 for %s — check slug order (expected home-v-away)",
+                    path,
+                )
+                return None
+            if 500 <= response.status_code < 600:
+                if attempt == max_retries:
+                    response.raise_for_status()
+                delay = _backoff_delay(attempt)
+                logger.warning(
+                    "%d from %s (attempt %d/%d); retrying in %.2fs",
+                    response.status_code,
+                    path,
+                    attempt,
+                    max_retries,
+                    delay,
+                )
+                time.sleep(delay)
+                continue
+
+            response.raise_for_status()
+            return response.json()
+
+        # Loop fell through without returning — should be unreachable because
+        # the last attempt either returns, raises, or is a 404 short-circuit.
+        raise RuntimeError("fetch_match retry loop exited without resolution")
+    finally:
+        if owns_client:
+            http.close()
+
+
+def _backoff_delay(attempt: int) -> float:
+    """Exponential backoff with jitter: 1s, 2s, 4s (+/- 25% jitter)."""
+    base = 2 ** (attempt - 1)
+    jitter = random.uniform(-0.25, 0.25) * base
+    return max(0.0, base + jitter)

--- a/src/fantasy_coach/storage/__init__.py
+++ b/src/fantasy_coach/storage/__init__.py
@@ -1,0 +1,4 @@
+from fantasy_coach.storage.repository import Repository
+from fantasy_coach.storage.sqlite import SQLiteRepository
+
+__all__ = ["Repository", "SQLiteRepository"]

--- a/src/fantasy_coach/storage/repository.py
+++ b/src/fantasy_coach/storage/repository.py
@@ -1,0 +1,20 @@
+"""Storage abstraction for match rows.
+
+Local dev uses `SQLiteRepository`; production will add a Firestore impl.
+Kept as a `Protocol` so the swap is mechanical and callers depend on the
+interface rather than the concrete class.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from fantasy_coach.features import MatchRow
+
+
+class Repository(Protocol):
+    def upsert_match(self, row: MatchRow) -> None: ...
+
+    def get_match(self, match_id: int) -> MatchRow | None: ...
+
+    def list_matches(self, season: int, round: int | None = None) -> list[MatchRow]: ...

--- a/src/fantasy_coach/storage/schema.sql
+++ b/src/fantasy_coach/storage/schema.sql
@@ -1,0 +1,53 @@
+-- Schema version 1.
+--
+-- One row per match in `matches`, children (`match_players`, `match_team_stats`)
+-- keyed by match_id + side ('home' | 'away'). Upserts are done by deleting the
+-- existing match rows and re-inserting, so children stay consistent.
+
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS matches (
+    match_id      INTEGER PRIMARY KEY,
+    season        INTEGER NOT NULL,
+    round         INTEGER NOT NULL,
+    start_time    TEXT    NOT NULL,  -- ISO 8601 UTC
+    match_state   TEXT    NOT NULL,
+    venue         TEXT,
+    venue_city    TEXT,
+    weather       TEXT,
+    home_team_id  INTEGER NOT NULL,
+    home_name     TEXT    NOT NULL,
+    home_nick     TEXT    NOT NULL,
+    home_score    INTEGER,
+    away_team_id  INTEGER NOT NULL,
+    away_name     TEXT    NOT NULL,
+    away_nick     TEXT    NOT NULL,
+    away_score    INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_matches_season_round
+    ON matches(season, round);
+
+CREATE TABLE IF NOT EXISTS match_players (
+    match_id       INTEGER NOT NULL REFERENCES matches(match_id) ON DELETE CASCADE,
+    side           TEXT    NOT NULL CHECK (side IN ('home', 'away')),
+    player_id      INTEGER NOT NULL,
+    jersey_number  INTEGER,
+    position       TEXT,
+    first_name     TEXT,
+    last_name      TEXT,
+    PRIMARY KEY (match_id, side, player_id)
+);
+
+CREATE TABLE IF NOT EXISTS match_team_stats (
+    match_id    INTEGER NOT NULL REFERENCES matches(match_id) ON DELETE CASCADE,
+    ordinal     INTEGER NOT NULL,
+    title       TEXT    NOT NULL,
+    type        TEXT    NOT NULL,
+    units       TEXT,
+    home_value  REAL,
+    away_value  REAL,
+    PRIMARY KEY (match_id, ordinal)
+);

--- a/src/fantasy_coach/storage/sqlite.py
+++ b/src/fantasy_coach/storage/sqlite.py
@@ -1,0 +1,233 @@
+"""SQLite implementation of `Repository`.
+
+Uses `sqlite3` stdlib — no ORM needed at this size. Upserts are done as
+`DELETE + INSERT` inside a transaction so child rows (players, stats)
+stay consistent when a match transitions Upcoming → Live → FullTime.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from importlib import resources
+from pathlib import Path
+
+from fantasy_coach.features import MatchRow, PlayerRow, TeamRow, TeamStat
+
+SCHEMA_VERSION = 1
+
+
+class SQLiteRepository:
+    def __init__(self, path: str | Path) -> None:
+        self._path = str(path)
+        self._conn = sqlite3.connect(self._path)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._migrate()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> SQLiteRepository:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def upsert_match(self, row: MatchRow) -> None:
+        with self._conn:  # commit on success, rollback on exception
+            self._conn.execute("DELETE FROM matches WHERE match_id = ?", (row.match_id,))
+            self._conn.execute(
+                """
+                INSERT INTO matches (
+                    match_id, season, round, start_time, match_state,
+                    venue, venue_city, weather,
+                    home_team_id, home_name, home_nick, home_score,
+                    away_team_id, away_name, away_nick, away_score
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    row.match_id,
+                    row.season,
+                    row.round,
+                    row.start_time.isoformat(),
+                    row.match_state,
+                    row.venue,
+                    row.venue_city,
+                    row.weather,
+                    row.home.team_id,
+                    row.home.name,
+                    row.home.nick_name,
+                    row.home.score,
+                    row.away.team_id,
+                    row.away.name,
+                    row.away.nick_name,
+                    row.away.score,
+                ),
+            )
+            self._insert_players(row.match_id, "home", row.home.players)
+            self._insert_players(row.match_id, "away", row.away.players)
+            self._insert_stats(row.match_id, row.team_stats)
+
+    def get_match(self, match_id: int) -> MatchRow | None:
+        match = self._conn.execute(
+            "SELECT * FROM matches WHERE match_id = ?", (match_id,)
+        ).fetchone()
+        if match is None:
+            return None
+        return self._hydrate(match)
+
+    def list_matches(self, season: int, round: int | None = None) -> list[MatchRow]:
+        if round is None:
+            rows = self._conn.execute(
+                "SELECT * FROM matches WHERE season = ? ORDER BY start_time, match_id",
+                (season,),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM matches
+                WHERE season = ? AND round = ?
+                ORDER BY start_time, match_id
+                """,
+                (season, round),
+            ).fetchall()
+        return [self._hydrate(r) for r in rows]
+
+    # ----- internals -----
+
+    def _migrate(self) -> None:
+        schema_sql = (
+            resources.files("fantasy_coach.storage")
+            .joinpath("schema.sql")
+            .read_text(encoding="utf-8")
+        )
+        self._conn.executescript(schema_sql)
+        current = self._conn.execute("SELECT version FROM schema_version").fetchone()
+        if current is None:
+            with self._conn:
+                self._conn.execute(
+                    "INSERT INTO schema_version (version) VALUES (?)",
+                    (SCHEMA_VERSION,),
+                )
+        elif current["version"] != SCHEMA_VERSION:
+            raise RuntimeError(
+                f"SQLite DB at {self._path} is schema v{current['version']}, "
+                f"code expects v{SCHEMA_VERSION}. No migration path yet."
+            )
+
+    def _insert_players(self, match_id: int, side: str, players: list[PlayerRow]) -> None:
+        if not players:
+            return
+        self._conn.executemany(
+            """
+            INSERT INTO match_players
+                (match_id, side, player_id, jersey_number, position,
+                 first_name, last_name)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    match_id,
+                    side,
+                    p.player_id,
+                    p.jersey_number,
+                    p.position,
+                    p.first_name,
+                    p.last_name,
+                )
+                for p in players
+            ],
+        )
+
+    def _insert_stats(self, match_id: int, stats: list[TeamStat]) -> None:
+        if not stats:
+            return
+        self._conn.executemany(
+            """
+            INSERT INTO match_team_stats
+                (match_id, ordinal, title, type, units, home_value, away_value)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    match_id,
+                    ordinal,
+                    s.title,
+                    s.type,
+                    s.units,
+                    s.home_value,
+                    s.away_value,
+                )
+                for ordinal, s in enumerate(stats)
+            ],
+        )
+
+    def _hydrate(self, match: sqlite3.Row) -> MatchRow:
+        match_id = match["match_id"]
+        players = self._conn.execute(
+            """
+            SELECT side, player_id, jersey_number, position, first_name, last_name
+            FROM match_players
+            WHERE match_id = ?
+            ORDER BY side, jersey_number, player_id
+            """,
+            (match_id,),
+        ).fetchall()
+        stats = self._conn.execute(
+            """
+            SELECT title, type, units, home_value, away_value
+            FROM match_team_stats
+            WHERE match_id = ?
+            ORDER BY ordinal
+            """,
+            (match_id,),
+        ).fetchall()
+
+        home_players = [self._row_to_player(p) for p in players if p["side"] == "home"]
+        away_players = [self._row_to_player(p) for p in players if p["side"] == "away"]
+
+        return MatchRow(
+            match_id=match_id,
+            season=match["season"],
+            round=match["round"],
+            start_time=datetime.fromisoformat(match["start_time"]),
+            match_state=match["match_state"],
+            venue=match["venue"],
+            venue_city=match["venue_city"],
+            weather=match["weather"],
+            home=TeamRow(
+                team_id=match["home_team_id"],
+                name=match["home_name"],
+                nick_name=match["home_nick"],
+                score=match["home_score"],
+                players=home_players,
+            ),
+            away=TeamRow(
+                team_id=match["away_team_id"],
+                name=match["away_name"],
+                nick_name=match["away_nick"],
+                score=match["away_score"],
+                players=away_players,
+            ),
+            team_stats=[
+                TeamStat(
+                    title=s["title"],
+                    type=s["type"],
+                    units=s["units"],
+                    home_value=s["home_value"],
+                    away_value=s["away_value"],
+                )
+                for s in stats
+            ],
+        )
+
+    @staticmethod
+    def _row_to_player(p: sqlite3.Row) -> PlayerRow:
+        return PlayerRow(
+            player_id=p["player_id"],
+            jersey_number=p["jersey_number"],
+            position=p["position"],
+            first_name=p["first_name"],
+            last_name=p["last_name"],
+        )

--- a/tests/fixtures/match-2024-rd1-sea-eagles-v-rabbitohs.json
+++ b/tests/fixtures/match-2024-rd1-sea-eagles-v-rabbitohs.json
@@ -1,0 +1,5007 @@
+{
+  "matchId": "20241110110",
+  "matchMode": "Post",
+  "matchState": "FullTime",
+  "updated": "2026-03-30T22:50:59Z",
+  "gameSeconds": 4800,
+  "roundNumber": 1,
+  "roundTitle": "Round 1",
+  "startTime": "2024-03-03T02:30:00Z",
+  "url": "https://www.nrl.com/draw/nrl-premiership/2024/round-1/sea-eagles-v-rabbitohs/",
+  "imageUrl": "https://www.nrl.com/siteassets/2024/-nrl-season-/240303---round-1/240303---sea-eagles-v-rabbitohs/73829469_brownn-240302_akd_6131_202433144946.jpg",
+  "homeTeam": {
+    "teamId": 500002,
+    "nickName": "Sea Eagles",
+    "name": "Manly-Warringah Sea Eagles",
+    "score": 36,
+    "captainPlayerId": 500024,
+    "theme": {
+      "key": "sea-eagles",
+      "logos": {
+        "badge-basic24-mono.svg": "202603300722",
+        "badge-basic24.svg": "202603300722",
+        "badge-light.png": "202603300722",
+        "badge-light.svg": "202510300111",
+        "badge.png": "202603300722",
+        "badge.svg": "202510300111",
+        "header-background.png": "202603300722",
+        "header-background.svg": "202603300722",
+        "silhouette.png": "202603300722",
+        "silhouette.svg": "202603300722",
+        "text.svg": "202603300722"
+      }
+    },
+    "players": [
+      {
+        "firstName": "Tom",
+        "lastName": "Trbojevic",
+        "position": "Fullback",
+        "headImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500002/Tom%20Trbojevic_260128_SeaEgales_MK1441.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500002/Tom%20Trbojevic_260128_SeaEgales_MK1441.png?center=0.5%2C0.5",
+        "url": "https://www.seaeagles.com.au/teams/nrl-premiership/manly-warringah-sea-eagles/tom-trbojevic/",
+        "playerId": 501505,
+        "number": 1,
+        "isOnField": true
+      },
+      {
+        "firstName": "Jason",
+        "lastName": "Saab",
+        "position": "Winger",
+        "headImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500002/Jason%20Saab%20_260128_SeaEgales_MK219.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500002/Jason%20Saab%20_260128_SeaEgales_MK219.png?center=0.5%2C0.5",
+        "url": "https://www.seaeagles.com.au/teams/nrl-premiership/manly-warringah-sea-eagles/jason-saab/",
+        "playerId": 507670,
+        "number": 2,
+        "isOnField": false
+      },
+      {
+        "firstName": "Tolutau",
+        "lastName": "Koula",
+        "position": "Centre",
+        "headImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500002/Tolu%20Koula%20_260128_SeaEgales_MK2447.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500002/Tolu%20Koula%20_260128_SeaEgales_MK2447.png?center=0.5%2C0.5",
+        "url": "https://www.seaeagles.com.au/teams/nrl-premiership/manly-warringah-sea-eagles/tolutau-koula/",
+        "playerId": 509634,
+        "number": 3,
+        "isOnField": true
+      },
+      {
+        "firstName": "Reuben",
+        "lastName": "Garrick",
+        "position": "Centre",
+        "headImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500002/Reuben%20Garrick%20_260128_SeaEgales_MK085.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500002/Reuben%20Garrick%20_260128_SeaEgales_MK085.png?center=0.5%2C0.5",
+        "url": "https://www.seaeagles.com.au/teams/nrl-premiership/manly-warringah-sea-eagles/reuben-garrick/",
+        "playerId": 503443,
+        "number": 4,
+        "isOnField": true
+      },
+      {
+        "firstName": "Jaxson",
+        "lastName": "Paulo",
+        "position": "Winger",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2024/500002/jaxson-paulo.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2024/500002/jaxson-paulo-744.png?center=0.5%2C0.5",
+        "playerId": 506255,
+        "number": 5,
+        "isOnField": true
+      },
+      {
+        "firstName": "Luke",
+        "lastName": "Brooks",
+        "position": "Five-Eighth",
+        "headImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500002/Luke%20Brooks%20_260128_SeaEgales_MK004.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500002/Luke%20Brooks%20_260128_SeaEgales_MK004.png?center=0.5%2C0.5",
+        "url": "https://www.seaeagles.com.au/teams/nrl-premiership/manly-warringah-sea-eagles/luke-brooks/",
+        "playerId": 500646,
+        "number": 6,
+        "isOnField": true
+      },
+      {
+        "firstName": "Daly",
+        "lastName": "Cherry-Evans",
+        "position": "Halfback",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2025/500002/CHERRY%20EVANS%2CDaly_NRL_2025_GP0001-COPY.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2025/500002/CHERRY%20EVANS%2CDaly_NRL_2025_GP0001-COPY.png?center=0.5%2C0.5",
+        "playerId": 500024,
+        "number": 7,
+        "isCaptain": true,
+        "isOnField": true
+      },
+      {
+        "firstName": "Taniela",
+        "lastName": "Paseka",
+        "position": "Prop",
+        "headImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500002/Taniela%20Paseka%20_260128_SeaEgales_MK1555.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500002/Taniela%20Paseka%20_260128_SeaEgales_MK1555.png?center=0.5%2C0.5",
+        "url": "https://www.seaeagles.com.au/teams/nrl-premiership/manly-warringah-sea-eagles/taniela-paseka/",
+        "playerId": 504251,
+        "number": 8,
+        "isOnField": false
+      },
+      {
+        "firstName": "Lachlan",
+        "lastName": "Croker",
+        "position": "Hooker",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2025/500002/CROKER%2CLachlan_NRL_2025_GP0001-COPY.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2025/500002/CROKER%2CLachlan_NRL_2025_GP0001-COPY.png?center=0.5%2C0.5",
+        "playerId": 502063,
+        "number": 9,
+        "isOnField": true
+      },
+      {
+        "firstName": "Josh",
+        "lastName": "Aloiai",
+        "position": "Prop",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2025/500002/ALOIAI%2CJosh_2025_GP0001-COPY.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2025/500002/ALOIAI%2CJosh_2025_GP0001-COPY.png?center=0.5%2C0.5",
+        "playerId": 500882,
+        "number": 10,
+        "isOnField": true
+      },
+      {
+        "firstName": "Haumole",
+        "lastName": "Olakau'atu",
+        "position": "2nd Row",
+        "headImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500002/Haumole%20Olakauatu%20_260128_SeaEgales_MK1679.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500002/Haumole%20Olakauatu%20_260128_SeaEgales_MK1679.png?center=0.5%2C0.5",
+        "url": "https://www.seaeagles.com.au/teams/nrl-premiership/manly-warringah-sea-eagles/haumole-olakauatu/",
+        "playerId": 508033,
+        "number": 11,
+        "isOnField": true
+      },
+      {
+        "firstName": "Ben",
+        "lastName": "Trbojevic",
+        "position": "2nd Row",
+        "headImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500002/Ben%20Trbojevic%20_260128_SeaEgales_MK1909.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500002/Ben%20Trbojevic%20_260128_SeaEgales_MK1909.png?center=0.5%2C0.5",
+        "url": "https://www.seaeagles.com.au/teams/nrl-premiership/manly-warringah-sea-eagles/ben-trbojevic/",
+        "playerId": 507850,
+        "number": 12,
+        "isOnField": false
+      },
+      {
+        "firstName": "Jake",
+        "lastName": "Trbojevic",
+        "position": "Lock",
+        "headImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500002/Jake%20Trbojevic%20_260128_SeaEgales_MK2030.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500002/Jake%20Trbojevic%20_260128_SeaEgales_MK2030.png?center=0.5%2C0.5",
+        "url": "https://www.seaeagles.com.au/teams/nrl-premiership/manly-warringah-sea-eagles/jake-trbojevic/",
+        "playerId": 500751,
+        "number": 13,
+        "isOnField": true
+      },
+      {
+        "firstName": "Karl",
+        "lastName": "Lawton",
+        "position": "Interchange",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2024/500002/karl-lawton.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2024/500002/karl-lawton-744.png?center=0.5%2C0.5",
+        "playerId": 502409,
+        "number": 14,
+        "isOnField": false
+      },
+      {
+        "firstName": "Corey",
+        "lastName": "Waddell",
+        "position": "Interchange",
+        "headImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500002/Corey%20Waddell%20_260128_SeaEgales_MK2137.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500002/Corey%20Waddell%20_260128_SeaEgales_MK2137.png?center=0.5%2C0.5",
+        "url": "https://www.seaeagles.com.au/teams/nrl-premiership/manly-warringah-sea-eagles/corey-waddell/",
+        "playerId": 503341,
+        "number": 15,
+        "isOnField": true
+      },
+      {
+        "firstName": "Ethan",
+        "lastName": "Bullemor",
+        "position": "Interchange",
+        "headImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500002/Ethan%20Bullemor%20_260128_SeaEgales_MK1030.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500002/Ethan%20Bullemor%20_260128_SeaEgales_MK1030.png?center=0.5%2C0.5",
+        "url": "https://www.seaeagles.com.au/teams/nrl-premiership/manly-warringah-sea-eagles/ethan-bullemor/",
+        "playerId": 506153,
+        "number": 16,
+        "isOnField": false
+      },
+      {
+        "firstName": "Nathan",
+        "lastName": "Brown",
+        "position": "Interchange",
+        "headImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500002/Nathan%20Brown%20_260128_SeaEgales_MK129.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500002/Nathan%20Brown%20_260128_SeaEgales_MK129.png?center=0.5%2C0.5",
+        "url": "https://www.seaeagles.com.au/teams/nrl-premiership/manly-warringah-sea-eagles/nathan-brown/",
+        "playerId": 500647,
+        "number": 17,
+        "isOnField": true
+      },
+      {
+        "firstName": "Jake",
+        "lastName": "Arthur",
+        "position": "Replacement",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2025/500002/ARTHUR_640.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2025/500002/ARTHUR_744.png?center=0.5%2C0.5",
+        "playerId": 509765,
+        "number": 18,
+        "isOnField": false
+      }
+    ],
+    "coaches": [
+      {
+        "firstName": "Anthony",
+        "lastName": "Seibold",
+        "profileId": 50178,
+        "position": "Coach",
+        "headImage": "https://www.seaeagles.com.au/SysSiteAssets/teams/coach/anthony-seibold-_260128_seaegales_mk19931.png?center=0.36%2C0.55"
+      }
+    ],
+    "scoring": {
+      "conversions": {
+        "summaries": [
+          "Reuben Garrick 24'",
+          "Reuben Garrick 38'",
+          "Reuben Garrick 51'",
+          "Reuben Garrick 55'",
+          "Reuben Garrick 62'",
+          "Reuben Garrick 78'"
+        ],
+        "attempts": 6,
+        "made": 6
+      },
+      "halfTimeScore": 12,
+      "tries": {
+        "summaries": [
+          "Haumole Olakau'atu 22'",
+          "Jason Saab 37'",
+          "Lachlan Croker 49'",
+          "Ben Trbojevic 53'",
+          "Reuben Garrick 60'",
+          "Luke Brooks 76'"
+        ],
+        "made": 6
+      }
+    },
+    "url": "https://www.seaeagles.com.au/teams/nrl-premiership/manly-warringah-sea-eagles/"
+  },
+  "awayTeam": {
+    "teamId": 500005,
+    "nickName": "Rabbitohs",
+    "name": "South Sydney Rabbitohs",
+    "score": 24,
+    "captainPlayerId": 504176,
+    "theme": {
+      "key": "rabbitohs",
+      "logos": {
+        "badge-basic24-light.svg": "202603300722",
+        "badge-basic24-mono.svg": "202603300722",
+        "badge-basic24.svg": "202603300722",
+        "badge-light.png": "202603300722",
+        "badge-light.svg": "202603300722",
+        "badge.png": "202603300722",
+        "badge.svg": "202603300722",
+        "silhouette.png": "202603300722",
+        "silhouette.svg": "202603300722",
+        "text.svg": "202603300722"
+      }
+    },
+    "players": [
+      {
+        "firstName": "Latrell",
+        "lastName": "Mitchell",
+        "position": "Fullback",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500005/Latrell%20Mitchell_260113_Rabbitohs_MK0323.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500005/Latrell%20Mitchell_260113_Rabbitohs_MK0323.png?center=0.5%2C0.5",
+        "url": "https://www.nrl.com/players/nrl-premiership/south-sydney-rabbitohs/latrell-mitchell/",
+        "playerId": 502502,
+        "number": 1,
+        "isOnField": true
+      },
+      {
+        "firstName": "Alex",
+        "lastName": "Johnston",
+        "position": "Winger",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500005/Alex%20Johnston_260113_Rabbitohs_MK0562.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500005/Alex%20Johnston_260113_Rabbitohs_MK0562.png?center=0.5%2C0.5",
+        "url": "https://www.nrl.com/players/nrl-premiership/south-sydney-rabbitohs/alex-johnston/",
+        "playerId": 500108,
+        "number": 2,
+        "isOnField": true
+      },
+      {
+        "firstName": "Isaiah",
+        "lastName": "Tass",
+        "position": "Centre",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500005/Isaiah%20Tass_260115_Rabbitohs528%281%29.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500005/Isaiah%20Tass_260115_Rabbitohs528.png?center=0.5%2C0.5",
+        "url": "https://www.nrl.com/players/nrl-premiership/south-sydney-rabbitohs/isaiah-tass/",
+        "playerId": 506548,
+        "number": 3,
+        "isOnField": true
+      },
+      {
+        "firstName": "Richard",
+        "lastName": "Kennar",
+        "position": "Centre",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2024/500005/KENNAR%2CRichie_NRL_2024_0410.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2024/500005/KENNAR%2CRichie_NRL_2024_0410.png?center=0.5%2C0.5",
+        "playerId": 500599,
+        "number": 4,
+        "isOnField": true
+      },
+      {
+        "firstName": "Jacob",
+        "lastName": "Gagai",
+        "position": "Winger",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2024/500005/GAGAI%2CJacob_NRL_2024_0322.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2024/500005/GAGAI%2CJacob_NRL_2024_0322.png?center=0.5%2C0.5",
+        "playerId": 501245,
+        "number": 5,
+        "isOnField": true
+      },
+      {
+        "firstName": "Cody",
+        "lastName": "Walker",
+        "position": "Five-Eighth",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500005/Cody%20Walker_260113_Rabbitohs_MK0220.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500005/Cody%20Walker_260113_Rabbitohs_MK0220.png?center=0.5%2C0.5",
+        "url": "https://www.nrl.com/players/nrl-premiership/south-sydney-rabbitohs/cody-walker/",
+        "playerId": 500611,
+        "number": 6,
+        "isOnField": true
+      },
+      {
+        "firstName": "Lachlan",
+        "lastName": "Ilias",
+        "position": "Halfback",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2024/500005/ILIAS%2CLachlan%20NRL_2024_GP0017-COPY.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2024/500005/ILIAS%2CLachlan%20NRL_2024_GP0017-COPY.png?center=0.5%2C0.5",
+        "playerId": 505564,
+        "number": 7,
+        "isOnField": true
+      },
+      {
+        "firstName": "Tevita",
+        "lastName": "Tatola",
+        "position": "Prop",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500005/Tevita%20Tatola_260115_Rabbitohs004.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500005/Tevita%20Tatola_260115_Rabbitohs004.png?center=0.5%2C0.5",
+        "url": "https://www.nrl.com/players/nrl-premiership/south-sydney-rabbitohs/tevita-tatola/",
+        "playerId": 503450,
+        "number": 8,
+        "isOnField": true
+      },
+      {
+        "firstName": "Damien",
+        "lastName": "Cook",
+        "position": "Hooker",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2024/500005/COOK%2CDamien_NRL_2024_0557.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2024/500005/COOK%2CDamien_NRL_2024_0557.png?center=0.5%2C0.5",
+        "playerId": 501600,
+        "number": 9,
+        "isOnField": true
+      },
+      {
+        "firstName": "Sean",
+        "lastName": "Keppie",
+        "position": "Prop",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500005/Sean%20Keppie_260113_Rabbitohs_MK0670.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500005/Sean%20Keppie_260113_Rabbitohs_MK0670.png?center=0.5%2C0.5",
+        "url": "https://www.nrl.com/players/nrl-premiership/south-sydney-rabbitohs/sean-keppie/",
+        "playerId": 504265,
+        "number": 10,
+        "isOnField": true
+      },
+      {
+        "firstName": "Keaon",
+        "lastName": "Koloamatangi",
+        "position": "2nd Row",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500005/Keaon%20Koloamatangi_260115_Rabbitohs117.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500005/Keaon%20Koloamatangi_260115_Rabbitohs117.png?center=0.5%2C0.5",
+        "url": "https://www.nrl.com/players/nrl-premiership/south-sydney-rabbitohs/keaon-koloamatangi/",
+        "playerId": 504174,
+        "number": 11,
+        "isOnField": true
+      },
+      {
+        "firstName": "Jai",
+        "lastName": "Arrow",
+        "position": "2nd Row",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500005/Jai%20Arrow_260113_Rabbitohs_MK0007.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500005/Jai%20Arrow_260113_Rabbitohs_MK0007.png?center=0.5%2C0.5",
+        "url": "https://www.nrl.com/players/nrl-premiership/south-sydney-rabbitohs/jai-arrow/",
+        "playerId": 500149,
+        "number": 12,
+        "isOnField": true
+      },
+      {
+        "firstName": "Cameron",
+        "lastName": "Murray",
+        "position": "Lock",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2026/500005/Cameron%20Murray_260113_Rabbitohs_MK0101.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2026/500005/Cameron%20Murray_260113_Rabbitohs_MK0101.png?center=0.5%2C0.5",
+        "url": "https://www.nrl.com/players/nrl-premiership/south-sydney-rabbitohs/cameron-murray/",
+        "playerId": 504176,
+        "number": 13,
+        "isCaptain": true,
+        "isOnField": true
+      },
+      {
+        "firstName": "Siliva",
+        "lastName": "Havili",
+        "position": "Interchange",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2024/500005/HAVILI%2C%20Siliva%20NRL_2024_GP0018-COPY.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2024/500005/HAVILI%2C%20Siliva%20NRL_2024_GP0018-COPY.png?center=0.5%2C0.5",
+        "playerId": 501394,
+        "number": 14,
+        "isOnField": false
+      },
+      {
+        "firstName": "Jacob",
+        "lastName": "Host",
+        "position": "Interchange",
+        "headImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2025/500005/Host%20-%20Headshot.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Bodyshots/111/2025/500005/Host%20-%20Bodyshot.png?center=0.5%2C0.5",
+        "url": "https://www.nrl.com/players/nrl-premiership/south-sydney-rabbitohs/jacob-host/",
+        "playerId": 500453,
+        "number": 15,
+        "isOnField": false
+      },
+      {
+        "firstName": "Davvy",
+        "lastName": "Moale",
+        "position": "Interchange",
+        "headImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2025/500005/Moale%20-%20Headshot.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?http://rugbyimages.statsperform.com/Player%20Bodyshots/111/2025/500005/Moale%20-%20Bodyshot.png?center=0.5%2C0.5",
+        "playerId": 509444,
+        "number": 16,
+        "isOnField": false
+      },
+      {
+        "firstName": "Thomas",
+        "lastName": "Burgess",
+        "position": "Interchange",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2024/500005/BURGESS%2CThomas%20NRL_2024_GP0041-COPY.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2024/500005/BURGESS%2CThomas%20NRL_2024_GP0041-COPY.png?center=0.5%2C0.5",
+        "playerId": 500087,
+        "number": 17,
+        "isOnField": false
+      },
+      {
+        "firstName": "Dean",
+        "lastName": "Hawkins",
+        "position": "Replacement",
+        "headImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Profile%20Headshots/111/2024/500005/HAWKINS%2CDean_NRL_2024_0153.png?center=0.3%2C0.5",
+        "bodyImage": "/remote.axd?https://rugbyimages.statsperform.com/Player%20Bodyshots/111/2024/500005/HAWKINS%2CDean_NRL_2024_0153.png?center=0.5%2C0.5",
+        "playerId": 504669,
+        "number": 24,
+        "isOnField": false
+      }
+    ],
+    "coaches": [
+      {
+        "firstName": "Jason",
+        "lastName": "Demetriou",
+        "profileId": 50333,
+        "position": "Coach",
+        "headImage": "https://www.nrl.com/contentassets/1716d55cc5b2462ab55032e7575dffd6/demetriouj-nrl-h-gp0004-copy-head-shot.png?center=0.39%2C0.5"
+      }
+    ],
+    "scoring": {
+      "conversions": {
+        "summaries": [
+          "Latrell Mitchell 7'",
+          "Latrell Mitchell 48'"
+        ],
+        "attempts": 5,
+        "made": 2
+      },
+      "halfTimeScore": 10,
+      "tries": {
+        "summaries": [
+          "Richard Kennar 6'",
+          "Jacob Gagai 30'",
+          "Latrell Mitchell 43'",
+          "Alex Johnston 47'",
+          "Richard Kennar 78'"
+        ],
+        "made": 5
+      }
+    },
+    "url": "https://www.nrl.com/players/nrl-premiership/south-sydney-rabbitohs/"
+  },
+  "venue": "Allegiant Stadium",
+  "venueCity": "Las Vegas",
+  "animateMatchClock": true,
+  "attendance": 40746,
+  "competition": {
+    "competitionId": 111,
+    "name": "Telstra Premiership",
+    "theme": {
+      "key": "nrl-premiership",
+      "logos": {
+        "badge-light.png": "202603300722",
+        "badge-light.svg": "202603300722",
+        "badge.png": "202603300722",
+        "badge.svg": "202603300722"
+      }
+    }
+  },
+  "groundConditions": "Good",
+  "hasExtraTime": true,
+  "hasOnFieldTracking": true,
+  "officials": [
+    {
+      "firstName": "Ashley",
+      "lastName": "Klein",
+      "profileId": 500039,
+      "position": "Referee",
+      "headImage": "https://www.nrl.com/contentassets/83877c45ca144f2690d06991113ef234/kleina-referees-2023_nrl_0054-head-shot.png?center=0.37%2C0.52",
+      "url": "https://www.nrl.com/operations/the-officials/match-officials/ashley-klein/"
+    },
+    {
+      "firstName": "Chris",
+      "lastName": "Sutton",
+      "profileId": 500068,
+      "position": "Touch Judge",
+      "headImage": "https://www.nrl.com/contentassets/87be5eb0c270427b97f45d424e00373b/suttonc-referees-2023_nrl_0136-head-shot.png?center=0.39%2C0.51",
+      "url": "https://www.nrl.com/operations/the-officials/match-officials/chris-sutton/"
+    },
+    {
+      "firstName": "Wyatt",
+      "lastName": "Raymond",
+      "profileId": 500262,
+      "position": "Touch Judge",
+      "headImage": "https://www.nrl.com/contentassets/34ac6810f7c94b009f0b5f0cdb10a21e/raymondwyatt-referees-2023_nrl_0065-head-shot.png?center=0.38%2C0.51",
+      "url": "https://www.nrl.com/operations/the-officials/match-officials/wyatt-raymond/"
+    },
+    {
+      "firstName": "Gerard",
+      "lastName": "Sutton",
+      "profileId": 500004,
+      "position": "Senior Review Official",
+      "headImage": "https://www.nrl.com/contentassets/edf145e59b4740599097b4e68dc011fc/suttong-referees-2023_nrl_0152-head-shot.png?center=0.38%2C0.51",
+      "url": "https://www.nrl.com/operations/the-officials/match-officials/gerard-sutton/"
+    }
+  ],
+  "positionGroups": [
+    {
+      "title": "Backs",
+      "positions": [
+        {
+          "name": "Fullback",
+          "homeProfileId": 501505,
+          "awayProfileId": 502502
+        },
+        {
+          "name": "Winger",
+          "homeProfileId": 507670,
+          "awayProfileId": 500108
+        },
+        {
+          "name": "Centre",
+          "homeProfileId": 509634,
+          "awayProfileId": 506548
+        },
+        {
+          "name": "Centre",
+          "homeProfileId": 503443,
+          "awayProfileId": 500599
+        },
+        {
+          "name": "Winger",
+          "homeProfileId": 506255,
+          "awayProfileId": 501245
+        },
+        {
+          "name": "Five-Eighth",
+          "homeProfileId": 500646,
+          "awayProfileId": 500611
+        },
+        {
+          "name": "Halfback",
+          "homeProfileId": 500024,
+          "awayProfileId": 505564
+        }
+      ]
+    },
+    {
+      "title": "Forwards",
+      "positions": [
+        {
+          "name": "Prop",
+          "homeProfileId": 504251,
+          "awayProfileId": 503450
+        },
+        {
+          "name": "Hooker",
+          "homeProfileId": 502063,
+          "awayProfileId": 501600
+        },
+        {
+          "name": "Prop",
+          "homeProfileId": 500882,
+          "awayProfileId": 504265
+        },
+        {
+          "name": "2nd Row",
+          "homeProfileId": 508033,
+          "awayProfileId": 504174
+        },
+        {
+          "name": "2nd Row",
+          "homeProfileId": 507850,
+          "awayProfileId": 500149
+        },
+        {
+          "name": "Lock",
+          "homeProfileId": 500751,
+          "awayProfileId": 504176
+        }
+      ]
+    },
+    {
+      "title": "Interchange",
+      "positions": [
+        {
+          "name": "Interchange",
+          "homeProfileId": 502409,
+          "awayProfileId": 501394
+        },
+        {
+          "name": "Interchange",
+          "homeProfileId": 503341,
+          "awayProfileId": 500453
+        },
+        {
+          "name": "Interchange",
+          "homeProfileId": 506153,
+          "awayProfileId": 509444
+        },
+        {
+          "name": "Interchange",
+          "homeProfileId": 500647,
+          "awayProfileId": 500087
+        }
+      ]
+    },
+    {
+      "title": "Reserves",
+      "positions": [
+        {
+          "name": "Replacement",
+          "homeProfileId": 509765,
+          "awayProfileId": 504669
+        }
+      ]
+    },
+    {
+      "title": "Coaches",
+      "positions": [
+        {
+          "name": "Coach",
+          "homeProfileId": 50178,
+          "awayProfileId": 50333
+        }
+      ]
+    }
+  ],
+  "segmentCount": 2,
+  "segmentDuration": 2400,
+  "showTeamPositions": false,
+  "showPlayerPositions": true,
+  "stats": {
+    "topPerformers": [
+      {
+        "title": "Most Tackles",
+        "homeTotal": 46.0,
+        "homePlayerId": 500751,
+        "awayTotal": 42.0,
+        "awayPlayerId": 501600
+      },
+      {
+        "title": "Most Run Metres",
+        "homeTotal": 248.0,
+        "homePlayerId": 507670,
+        "awayTotal": 167.0,
+        "awayPlayerId": 504176
+      },
+      {
+        "title": "Most Line Breaks",
+        "homeTotal": 1.0,
+        "homePlayerId": 501505,
+        "awayTotal": 2.0,
+        "awayPlayerId": 500599
+      },
+      {
+        "title": "Most Fantasy Points",
+        "homeTotal": 70.0,
+        "homePlayerId": 508033,
+        "awayTotal": 81.0,
+        "awayPlayerId": 502502
+      }
+    ],
+    "groups": [
+      {
+        "title": "Possession & Completions",
+        "stats": [
+          {
+            "title": "Possession %",
+            "type": "PercentageCombined",
+            "homeValue": {
+              "value": 51.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 49.0,
+              "isLeader": false
+            },
+            "keyStatOrder": 1
+          },
+          {
+            "title": "Time In Possession",
+            "type": "Number",
+            "units": "Minutes",
+            "homeValue": {
+              "value": 1577.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 1545.0,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Completion Rate",
+            "type": "PercentageAndFraction",
+            "homeValue": {
+              "value": 78.0,
+              "numerator": 33,
+              "denominator": 42,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 80.0,
+              "numerator": 32,
+              "denominator": 40,
+              "isLeader": true
+            }
+          }
+        ]
+      },
+      {
+        "title": "Attack",
+        "stats": [
+          {
+            "title": "All Runs",
+            "type": "Number",
+            "homeValue": {
+              "value": 208.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 206.0,
+              "isLeader": false
+            },
+            "keyStatOrder": 2
+          },
+          {
+            "title": "All Run Metres",
+            "type": "Number",
+            "homeValue": {
+              "value": 1870.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 1645.0,
+              "isLeader": false
+            },
+            "keyStatOrder": 3
+          },
+          {
+            "title": "Post Contact Metres",
+            "type": "Number",
+            "homeValue": {
+              "value": 485.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 483.0,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Line Breaks",
+            "type": "Number",
+            "homeValue": {
+              "value": 7.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 5.0,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Tackle Breaks",
+            "type": "Number",
+            "homeValue": {
+              "value": 31.0,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 38.0,
+              "isLeader": true
+            }
+          },
+          {
+            "title": "Average Set Distance",
+            "type": "Number",
+            "homeValue": {
+              "value": 44.55,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 41.13,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Kick Return Metres",
+            "type": "Number",
+            "homeValue": {
+              "value": 209.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 147.0,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Average Play The Ball Speed",
+            "type": "Range",
+            "units": "Seconds",
+            "homeValue": {
+              "value": 3.64,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 3.49,
+              "isLeader": true
+            },
+            "maxValue": 5.0
+          }
+        ]
+      },
+      {
+        "title": "Passing",
+        "stats": [
+          {
+            "title": "Offloads",
+            "type": "Number",
+            "homeValue": {
+              "value": 8.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 4.0,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Receipts",
+            "type": "Number",
+            "homeValue": {
+              "value": 423.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 410.0,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Total Passes",
+            "type": "Number",
+            "homeValue": {
+              "value": 237.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 218.0,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Dummy Passes",
+            "type": "Number",
+            "homeValue": {
+              "value": 7.0,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 15.0,
+              "isLeader": true
+            }
+          }
+        ]
+      },
+      {
+        "title": "Kicking",
+        "stats": [
+          {
+            "title": "Kicks",
+            "type": "Number",
+            "homeValue": {
+              "value": 21.0,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 21.0,
+              "isLeader": false
+            },
+            "keyStatOrder": 4
+          },
+          {
+            "title": "Kicking Metres",
+            "type": "Number",
+            "homeValue": {
+              "value": 555.0,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 769.0,
+              "isLeader": true
+            },
+            "keyStatOrder": 5
+          },
+          {
+            "title": "Forced Drop Outs",
+            "type": "Number",
+            "homeValue": {
+              "value": 1.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 0.0,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Kick Defusal %",
+            "type": "Percentage",
+            "homeValue": {
+              "value": 100.0,
+              "numerator": 9,
+              "denominator": 9,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 50.0,
+              "numerator": 8,
+              "denominator": 16,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Bombs",
+            "type": "Number",
+            "homeValue": {
+              "value": 6.0,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 8.0,
+              "isLeader": true
+            }
+          },
+          {
+            "title": "Grubbers",
+            "type": "Number",
+            "homeValue": {
+              "value": 6.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 0.0,
+              "isLeader": false
+            }
+          }
+        ]
+      },
+      {
+        "title": "Defence",
+        "stats": [
+          {
+            "title": "Effective Tackle %",
+            "type": "Percentage",
+            "homeValue": {
+              "value": 87.07,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 88.0,
+              "isLeader": true
+            }
+          },
+          {
+            "title": "Tackles Made",
+            "type": "Number",
+            "homeValue": {
+              "value": 330.0,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 308.0,
+              "isLeader": true
+            },
+            "keyStatOrder": 6
+          },
+          {
+            "title": "Missed Tackles",
+            "type": "Number",
+            "homeValue": {
+              "value": 38.0,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 31.0,
+              "isLeader": true
+            },
+            "keyStatOrder": 7
+          },
+          {
+            "title": "Intercepts",
+            "type": "Number",
+            "homeValue": {
+              "value": 3.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 0.0,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Ineffective Tackles",
+            "type": "Number",
+            "homeValue": {
+              "value": 11.0,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 11.0,
+              "isLeader": false
+            }
+          }
+        ]
+      },
+      {
+        "title": "Negative Play",
+        "stats": [
+          {
+            "title": "Errors",
+            "type": "Number",
+            "homeValue": {
+              "value": 14.0,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 11.0,
+              "isLeader": true
+            }
+          },
+          {
+            "title": "Penalties Conceded",
+            "type": "Number",
+            "homeValue": {
+              "value": 1.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 5.0,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Ruck Infringements",
+            "type": "Number",
+            "homeValue": {
+              "value": 2.0,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 1.0,
+              "isLeader": true
+            }
+          },
+          {
+            "title": "Inside 10 Metres",
+            "type": "Number",
+            "homeValue": {
+              "value": 1.0,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 0.0,
+              "isLeader": true
+            }
+          }
+        ]
+      },
+      {
+        "title": "Interchanges",
+        "stats": [
+          {
+            "title": "Used",
+            "type": "Number",
+            "homeValue": {
+              "value": 8.0,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 8.0,
+              "isLeader": false
+            }
+          }
+        ]
+      }
+    ],
+    "players": {
+      "homeTeam": [
+        {
+          "playerId": 501505,
+          "allRunMetres": 224,
+          "allRuns": 28,
+          "bombKicks": 1,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 3,
+          "fantasyPointsTotal": 54,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 3,
+          "hitUps": 2,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 1,
+          "kicksDead": 0,
+          "kicksDefused": 5,
+          "kickMetres": 30,
+          "kickReturnMetres": 87,
+          "lineBreakAssists": 2,
+          "lineBreaks": 1,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 2,
+          "offloads": 4,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.82,
+          "passes": 23,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.02,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 58,
+          "receipts": 48,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 3,
+          "tackleEfficiency": 71.43,
+          "tacklesMade": 5,
+          "tries": 0,
+          "tryAssists": 1,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 507670,
+          "allRunMetres": 248,
+          "allRuns": 14,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 2,
+          "fantasyPointsTotal": 48,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 2,
+          "hitUps": 1,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 1,
+          "intercepts": 1,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 1,
+          "kickMetres": 0,
+          "kickReturnMetres": 27,
+          "lineBreakAssists": 0,
+          "lineBreaks": 1,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 76,
+          "missedTackles": 2,
+          "offloads": 1,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.0,
+          "passes": 0,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.93,
+          "penalties": 0,
+          "points": 4,
+          "penaltyGoals": 0,
+          "postContactMetres": 32,
+          "receipts": 14,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4590,
+          "tackleBreaks": 3,
+          "tackleEfficiency": 70.0,
+          "tacklesMade": 7,
+          "tries": 1,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 509634,
+          "allRunMetres": 165,
+          "allRuns": 15,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 3,
+          "fantasyPointsTotal": 23,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 3,
+          "hitUps": 0,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 1,
+          "intercepts": 1,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 2,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.53,
+          "passes": 8,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.71,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 62,
+          "receipts": 23,
+          "ruckInfringements": 1,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 3,
+          "tackleEfficiency": 72.73,
+          "tacklesMade": 8,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 503443,
+          "allRunMetres": 214,
+          "allRuns": 19,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 6,
+          "conversionAttempts": 6,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 1,
+          "errors": 1,
+          "fantasyPointsTotal": 68,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 100.0,
+          "grubberKicks": 0,
+          "handlingErrors": 1,
+          "hitUps": 1,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 1,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 1,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 1,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 5,
+          "offloads": 1,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.26,
+          "passes": 5,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.52,
+          "penalties": 0,
+          "points": 16,
+          "penaltyGoals": 0,
+          "postContactMetres": 56,
+          "receipts": 22,
+          "ruckInfringements": 1,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 2,
+          "tackleEfficiency": 79.17,
+          "tacklesMade": 19,
+          "tries": 1,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 506255,
+          "allRunMetres": 94,
+          "allRuns": 13,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 1,
+          "fantasyPointsTotal": 12,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 1,
+          "hitUps": 2,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 1,
+          "kickMetres": 0,
+          "kickReturnMetres": 44,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 3,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.38,
+          "passes": 5,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 4.23,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 27,
+          "receipts": 19,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 2,
+          "tackleEfficiency": 66.67,
+          "tacklesMade": 6,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 500646,
+          "allRunMetres": 97,
+          "allRuns": 19,
+          "bombKicks": 1,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 1,
+          "errors": 2,
+          "fantasyPointsTotal": 45,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 2,
+          "handlingErrors": 2,
+          "hitUps": 0,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 3,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 60,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 1,
+          "lineBreaks": 1,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 2,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 2.11,
+          "passes": 40,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.9,
+          "penalties": 0,
+          "points": 4,
+          "penaltyGoals": 0,
+          "postContactMetres": 10,
+          "receipts": 48,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 2,
+          "tackleEfficiency": 92.31,
+          "tacklesMade": 24,
+          "tries": 1,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 500024,
+          "allRunMetres": 125,
+          "allRuns": 19,
+          "bombKicks": 3,
+          "crossFieldKicks": 1,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 5,
+          "dummyHalfRunMetres": 43,
+          "dummyPasses": 3,
+          "errors": 1,
+          "fantasyPointsTotal": 53,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 1,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 3,
+          "handlingErrors": 1,
+          "hitUps": 0,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 14,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 379,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 1,
+          "offloads": 1,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 2.79,
+          "passes": 53,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 4.74,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 8,
+          "receipts": 72,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 2,
+          "tackleEfficiency": 94.74,
+          "tacklesMade": 18,
+          "tries": 0,
+          "tryAssists": 1,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 504251,
+          "allRunMetres": 90,
+          "allRuns": 10,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 31,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 8,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 20,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 39,
+          "missedTackles": 1,
+          "offloads": 0,
+          "offsideWithinTenMetres": 1,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.0,
+          "passes": 0,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.29,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 41,
+          "receipts": 10,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 1554,
+          "stintTwo": 796,
+          "tackleBreaks": 2,
+          "tackleEfficiency": 95.45,
+          "tacklesMade": 21,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 502063,
+          "allRunMetres": 4,
+          "allRuns": 1,
+          "bombKicks": 1,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 1,
+          "dummyHalfRunMetres": 4,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 41,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 0,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 1,
+          "intercepts": 0,
+          "kicks": 2,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 78,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 1,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 57,
+          "missedTackles": 4,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 51.0,
+          "passes": 51,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 0.0,
+          "penalties": 0,
+          "points": 4,
+          "penaltyGoals": 0,
+          "postContactMetres": 0,
+          "receipts": 54,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 3090,
+          "stintTwo": 359,
+          "tackleBreaks": 1,
+          "tackleEfficiency": 86.84,
+          "tacklesMade": 33,
+          "tries": 1,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 500882,
+          "allRunMetres": 78,
+          "allRuns": 8,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 31,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 7,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 7,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 36,
+          "missedTackles": 0,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.0,
+          "passes": 0,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.86,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 19,
+          "receipts": 8,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 1089,
+          "stintTwo": 1073,
+          "tackleBreaks": 0,
+          "tackleEfficiency": 100.0,
+          "tacklesMade": 24,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 508033,
+          "allRunMetres": 184,
+          "allRuns": 16,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 1,
+          "errors": 1,
+          "fantasyPointsTotal": 70,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 1,
+          "hitUps": 16,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 1,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 3,
+          "offloads": 1,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.19,
+          "passes": 3,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.62,
+          "penalties": 0,
+          "points": 4,
+          "penaltyGoals": 0,
+          "postContactMetres": 84,
+          "receipts": 20,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 6,
+          "tackleEfficiency": 91.43,
+          "tacklesMade": 32,
+          "tries": 1,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 507850,
+          "allRunMetres": 63,
+          "allRuns": 10,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 53,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 1,
+          "handlingErrors": 0,
+          "hitUps": 10,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 1,
+          "intercepts": 0,
+          "kicks": 1,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 6,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 1,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 71,
+          "missedTackles": 4,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.2,
+          "passes": 2,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.45,
+          "penalties": 0,
+          "points": 4,
+          "penaltyGoals": 0,
+          "postContactMetres": 14,
+          "receipts": 12,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4306,
+          "tackleBreaks": 4,
+          "tackleEfficiency": 87.5,
+          "tacklesMade": 35,
+          "tries": 1,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 500751,
+          "allRunMetres": 74,
+          "allRuns": 12,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 1,
+          "errors": 0,
+          "fantasyPointsTotal": 49,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 5,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 3,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 7,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 4,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 1.0,
+          "passes": 12,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.37,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 14,
+          "receipts": 18,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 0,
+          "tackleEfficiency": 86.79,
+          "tacklesMade": 46,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 502409,
+          "allRunMetres": 13,
+          "allRuns": 1,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 1,
+          "dummyHalfRunMetres": 13,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 15,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 0,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 23,
+          "missedTackles": 0,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 28.0,
+          "passes": 28,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 2.92,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 6,
+          "receipts": 29,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 1351,
+          "tackleBreaks": 0,
+          "tackleEfficiency": 100.0,
+          "tacklesMade": 10,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 503341,
+          "allRunMetres": 34,
+          "allRuns": 5,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 6,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 4,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 1,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 19,
+          "missedTackles": 2,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.0,
+          "passes": 0,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.7,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 12,
+          "receipts": 5,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 1140,
+          "tackleBreaks": 0,
+          "tackleEfficiency": 75.0,
+          "tacklesMade": 6,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 506153,
+          "allRunMetres": 44,
+          "allRuns": 5,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 19,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 3,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 2,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 15,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 22,
+          "missedTackles": 1,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.0,
+          "passes": 0,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.22,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 12,
+          "receipts": 5,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 1370,
+          "tackleBreaks": 1,
+          "tackleEfficiency": 83.33,
+          "tacklesMade": 15,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 500647,
+          "allRunMetres": 113,
+          "allRuns": 13,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 1,
+          "dummyHalfRunMetres": 1,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 26,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 8,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 2,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 52,
+          "missedTackles": 2,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.54,
+          "passes": 7,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 4.37,
+          "penalties": 1,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 24,
+          "receipts": 16,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 2638,
+          "stintTwo": 494,
+          "tackleBreaks": 0,
+          "tackleEfficiency": 84.0,
+          "tacklesMade": 21,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 509765,
+          "allRunMetres": 0,
+          "allRuns": 0,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 0,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 0,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 0,
+          "missedTackles": 0,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.0,
+          "passes": 0,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 0.0,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 0,
+          "receipts": 0,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 0,
+          "tackleBreaks": 0,
+          "tackleEfficiency": 0.0,
+          "tacklesMade": 0,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        }
+      ],
+      "awayTeam": [
+        {
+          "playerId": 502502,
+          "allRunMetres": 120,
+          "allRuns": 17,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 2,
+          "conversionAttempts": 5,
+          "dummyHalfRuns": 1,
+          "dummyHalfRunMetres": 6,
+          "dummyPasses": 4,
+          "errors": 3,
+          "fantasyPointsTotal": 81,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 40.0,
+          "grubberKicks": 0,
+          "handlingErrors": 3,
+          "hitUps": 0,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 3,
+          "kickMetres": 0,
+          "kickReturnMetres": 37,
+          "lineBreakAssists": 2,
+          "lineBreaks": 1,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 0,
+          "offloads": 2,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.76,
+          "passes": 13,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.19,
+          "penalties": 1,
+          "points": 8,
+          "penaltyGoals": 0,
+          "postContactMetres": 34,
+          "receipts": 29,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 7,
+          "tackleEfficiency": 100.0,
+          "tacklesMade": 4,
+          "tries": 1,
+          "tryAssists": 2,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 500108,
+          "allRunMetres": 96,
+          "allRuns": 12,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 2,
+          "fantasyPointsTotal": 42,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 2,
+          "hitUps": 0,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 3,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 3,
+          "kickMetres": 0,
+          "kickReturnMetres": 45,
+          "lineBreakAssists": 0,
+          "lineBreaks": 1,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 0,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.33,
+          "passes": 4,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.68,
+          "penalties": 0,
+          "points": 4,
+          "penaltyGoals": 0,
+          "postContactMetres": 18,
+          "receipts": 18,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 4,
+          "tackleEfficiency": 70.0,
+          "tacklesMade": 7,
+          "tries": 1,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 506548,
+          "allRunMetres": 46,
+          "allRuns": 8,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 2,
+          "dummyHalfRunMetres": 10,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 19,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 0,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 1,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 2,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.5,
+          "passes": 4,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.98,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 15,
+          "receipts": 12,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 1,
+          "tackleEfficiency": 85.0,
+          "tacklesMade": 17,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 500599,
+          "allRunMetres": 144,
+          "allRuns": 15,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 1,
+          "dummyHalfRunMetres": 6,
+          "dummyPasses": 0,
+          "errors": 1,
+          "fantasyPointsTotal": 58,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 1,
+          "hitUps": 0,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 4,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 2,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 4,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.2,
+          "passes": 3,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.33,
+          "penalties": 1,
+          "points": 8,
+          "penaltyGoals": 0,
+          "postContactMetres": 45,
+          "receipts": 17,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 5,
+          "tackleEfficiency": 63.64,
+          "tacklesMade": 14,
+          "tries": 2,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 501245,
+          "allRunMetres": 119,
+          "allRuns": 11,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 1,
+          "fantasyPointsTotal": 28,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 1,
+          "hitUps": 0,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 1,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 1,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 3,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.0,
+          "passes": 0,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.78,
+          "penalties": 0,
+          "points": 4,
+          "penaltyGoals": 0,
+          "postContactMetres": 22,
+          "receipts": 12,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 3,
+          "tackleEfficiency": 63.64,
+          "tacklesMade": 7,
+          "tries": 1,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 500611,
+          "allRunMetres": 40,
+          "allRuns": 10,
+          "bombKicks": 2,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 1,
+          "dummyHalfRunMetres": 2,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 31,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 0,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 7,
+          "kicksDead": 1,
+          "kicksDefused": 0,
+          "kickMetres": 236,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 5,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 2.1,
+          "passes": 21,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 7.64,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 0,
+          "receipts": 30,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 2,
+          "tackleEfficiency": 81.48,
+          "tacklesMade": 22,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 505564,
+          "allRunMetres": 53,
+          "allRuns": 11,
+          "bombKicks": 6,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 3,
+          "errors": 1,
+          "fantasyPointsTotal": 27,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 1,
+          "hitUps": 0,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 1,
+          "intercepts": 0,
+          "kicks": 13,
+          "kicksDead": 0,
+          "kicksDefused": 1,
+          "kickMetres": 483,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 4,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 2.82,
+          "passes": 31,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 2.7,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 2,
+          "receipts": 47,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 0,
+          "tackleEfficiency": 75.0,
+          "tacklesMade": 15,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 503450,
+          "allRunMetres": 115,
+          "allRuns": 12,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 1,
+          "errors": 1,
+          "fantasyPointsTotal": 32,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 1,
+          "hitUps": 10,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 16,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 43,
+          "missedTackles": 0,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.0,
+          "passes": 0,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.23,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 45,
+          "receipts": 12,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 1200,
+          "stintTwo": 1324,
+          "tackleBreaks": 1,
+          "tackleEfficiency": 100.0,
+          "tacklesMade": 21,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 501600,
+          "allRunMetres": 70,
+          "allRuns": 9,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 8,
+          "dummyHalfRunMetres": 58,
+          "dummyPasses": 3,
+          "errors": 0,
+          "fantasyPointsTotal": 60,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 1,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 1,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 49,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 1,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 4,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 13.22,
+          "passes": 119,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 4.08,
+          "penalties": 1,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 16,
+          "receipts": 124,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 2,
+          "tackleEfficiency": 91.3,
+          "tacklesMade": 42,
+          "tries": 0,
+          "tryAssists": 1,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 504265,
+          "allRunMetres": 131,
+          "allRuns": 15,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 32,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 14,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 11,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 40,
+          "missedTackles": 0,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.0,
+          "passes": 0,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.46,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 45,
+          "receipts": 15,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 1340,
+          "stintTwo": 974,
+          "tackleBreaks": 0,
+          "tackleEfficiency": 100.0,
+          "tacklesMade": 19,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 504174,
+          "allRunMetres": 144,
+          "allRuns": 15,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 1,
+          "fantasyPointsTotal": 49,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 1,
+          "hitUps": 11,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 80,
+          "missedTackles": 1,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.33,
+          "passes": 5,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.02,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 52,
+          "receipts": 17,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 4800,
+          "tackleBreaks": 1,
+          "tackleEfficiency": 96.67,
+          "tacklesMade": 29,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 500149,
+          "allRunMetres": 87,
+          "allRuns": 12,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 34,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 12,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 53,
+          "missedTackles": 1,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.0,
+          "passes": 0,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.53,
+          "penalties": 1,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 33,
+          "receipts": 12,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 1740,
+          "stintTwo": 1411,
+          "tackleBreaks": 1,
+          "tackleEfficiency": 96.55,
+          "tacklesMade": 28,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 504176,
+          "allRunMetres": 167,
+          "allRuns": 23,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 3,
+          "errors": 0,
+          "fantasyPointsTotal": 62,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 18,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 1,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 1,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 72,
+          "missedTackles": 2,
+          "offloads": 1,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.39,
+          "passes": 9,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.21,
+          "penalties": 1,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 34,
+          "receipts": 26,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 3826,
+          "stintTwo": 469,
+          "tackleBreaks": 2,
+          "tackleEfficiency": 92.31,
+          "tacklesMade": 36,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 501394,
+          "allRunMetres": 83,
+          "allRuns": 11,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 1,
+          "errors": 0,
+          "fantasyPointsTotal": 26,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 5,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 27,
+          "missedTackles": 0,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.82,
+          "passes": 9,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.15,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 25,
+          "receipts": 14,
+          "ruckInfringements": 1,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 1649,
+          "tackleBreaks": 0,
+          "tackleEfficiency": 100.0,
+          "tacklesMade": 19,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 500453,
+          "allRunMetres": 29,
+          "allRuns": 4,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 6,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 4,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 21,
+          "missedTackles": 2,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.0,
+          "passes": 0,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.67,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 18,
+          "receipts": 4,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 1241,
+          "tackleBreaks": 2,
+          "tackleEfficiency": 66.67,
+          "tacklesMade": 4,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 509444,
+          "allRunMetres": 77,
+          "allRuns": 9,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 1,
+          "fantasyPointsTotal": 27,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 1,
+          "hitUps": 9,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 28,
+          "missedTackles": 0,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.0,
+          "passes": 0,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.73,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 26,
+          "receipts": 9,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 1750,
+          "tackleBreaks": 5,
+          "tackleEfficiency": 100.0,
+          "tacklesMade": 12,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 500087,
+          "allRunMetres": 118,
+          "allRuns": 12,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 25,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 9,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 37,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 37,
+          "missedTackles": 3,
+          "offloads": 1,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.0,
+          "passes": 0,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 3.8,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 47,
+          "receipts": 12,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 2276,
+          "tackleBreaks": 2,
+          "tackleEfficiency": 80.0,
+          "tacklesMade": 12,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        },
+        {
+          "playerId": 504669,
+          "allRunMetres": 0,
+          "allRuns": 0,
+          "bombKicks": 0,
+          "crossFieldKicks": 0,
+          "conversions": 0,
+          "conversionAttempts": 0,
+          "dummyHalfRuns": 0,
+          "dummyHalfRunMetres": 0,
+          "dummyPasses": 0,
+          "errors": 0,
+          "fantasyPointsTotal": 0,
+          "fieldGoals": 0,
+          "forcedDropOutKicks": 0,
+          "fortyTwentyKicks": 0,
+          "goals": 0,
+          "goalConversionRate": 0.0,
+          "grubberKicks": 0,
+          "handlingErrors": 0,
+          "hitUps": 0,
+          "hitUpRunMetres": 0,
+          "ineffectiveTackles": 0,
+          "intercepts": 0,
+          "kicks": 0,
+          "kicksDead": 0,
+          "kicksDefused": 0,
+          "kickMetres": 0,
+          "kickReturnMetres": 0,
+          "lineBreakAssists": 0,
+          "lineBreaks": 0,
+          "lineEngagedRuns": 0,
+          "minutesPlayed": 0,
+          "missedTackles": 0,
+          "offloads": 0,
+          "offsideWithinTenMetres": 0,
+          "oneOnOneLost": 0,
+          "oneOnOneSteal": 0,
+          "onePointFieldGoals": 0,
+          "onReport": 0,
+          "passesToRunRatio": 0.0,
+          "passes": 0,
+          "playTheBallTotal": 0,
+          "playTheBallAverageSpeed": 0.0,
+          "penalties": 0,
+          "points": 0,
+          "penaltyGoals": 0,
+          "postContactMetres": 0,
+          "receipts": 0,
+          "ruckInfringements": 0,
+          "sendOffs": 0,
+          "sinBins": 0,
+          "stintOne": 0,
+          "tackleBreaks": 0,
+          "tackleEfficiency": 0.0,
+          "tacklesMade": 0,
+          "tries": 0,
+          "tryAssists": 0,
+          "twentyFortyKicks": 0,
+          "twoPointFieldGoals": 0
+        }
+      ],
+      "meta": [
+        {
+          "title": "General",
+          "stats": [
+            {
+              "name": "minutesPlayed",
+              "title": "Mins Played",
+              "type": "Number",
+              "units": "Minutes"
+            }
+          ]
+        },
+        {
+          "title": "Scoring",
+          "stats": [
+            {
+              "name": "points",
+              "title": "Points",
+              "type": "Number"
+            },
+            {
+              "name": "tries",
+              "title": "Tries",
+              "type": "Number"
+            },
+            {
+              "name": "conversions",
+              "title": "Conversions",
+              "type": "Number"
+            },
+            {
+              "name": "conversionAttempts",
+              "title": "Conversion Attempts",
+              "type": "Number"
+            },
+            {
+              "name": "penaltyGoals",
+              "title": "Penalty Goals",
+              "type": "Number"
+            },
+            {
+              "name": "goalConversionRate",
+              "title": "Goal Conversion Rate",
+              "type": "Percentage"
+            },
+            {
+              "name": "onePointFieldGoals",
+              "title": "1 Point Field Goals",
+              "type": "Number"
+            },
+            {
+              "name": "twoPointFieldGoals",
+              "title": "2 Point Field Goals",
+              "type": "Number"
+            }
+          ]
+        },
+        {
+          "title": "Fantasy",
+          "stats": [
+            {
+              "name": "fantasyPointsTotal",
+              "title": "Total Points",
+              "type": "Number"
+            }
+          ]
+        },
+        {
+          "title": "Running Metres",
+          "stats": [
+            {
+              "name": "allRuns",
+              "title": "All Runs",
+              "type": "Number"
+            },
+            {
+              "name": "allRunMetres",
+              "title": "All Run Metres",
+              "type": "Number"
+            },
+            {
+              "name": "kickReturnMetres",
+              "title": "Kick Return Metres",
+              "type": "Number"
+            }
+          ]
+        },
+        {
+          "title": "Attack",
+          "stats": [
+            {
+              "name": "postContactMetres",
+              "title": "Post Contact Metres",
+              "type": "Number"
+            },
+            {
+              "name": "lineBreaks",
+              "title": "Line Breaks",
+              "type": "Number"
+            },
+            {
+              "name": "lineBreakAssists",
+              "title": "Line Break Assists",
+              "type": "Number"
+            },
+            {
+              "name": "tryAssists",
+              "title": "Try Assists",
+              "type": "Number"
+            },
+            {
+              "name": "lineEngagedRuns",
+              "title": "Line Engaged Runs",
+              "type": "Number"
+            },
+            {
+              "name": "tackleBreaks",
+              "title": "Tackle Breaks",
+              "type": "Number"
+            },
+            {
+              "name": "hitUps",
+              "title": "Hit Ups",
+              "type": "Number"
+            },
+            {
+              "name": "playTheBallTotal",
+              "title": "Play The Ball",
+              "type": "Number"
+            },
+            {
+              "name": "playTheBallAverageSpeed",
+              "title": "Average Play The Ball Speed",
+              "type": "Number",
+              "units": "Seconds"
+            },
+            {
+              "name": "dummyHalfRuns",
+              "title": "Dummy Half Runs",
+              "type": "Number"
+            },
+            {
+              "name": "dummyHalfRunMetres",
+              "title": "Dummy Half Run Metres",
+              "type": "Number"
+            },
+            {
+              "name": "oneOnOneSteal",
+              "title": "One on One Steal",
+              "type": "Number"
+            }
+          ]
+        },
+        {
+          "title": "Passing",
+          "stats": [
+            {
+              "name": "offloads",
+              "title": "Offloads",
+              "type": "Number"
+            },
+            {
+              "name": "dummyPasses",
+              "title": "Dummy Passes",
+              "type": "Number"
+            },
+            {
+              "name": "passes",
+              "title": "Passes",
+              "type": "Number"
+            },
+            {
+              "name": "receipts",
+              "title": "Receipts",
+              "type": "Number"
+            },
+            {
+              "name": "passesToRunRatio",
+              "title": "Passes To Run Ratio",
+              "type": "Number"
+            }
+          ]
+        },
+        {
+          "title": "Defence",
+          "stats": [
+            {
+              "name": "tackleEfficiency",
+              "title": "Tackle Efficiency",
+              "type": "Percentage"
+            },
+            {
+              "name": "tacklesMade",
+              "title": "Tackles Made",
+              "type": "Number"
+            },
+            {
+              "name": "missedTackles",
+              "title": "Missed Tackles",
+              "type": "Number"
+            },
+            {
+              "name": "ineffectiveTackles",
+              "title": "Ineffective Tackles",
+              "type": "Number"
+            },
+            {
+              "name": "intercepts",
+              "title": "Intercepts",
+              "type": "Number"
+            },
+            {
+              "name": "kicksDefused",
+              "title": "Kicks Defused",
+              "type": "Number"
+            }
+          ]
+        },
+        {
+          "title": "Kicking",
+          "stats": [
+            {
+              "name": "kicks",
+              "title": "Kicks",
+              "type": "Number"
+            },
+            {
+              "name": "kickMetres",
+              "title": "Kicking Metres",
+              "type": "Number"
+            },
+            {
+              "name": "forcedDropOutKicks",
+              "title": "Forced Drop Outs",
+              "type": "Number"
+            },
+            {
+              "name": "bombKicks",
+              "title": "Bomb Kicks",
+              "type": "Number"
+            },
+            {
+              "name": "grubberKicks",
+              "title": "Grubbers",
+              "type": "Number"
+            },
+            {
+              "name": "fortyTwentyKicks",
+              "title": "40/20",
+              "type": "Number"
+            },
+            {
+              "name": "twentyFortyKicks",
+              "title": "20/40",
+              "type": "Number"
+            },
+            {
+              "name": "crossFieldKicks",
+              "title": "Cross Field Kicks",
+              "type": "Number"
+            },
+            {
+              "name": "kicksDead",
+              "title": "Kicked Dead",
+              "type": "Number"
+            }
+          ]
+        },
+        {
+          "title": "Negative Play",
+          "stats": [
+            {
+              "name": "errors",
+              "title": "Errors",
+              "type": "Number"
+            },
+            {
+              "name": "handlingErrors",
+              "title": "Handling Errors",
+              "type": "Number"
+            },
+            {
+              "name": "oneOnOneLost",
+              "title": "One on One Lost",
+              "type": "Number"
+            },
+            {
+              "name": "penalties",
+              "title": "Penalties",
+              "type": "Number"
+            },
+            {
+              "name": "ruckInfringements",
+              "title": "Ruck Infringements",
+              "type": "Number"
+            },
+            {
+              "name": "offsideWithinTenMetres",
+              "title": "Inside 10 Metres",
+              "type": "Number"
+            },
+            {
+              "name": "onReport",
+              "title": "On Report",
+              "type": "Number"
+            },
+            {
+              "name": "sinBins",
+              "title": "Sin Bins",
+              "type": "Number"
+            },
+            {
+              "name": "sendOffs",
+              "title": "Send Offs",
+              "type": "Number"
+            }
+          ]
+        },
+        {
+          "title": "Interchange",
+          "stats": [
+            {
+              "name": "stintOne",
+              "title": "Stint One",
+              "type": "Number",
+              "units": "Seconds"
+            },
+            {
+              "name": "stintTwo",
+              "title": "Stint Two",
+              "type": "Number",
+              "units": "Seconds"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "timeline": [
+    {
+      "title": "KICK OFF",
+      "type": "GameTime",
+      "gameSeconds": 0,
+      "teamId": 0
+    },
+    {
+      "title": "Kick Bomb",
+      "type": "KickBomb",
+      "gameSeconds": 158,
+      "playerId": 505564,
+      "teamId": 500005
+    },
+    {
+      "title": "Kick Bomb",
+      "type": "KickBomb",
+      "gameSeconds": 293,
+      "playerId": 501505,
+      "teamId": 500002
+    },
+    {
+      "title": "Ruck Infringement",
+      "type": "RuckInfringement",
+      "gameSeconds": 337,
+      "playerId": 503443,
+      "teamId": 500002
+    },
+    {
+      "title": "Set Restart",
+      "type": "SetRestart",
+      "gameSeconds": 339,
+      "teamId": 500005
+    },
+    {
+      "title": "Linebreak",
+      "type": "LineBreak",
+      "gameSeconds": 386,
+      "playerId": 500599,
+      "teamId": 500005
+    },
+    {
+      "title": "Try",
+      "type": "Try",
+      "gameSeconds": 387,
+      "playerId": 500599,
+      "teamId": 500005,
+      "awayScore": 4,
+      "content": {
+        "contentId": 1631769,
+        "imageUrl": "/remote.axd?https://imageproxy-prod.nrl.digital/api/assets/73826316/keyframes/478149/image?center=0.5%2C0.5",
+        "topic": "Instant Highlights",
+        "label": "None",
+        "name": "Richard Kennar Try",
+        "published": "2024-03-03T02:45:52Z",
+        "url": "https://www.nrl.com/news/2024/03/03/richard-kennar-try/",
+        "type": "Video",
+        "summary": "Richard Kennar Try",
+        "lastModified": "2024-08-29T00:26:52Z",
+        "subType": "Instant Replay",
+        "showAdverts": true,
+        "tags": {
+          "competition": {
+            "id": "111",
+            "name": "Telstra Premiership"
+          },
+          "season": {
+            "id": "2024",
+            "name": "2024"
+          },
+          "round": {
+            "id": "1",
+            "name": "Round 1"
+          },
+          "match": {
+            "id": "20241110110",
+            "name": "Sea Eagles v Rabbitohs"
+          },
+          "teams": [
+            {
+              "id": "500005",
+              "name": "South Sydney Rabbitohs"
+            }
+          ]
+        },
+        "assetId": "73826316",
+        "autoplay": false,
+        "code": "b63b19ad-180f-44e6-a018-bcb4720073fb",
+        "duration": 15,
+        "isUpcomingLiveStream": false,
+        "tracks": {
+          "thumbnails": "https://vcdn-prod.nrl.com/vod/73826316-1709433764/thumbs.vtt"
+        }
+      }
+    },
+    {
+      "title": "Conversion-Made",
+      "type": "Goal",
+      "gameSeconds": 469,
+      "playerId": 502502,
+      "teamId": 500005,
+      "awayScore": 6
+    },
+    {
+      "title": "Kick Bomb",
+      "type": "KickBomb",
+      "gameSeconds": 580,
+      "playerId": 500646,
+      "teamId": 500002
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 584,
+      "playerId": 501505,
+      "teamId": 500002
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 673,
+      "playerId": 503443,
+      "teamId": 500002
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 753,
+      "playerId": 505564,
+      "teamId": 500005
+    },
+    {
+      "title": "Kick Bomb",
+      "type": "KickBomb",
+      "gameSeconds": 809,
+      "playerId": 500024,
+      "teamId": 500002
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 937,
+      "playerId": 509634,
+      "teamId": 500002
+    },
+    {
+      "title": "Inside 10 Metres",
+      "type": "OffsideWithinTenMetres",
+      "gameSeconds": 966,
+      "playerId": 504251,
+      "teamId": 500002
+    },
+    {
+      "title": "Set Restart",
+      "type": "SetRestart",
+      "gameSeconds": 966,
+      "teamId": 500005
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 1019,
+      "playerId": 504174,
+      "teamId": 500005
+    },
+    {
+      "title": "Linebreak",
+      "type": "LineBreak",
+      "gameSeconds": 1025,
+      "playerId": 507670,
+      "teamId": 500002
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 1046,
+      "playerId": 500024,
+      "teamId": 500002
+    },
+    {
+      "title": "Interchange #1",
+      "type": "Interchange",
+      "gameSeconds": 1089,
+      "playerId": 500647,
+      "teamId": 500002,
+      "offPlayerId": 500882
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 1184,
+      "playerId": 509634,
+      "teamId": 500002
+    },
+    {
+      "title": "Interchange #1",
+      "type": "Interchange",
+      "gameSeconds": 1200,
+      "playerId": 500087,
+      "teamId": 500005,
+      "offPlayerId": 503450
+    },
+    {
+      "title": "Kick Bomb",
+      "type": "KickBomb",
+      "gameSeconds": 1236,
+      "playerId": 505564,
+      "teamId": 500005
+    },
+    {
+      "title": "Penalty - Dangerous Tackle",
+      "type": "Penalty",
+      "gameSeconds": 1240,
+      "playerId": 500599,
+      "teamId": 500005
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 1335,
+      "playerId": 502502,
+      "teamId": 500005
+    },
+    {
+      "title": "Interchange #2",
+      "type": "Interchange",
+      "gameSeconds": 1340,
+      "playerId": 509444,
+      "teamId": 500005,
+      "offPlayerId": 504265
+    },
+    {
+      "title": "Linebreak",
+      "type": "LineBreak",
+      "gameSeconds": 1346,
+      "playerId": 508033,
+      "teamId": 500002
+    },
+    {
+      "title": "Try",
+      "type": "Try",
+      "gameSeconds": 1346,
+      "playerId": 508033,
+      "teamId": 500002,
+      "homeScore": 4,
+      "awayScore": 6,
+      "content": {
+        "contentId": 1631775,
+        "imageUrl": "/remote.axd?https://imageproxy-prod.nrl.digital/api/assets/73826033/keyframes/478153/image?center=0.5%2C0.5",
+        "topic": "Instant Highlights",
+        "label": "None",
+        "name": "Haumole Olakau'atu Try",
+        "published": "2024-03-03T03:15:19Z",
+        "url": "https://www.nrl.com/news/2024/03/03/haumole-olakauatu-try/",
+        "type": "Video",
+        "summary": "Haumole Olakau'atu Try",
+        "lastModified": "2024-08-29T00:26:52Z",
+        "subType": "Instant Replay",
+        "showAdverts": true,
+        "tags": {
+          "competition": {
+            "id": "111",
+            "name": "Telstra Premiership"
+          },
+          "season": {
+            "id": "2024",
+            "name": "2024"
+          },
+          "round": {
+            "id": "1",
+            "name": "Round 1"
+          },
+          "match": {
+            "id": "20241110110",
+            "name": "Sea Eagles v Rabbitohs"
+          },
+          "teams": [
+            {
+              "id": "500002",
+              "name": "Manly-Warringah Sea Eagles"
+            }
+          ]
+        },
+        "assetId": "73826033",
+        "autoplay": false,
+        "code": "6be51f89-df18-4de6-ab18-3e4edb00e66f",
+        "duration": 14,
+        "isUpcomingLiveStream": false,
+        "tracks": {
+          "thumbnails": "https://vcdn-prod.nrl.com/vod/73826033-1709435586/thumbs.vtt"
+        }
+      }
+    },
+    {
+      "title": "Conversion-Made",
+      "type": "Goal",
+      "gameSeconds": 1444,
+      "playerId": 503443,
+      "teamId": 500002,
+      "homeScore": 6,
+      "awayScore": 6
+    },
+    {
+      "title": "Kick Bomb",
+      "type": "KickBomb",
+      "gameSeconds": 1502,
+      "playerId": 502063,
+      "teamId": 500002
+    },
+    {
+      "title": "Interchange #2",
+      "type": "Interchange",
+      "gameSeconds": 1554,
+      "playerId": 506153,
+      "teamId": 500002,
+      "offPlayerId": 504251
+    },
+    {
+      "title": "Kick Bomb",
+      "type": "KickBomb",
+      "gameSeconds": 1596,
+      "playerId": 500024,
+      "teamId": 500002
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 1599,
+      "playerId": 501505,
+      "teamId": 500002
+    },
+    {
+      "title": "Linebreak",
+      "type": "LineBreak",
+      "gameSeconds": 1677,
+      "playerId": 503443,
+      "teamId": 500002
+    },
+    {
+      "title": "Penalty - Ball Strip",
+      "type": "Penalty",
+      "gameSeconds": 1683,
+      "playerId": 502502,
+      "teamId": 500005
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 1737,
+      "playerId": 500646,
+      "teamId": 500002
+    },
+    {
+      "title": "Interchange #3",
+      "type": "Interchange",
+      "gameSeconds": 1740,
+      "playerId": 501394,
+      "teamId": 500005,
+      "offPlayerId": 500149
+    },
+    {
+      "title": "Ruck Infringement",
+      "type": "RuckInfringement",
+      "gameSeconds": 1775,
+      "playerId": 509634,
+      "teamId": 500002
+    },
+    {
+      "title": "Set Restart",
+      "type": "SetRestart",
+      "gameSeconds": 1777,
+      "teamId": 500005
+    },
+    {
+      "title": "Linebreak",
+      "type": "LineBreak",
+      "gameSeconds": 1819,
+      "playerId": 501245,
+      "teamId": 500005
+    },
+    {
+      "title": "Try",
+      "type": "Try",
+      "gameSeconds": 1820,
+      "playerId": 501245,
+      "teamId": 500005,
+      "homeScore": 6,
+      "awayScore": 10,
+      "content": {
+        "contentId": 1631784,
+        "imageUrl": "/remote.axd?https://imageproxy-prod.nrl.digital/api/assets/73829284/keyframes/478155/image?center=0.5%2C0.5",
+        "topic": "Instant Highlights",
+        "label": "None",
+        "name": "Jacob Gagai Try",
+        "published": "2024-03-03T03:27:58Z",
+        "url": "https://www.nrl.com/news/2024/03/03/jacob-gagai-try/",
+        "type": "Video",
+        "summary": "Jacob Gagai Try",
+        "lastModified": "2024-08-29T00:26:52Z",
+        "subType": "Instant Replay",
+        "showAdverts": true,
+        "tags": {
+          "competition": {
+            "id": "111",
+            "name": "Telstra Premiership"
+          },
+          "season": {
+            "id": "2024",
+            "name": "2024"
+          },
+          "round": {
+            "id": "1",
+            "name": "Round 1"
+          },
+          "match": {
+            "id": "20241110110",
+            "name": "Sea Eagles v Rabbitohs"
+          },
+          "teams": [
+            {
+              "id": "500005",
+              "name": "South Sydney Rabbitohs"
+            }
+          ]
+        },
+        "assetId": "73829284",
+        "autoplay": false,
+        "code": "04ab2872-07c6-4de6-bb18-ad76c0009e6e",
+        "duration": 15,
+        "isUpcomingLiveStream": false,
+        "tracks": {
+          "thumbnails": "https://vcdn-prod.nrl.com/vod/73829284-1709436100/thumbs.vtt"
+        }
+      }
+    },
+    {
+      "title": "Conversion-Missed",
+      "type": "GoalMissed",
+      "gameSeconds": 1907,
+      "playerId": 502502,
+      "teamId": 500005
+    },
+    {
+      "title": "Kick Bomb",
+      "type": "KickBomb",
+      "gameSeconds": 1976,
+      "playerId": 505564,
+      "teamId": 500005
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 1981,
+      "playerId": 500108,
+      "teamId": 500005
+    },
+    {
+      "title": "Penalty - 2nd Effort",
+      "type": "Penalty",
+      "gameSeconds": 2008,
+      "playerId": 504176,
+      "teamId": 500005
+    },
+    {
+      "title": "Linebreak",
+      "type": "LineBreak",
+      "gameSeconds": 2077,
+      "playerId": 501505,
+      "teamId": 500002
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 2080,
+      "playerId": 501505,
+      "teamId": 500002
+    },
+    {
+      "title": "Kick Bomb",
+      "type": "KickBomb",
+      "gameSeconds": 2140,
+      "playerId": 500611,
+      "teamId": 500005
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 2234,
+      "playerId": 502502,
+      "teamId": 500005
+    },
+    {
+      "title": "Try",
+      "type": "Try",
+      "gameSeconds": 2242,
+      "playerId": 507670,
+      "teamId": 500002,
+      "homeScore": 10,
+      "awayScore": 10,
+      "content": {
+        "contentId": 1631791,
+        "imageUrl": "/remote.axd?https://imageproxy-prod.nrl.digital/api/assets/73829394/keyframes/478170/image?center=0.5%2C0.5",
+        "topic": "Instant Highlights",
+        "label": "None",
+        "name": "Jason Saab Try",
+        "published": "2024-03-03T03:40:23Z",
+        "url": "https://www.nrl.com/news/2024/03/03/jason-saab-try/",
+        "type": "Video",
+        "summary": "Jason Saab Try",
+        "lastModified": "2024-08-29T00:26:52Z",
+        "subType": "Instant Replay",
+        "showAdverts": true,
+        "tags": {
+          "competition": {
+            "id": "111",
+            "name": "Telstra Premiership"
+          },
+          "season": {
+            "id": "2024",
+            "name": "2024"
+          },
+          "round": {
+            "id": "1",
+            "name": "Round 1"
+          },
+          "match": {
+            "id": "20241110110",
+            "name": "Sea Eagles v Rabbitohs"
+          },
+          "teams": [
+            {
+              "id": "500002",
+              "name": "Manly-Warringah Sea Eagles"
+            }
+          ]
+        },
+        "assetId": "73829394",
+        "autoplay": false,
+        "code": "fb742ff8-0564-43e6-9b18-41fa0400da9b",
+        "duration": 15,
+        "isUpcomingLiveStream": false,
+        "tracks": {
+          "thumbnails": "https://vcdn-prod.nrl.com/vod/73829394-1709436874/thumbs.vtt"
+        }
+      }
+    },
+    {
+      "title": "Conversion-Made",
+      "type": "Goal",
+      "gameSeconds": 2303,
+      "playerId": 503443,
+      "teamId": 500002,
+      "homeScore": 12,
+      "awayScore": 10
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 2369,
+      "playerId": 509634,
+      "teamId": 500002
+    },
+    {
+      "title": "Kick Bomb",
+      "type": "KickBomb",
+      "gameSeconds": 2535,
+      "playerId": 505564,
+      "teamId": 500005
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 2546,
+      "playerId": 507670,
+      "teamId": 500002
+    },
+    {
+      "title": "Video Referee - Captain's Challenge",
+      "type": "CaptainsChallenge",
+      "gameSeconds": 2562,
+      "teamId": 500002,
+      "description": "Unsuccessful"
+    },
+    {
+      "title": "Linebreak",
+      "type": "LineBreak",
+      "gameSeconds": 2611,
+      "playerId": 502502,
+      "teamId": 500005
+    },
+    {
+      "title": "Try",
+      "type": "Try",
+      "gameSeconds": 2612,
+      "playerId": 502502,
+      "teamId": 500005,
+      "homeScore": 12,
+      "awayScore": 14,
+      "content": {
+        "contentId": 1631802,
+        "imageUrl": "/remote.axd?https://imageproxy-prod.nrl.digital/api/assets/73829355/keyframes/478172/image?center=0.5%2C0.5",
+        "topic": "Instant Highlights",
+        "label": "None",
+        "name": "Latrell Mitchell Try",
+        "published": "2024-03-03T03:59:23Z",
+        "url": "https://www.nrl.com/news/2024/03/03/latrell-mitchell-try/",
+        "type": "Video",
+        "summary": "Latrell Mitchell Try",
+        "lastModified": "2024-08-29T00:26:52Z",
+        "subType": "Instant Replay",
+        "showAdverts": true,
+        "tags": {
+          "competition": {
+            "id": "111",
+            "name": "Telstra Premiership"
+          },
+          "season": {
+            "id": "2024",
+            "name": "2024"
+          },
+          "round": {
+            "id": "1",
+            "name": "Round 1"
+          },
+          "match": {
+            "id": "20241110110",
+            "name": "Sea Eagles v Rabbitohs"
+          },
+          "teams": [
+            {
+              "id": "500005",
+              "name": "South Sydney Rabbitohs"
+            }
+          ]
+        },
+        "assetId": "73829355",
+        "autoplay": false,
+        "code": "9ba23afd-3557-4ae6-b618-ab4da400e00d",
+        "duration": 15,
+        "isUpcomingLiveStream": false,
+        "tracks": {
+          "thumbnails": "https://vcdn-prod.nrl.com/vod/73829355-1709438241/thumbs.vtt"
+        }
+      }
+    },
+    {
+      "title": "Conversion-Missed",
+      "type": "GoalMissed",
+      "gameSeconds": 2697,
+      "playerId": 502502,
+      "teamId": 500005
+    },
+    {
+      "title": "Kick Bomb",
+      "type": "KickBomb",
+      "gameSeconds": 2753,
+      "playerId": 505564,
+      "teamId": 500005
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 2786,
+      "playerId": 500646,
+      "teamId": 500002
+    },
+    {
+      "title": "Linebreak",
+      "type": "LineBreak",
+      "gameSeconds": 2842,
+      "playerId": 500108,
+      "teamId": 500005
+    },
+    {
+      "title": "Try",
+      "type": "Try",
+      "gameSeconds": 2842,
+      "playerId": 500108,
+      "teamId": 500005,
+      "homeScore": 12,
+      "awayScore": 18,
+      "content": {
+        "contentId": 1631804,
+        "imageUrl": "/remote.axd?https://imageproxy-prod.nrl.digital/api/assets/73829362/keyframes/478175/image?center=0.5%2C0.5",
+        "topic": "Instant Highlights",
+        "label": "None",
+        "name": "Alex Johnston Try",
+        "published": "2024-03-03T04:03:13Z",
+        "url": "https://www.nrl.com/news/2024/03/03/alex-johnston-try/",
+        "type": "Video",
+        "summary": "Alex Johnston Try",
+        "lastModified": "2024-08-29T00:26:52Z",
+        "subType": "Instant Replay",
+        "showAdverts": true,
+        "tags": {
+          "competition": {
+            "id": "111",
+            "name": "Telstra Premiership"
+          },
+          "season": {
+            "id": "2024",
+            "name": "2024"
+          },
+          "round": {
+            "id": "1",
+            "name": "Round 1"
+          },
+          "match": {
+            "id": "20241110110",
+            "name": "Sea Eagles v Rabbitohs"
+          },
+          "teams": [
+            {
+              "id": "500005",
+              "name": "South Sydney Rabbitohs"
+            }
+          ]
+        },
+        "assetId": "73829362",
+        "autoplay": false,
+        "code": "43fd3c2c-faab-40e6-9918-80d25800c2da",
+        "duration": 15,
+        "isUpcomingLiveStream": false,
+        "tracks": {
+          "thumbnails": "https://vcdn-prod.nrl.com/vod/73829362-1709438470/thumbs.vtt"
+        }
+      }
+    },
+    {
+      "title": "Conversion-Made",
+      "type": "Goal",
+      "gameSeconds": 2918,
+      "playerId": 502502,
+      "teamId": 500005,
+      "homeScore": 12,
+      "awayScore": 20
+    },
+    {
+      "title": "Interchange #3",
+      "type": "Interchange",
+      "gameSeconds": 2924,
+      "playerId": 504251,
+      "teamId": 500002,
+      "offPlayerId": 506153
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 2947,
+      "playerId": 509444,
+      "teamId": 500005
+    },
+    {
+      "title": "Linebreak",
+      "type": "LineBreak",
+      "gameSeconds": 2994,
+      "playerId": 502063,
+      "teamId": 500002
+    },
+    {
+      "title": "Try",
+      "type": "Try",
+      "gameSeconds": 2994,
+      "playerId": 502063,
+      "teamId": 500002,
+      "homeScore": 16,
+      "awayScore": 20,
+      "content": {
+        "contentId": 1631803,
+        "imageUrl": "/remote.axd?https://imageproxy-prod.nrl.digital/api/assets/73829379/keyframes/478176/image?center=0.5%2C0.5",
+        "topic": "Instant Highlights",
+        "label": "None",
+        "name": "Lachlan Croker Try",
+        "published": "2024-03-03T04:00:32Z",
+        "url": "https://www.nrl.com/news/2024/03/03/lachlan-croker-try/",
+        "type": "Video",
+        "summary": "Lachlan Croker Try",
+        "lastModified": "2024-08-29T00:26:52Z",
+        "subType": "Instant Replay",
+        "showAdverts": true,
+        "tags": {
+          "competition": {
+            "id": "111",
+            "name": "Telstra Premiership"
+          },
+          "season": {
+            "id": "2024",
+            "name": "2024"
+          },
+          "round": {
+            "id": "1",
+            "name": "Round 1"
+          },
+          "match": {
+            "id": "20241110110",
+            "name": "Sea Eagles v Rabbitohs"
+          },
+          "teams": [
+            {
+              "id": "500002",
+              "name": "Manly-Warringah Sea Eagles"
+            }
+          ]
+        },
+        "assetId": "73829379",
+        "autoplay": false,
+        "code": "82133bc5-1779-43e6-b718-dab11500d701",
+        "duration": 11,
+        "isUpcomingLiveStream": false,
+        "tracks": {
+          "thumbnails": "https://vcdn-prod.nrl.com/vod/73829379-1709438318/thumbs.vtt"
+        }
+      }
+    },
+    {
+      "title": "Conversion-Made",
+      "type": "Goal",
+      "gameSeconds": 3083,
+      "playerId": 503443,
+      "teamId": 500002,
+      "homeScore": 18,
+      "awayScore": 20
+    },
+    {
+      "title": "Interchange #4",
+      "type": "Interchange",
+      "gameSeconds": 3090,
+      "playerId": 502409,
+      "teamId": 500002,
+      "offPlayerId": 502063
+    },
+    {
+      "title": "Interchange #4",
+      "type": "Interchange",
+      "gameSeconds": 3090,
+      "playerId": 500453,
+      "teamId": 500005,
+      "offPlayerId": 509444
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 3158,
+      "playerId": 500599,
+      "teamId": 500005
+    },
+    {
+      "title": "Ruck Infringement",
+      "type": "RuckInfringement",
+      "gameSeconds": 3208,
+      "playerId": 501394,
+      "teamId": 500005
+    },
+    {
+      "title": "Set Restart",
+      "type": "SetRestart",
+      "gameSeconds": 3209,
+      "teamId": 500002
+    },
+    {
+      "title": "Linebreak",
+      "type": "LineBreak",
+      "gameSeconds": 3227,
+      "playerId": 507850,
+      "teamId": 500002
+    },
+    {
+      "title": "Try",
+      "type": "Try",
+      "gameSeconds": 3228,
+      "playerId": 507850,
+      "teamId": 500002,
+      "homeScore": 22,
+      "awayScore": 20,
+      "content": {
+        "contentId": 1631806,
+        "imageUrl": "/remote.axd?https://imageproxy-prod.nrl.digital/api/assets/73832214/keyframes/478179/image?center=0.124%2C0.488",
+        "topic": "Instant Highlights",
+        "label": "None",
+        "name": "Ben Trbojevic Try",
+        "published": "2024-03-03T04:08:45Z",
+        "url": "https://www.nrl.com/news/2024/03/03/ben-trbojevic-try/",
+        "type": "Video",
+        "summary": "Ben Trbojevic Try",
+        "lastModified": "2024-08-29T00:26:52Z",
+        "subType": "Instant Replay",
+        "showAdverts": true,
+        "tags": {
+          "competition": {
+            "id": "111",
+            "name": "Telstra Premiership"
+          },
+          "season": {
+            "id": "2024",
+            "name": "2024"
+          },
+          "round": {
+            "id": "1",
+            "name": "Round 1"
+          },
+          "match": {
+            "id": "20241110110",
+            "name": "Sea Eagles v Rabbitohs"
+          },
+          "teams": [
+            {
+              "id": "500002",
+              "name": "Manly-Warringah Sea Eagles"
+            }
+          ]
+        },
+        "assetId": "73832214",
+        "autoplay": false,
+        "code": "69e93ebf-4fa4-43e6-8318-6a04a6003530",
+        "duration": 16,
+        "isUpcomingLiveStream": false,
+        "tracks": {
+          "thumbnails": "https://vcdn-prod.nrl.com/vod/73832214-1709438812/thumbs.vtt"
+        }
+      }
+    },
+    {
+      "title": "Conversion-Made",
+      "type": "Goal",
+      "gameSeconds": 3320,
+      "playerId": 503443,
+      "teamId": 500002,
+      "homeScore": 24,
+      "awayScore": 20
+    },
+    {
+      "title": "Interchange #5",
+      "type": "Interchange",
+      "gameSeconds": 3389,
+      "playerId": 500149,
+      "teamId": 500005,
+      "offPlayerId": 501394
+    },
+    {
+      "title": "Kick Bomb",
+      "type": "KickBomb",
+      "gameSeconds": 3427,
+      "playerId": 500611,
+      "teamId": 500005
+    },
+    {
+      "title": "Penalty - Dangerous Tackle",
+      "type": "Penalty",
+      "gameSeconds": 3447,
+      "playerId": 500149,
+      "teamId": 500005
+    },
+    {
+      "title": "Interchange #6",
+      "type": "Interchange",
+      "gameSeconds": 3476,
+      "playerId": 503450,
+      "teamId": 500005,
+      "offPlayerId": 500087
+    },
+    {
+      "title": "Line Dropout",
+      "type": "LineDropout",
+      "gameSeconds": 3561,
+      "playerId": 502502,
+      "teamId": 500005
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 3565,
+      "playerId": 501245,
+      "teamId": 500005
+    },
+    {
+      "title": "Try",
+      "type": "Try",
+      "gameSeconds": 3657,
+      "playerId": 503443,
+      "teamId": 500002,
+      "homeScore": 28,
+      "awayScore": 20,
+      "content": {
+        "contentId": 1631809,
+        "imageUrl": "/remote.axd?https://imageproxy-prod.nrl.digital/api/assets/73831849/keyframes/478178/image?center=0.338%2C0.623",
+        "topic": "Instant Highlights",
+        "label": "None",
+        "name": "Reuben Garrick Try - with a Gronk spike",
+        "published": "2024-03-03T04:10:44Z",
+        "url": "https://www.nrl.com/news/2024/03/03/reuben-garrick-try/",
+        "type": "Video",
+        "summary": "Reuben Garrick Try - with a Gronk spike",
+        "lastModified": "2024-08-29T00:26:52Z",
+        "subType": "Instant Replay",
+        "showAdverts": true,
+        "tags": {
+          "competition": {
+            "id": "111",
+            "name": "Telstra Premiership"
+          },
+          "season": {
+            "id": "2024",
+            "name": "2024"
+          },
+          "round": {
+            "id": "1",
+            "name": "Round 1"
+          },
+          "match": {
+            "id": "20241110110",
+            "name": "Sea Eagles v Rabbitohs"
+          },
+          "teams": [
+            {
+              "id": "500002",
+              "name": "Manly-Warringah Sea Eagles"
+            }
+          ]
+        },
+        "assetId": "73831849",
+        "autoplay": false,
+        "code": "d283411a-428a-47e6-b918-0a8c0a00b864",
+        "duration": 15,
+        "isUpcomingLiveStream": false,
+        "tracks": {
+          "thumbnails": "https://vcdn-prod.nrl.com/vod/73831849-1709438886/thumbs.vtt"
+        }
+      }
+    },
+    {
+      "title": "Interchange #5",
+      "type": "Interchange",
+      "gameSeconds": 3720,
+      "playerId": 503341,
+      "teamId": 500002,
+      "offPlayerId": 504251
+    },
+    {
+      "title": "Interchange #6",
+      "type": "Interchange",
+      "gameSeconds": 3727,
+      "playerId": 500882,
+      "teamId": 500002,
+      "offPlayerId": 500647
+    },
+    {
+      "title": "Conversion-Made",
+      "type": "Goal",
+      "gameSeconds": 3754,
+      "playerId": 503443,
+      "teamId": 500002,
+      "homeScore": 30,
+      "awayScore": 20
+    },
+    {
+      "title": "Interchange #7",
+      "type": "Interchange",
+      "gameSeconds": 3826,
+      "playerId": 504265,
+      "teamId": 500005,
+      "offPlayerId": 504176
+    },
+    {
+      "title": "Kick Bomb",
+      "type": "KickBomb",
+      "gameSeconds": 3926,
+      "playerId": 500024,
+      "teamId": 500002
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 3929,
+      "playerId": 507670,
+      "teamId": 500002
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 4051,
+      "playerId": 508033,
+      "teamId": 500002
+    },
+    {
+      "title": "Penalty - Offside inside 10m",
+      "type": "Penalty",
+      "gameSeconds": 4149,
+      "playerId": 501600,
+      "teamId": 500005
+    },
+    {
+      "title": "Kick Bomb",
+      "type": "KickBomb",
+      "gameSeconds": 4288,
+      "playerId": 505564,
+      "teamId": 500005
+    },
+    {
+      "title": "Interchange #7",
+      "type": "Interchange",
+      "gameSeconds": 4306,
+      "playerId": 500647,
+      "teamId": 500002,
+      "offPlayerId": 507850
+    },
+    {
+      "title": "Interchange #8",
+      "type": "Interchange",
+      "gameSeconds": 4331,
+      "playerId": 504176,
+      "teamId": 500005,
+      "offPlayerId": 500453
+    },
+    {
+      "title": "Penalty - Dangerous Tackle",
+      "type": "Penalty",
+      "gameSeconds": 4336,
+      "playerId": 500647,
+      "teamId": 500002
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 4418,
+      "playerId": 503450,
+      "teamId": 500005
+    },
+    {
+      "title": "Interchange #8",
+      "type": "Interchange",
+      "gameSeconds": 4441,
+      "playerId": 502063,
+      "teamId": 500002,
+      "offPlayerId": 502409
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 4487,
+      "playerId": 502502,
+      "teamId": 500005
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 4544,
+      "playerId": 500108,
+      "teamId": 500005
+    },
+    {
+      "title": "Interchange #8",
+      "type": "Interchange",
+      "gameSeconds": 4590,
+      "teamId": 500002,
+      "offPlayerId": 507670
+    },
+    {
+      "title": "Linebreak",
+      "type": "LineBreak",
+      "gameSeconds": 4595,
+      "playerId": 500646,
+      "teamId": 500002
+    },
+    {
+      "title": "Try",
+      "type": "Try",
+      "gameSeconds": 4595,
+      "playerId": 500646,
+      "teamId": 500002,
+      "homeScore": 34,
+      "awayScore": 20,
+      "content": {
+        "contentId": 1631813,
+        "imageUrl": "/remote.axd?https://imageproxy-prod.nrl.digital/api/assets/73832272/keyframes/478180/image?center=0.5%2C0.5",
+        "topic": "Instant Highlights",
+        "label": "None",
+        "name": "Luke Brooks Try",
+        "published": "2024-03-03T04:35:28Z",
+        "url": "https://www.nrl.com/news/2024/03/03/luke-brooks-try/",
+        "type": "Video",
+        "summary": "Luke Brooks Try",
+        "lastModified": "2024-08-29T00:26:52Z",
+        "subType": "Instant Replay",
+        "showAdverts": true,
+        "tags": {
+          "competition": {
+            "id": "111",
+            "name": "Telstra Premiership"
+          },
+          "season": {
+            "id": "2024",
+            "name": "2024"
+          },
+          "round": {
+            "id": "1",
+            "name": "Round 1"
+          },
+          "match": {
+            "id": "20241110110",
+            "name": "Sea Eagles v Rabbitohs"
+          },
+          "teams": [
+            {
+              "id": "500002",
+              "name": "Manly-Warringah Sea Eagles"
+            }
+          ]
+        },
+        "assetId": "73832272",
+        "autoplay": false,
+        "code": "c65a455c-6f5f-4fe6-9518-5e168b00fb26",
+        "duration": 14,
+        "isUpcomingLiveStream": false,
+        "tracks": {
+          "thumbnails": "https://vcdn-prod.nrl.com/vod/73832272-1709440414/thumbs.vtt"
+        }
+      }
+    },
+    {
+      "title": "Conversion-Made",
+      "type": "Goal",
+      "gameSeconds": 4689,
+      "playerId": 503443,
+      "teamId": 500002,
+      "homeScore": 36,
+      "awayScore": 20
+    },
+    {
+      "title": "Error",
+      "type": "Error",
+      "gameSeconds": 4697,
+      "playerId": 506255,
+      "teamId": 500002
+    },
+    {
+      "title": "Linebreak",
+      "type": "LineBreak",
+      "gameSeconds": 4718,
+      "playerId": 500599,
+      "teamId": 500005
+    },
+    {
+      "title": "Try",
+      "type": "Try",
+      "gameSeconds": 4718,
+      "playerId": 500599,
+      "teamId": 500005,
+      "homeScore": 36,
+      "awayScore": 24,
+      "content": {
+        "contentId": 1631814,
+        "imageUrl": "/remote.axd?https://imageproxy-prod.nrl.digital/api/assets/73831905/keyframes/478181/image?center=0.5%2C0.5",
+        "topic": "Instant Highlights",
+        "label": "None",
+        "name": "Richard Kennar Try",
+        "published": "2024-03-03T04:37:26Z",
+        "url": "https://www.nrl.com/news/2024/03/03/richard-kennar-try2/",
+        "type": "Video",
+        "summary": "Richard Kennar Try",
+        "lastModified": "2024-08-29T00:26:52Z",
+        "subType": "Instant Replay",
+        "showAdverts": true,
+        "tags": {
+          "competition": {
+            "id": "111",
+            "name": "Telstra Premiership"
+          },
+          "season": {
+            "id": "2024",
+            "name": "2024"
+          },
+          "round": {
+            "id": "1",
+            "name": "Round 1"
+          },
+          "match": {
+            "id": "20241110110",
+            "name": "Sea Eagles v Rabbitohs"
+          },
+          "teams": [
+            {
+              "id": "500005",
+              "name": "South Sydney Rabbitohs"
+            }
+          ]
+        },
+        "assetId": "73831905",
+        "autoplay": false,
+        "code": "420e463d-5be9-4ae6-9a18-edb7c1005a05",
+        "duration": 14,
+        "isUpcomingLiveStream": false,
+        "tracks": {
+          "thumbnails": "https://vcdn-prod.nrl.com/vod/73831905-1709440452/thumbs.vtt"
+        }
+      }
+    },
+    {
+      "title": "Conversion-Missed",
+      "type": "GoalMissed",
+      "gameSeconds": 4748,
+      "playerId": 502502,
+      "teamId": 500005
+    },
+    {
+      "title": "FULL TIME",
+      "type": "GameTime",
+      "gameSeconds": 4800,
+      "teamId": 0
+    }
+  ]
+}

--- a/tests/fixtures/match-2026-rd8-wests-tigers-v-raiders.json
+++ b/tests/fixtures/match-2026-rd8-wests-tigers-v-raiders.json
@@ -1,0 +1,409 @@
+{
+  "matchId": "20261110810",
+  "matchMode": "Pre",
+  "matchState": "Upcoming",
+  "updated": "2026-04-20T23:46:11Z",
+  "gameSeconds": 0,
+  "roundNumber": 8,
+  "roundTitle": "Round 8",
+  "startTime": "2026-04-23T09:50:00Z",
+  "url": "https://www.nrl.com/draw/nrl-premiership/2026/round-8/wests-tigers-v-raiders/",
+  "homeTeam": {
+    "teamId": 500023,
+    "nickName": "Wests Tigers",
+    "name": "Wests Tigers",
+    "odds": "1.56",
+    "teamPosition": "3rd",
+    "theme": {
+      "key": "wests-tigers",
+      "logos": {
+        "badge-basic24-mono.svg": "202603300722",
+        "badge-basic24.svg": "202603300722",
+        "badge-light.svg": "202603300722",
+        "badge.png": "202603300722",
+        "badge.svg": "202603300722",
+        "header-background.png": "202603300722",
+        "header-background.svg": "202603300722",
+        "silhouette.png": "202603300722",
+        "silhouette.svg": "202603300722",
+        "text.svg": "202603300722"
+      }
+    },
+    "recentForm": [
+      {
+        "result": "Lost",
+        "summary": "vs Broncos",
+        "score": "20-21",
+        "url": "https://www.nrl.com/draw/nrl-premiership/2026/round-7/wests-tigers-v-broncos/"
+      },
+      {
+        "result": "Won",
+        "summary": "vs Knights",
+        "score": "42-22",
+        "url": "https://www.nrl.com/draw/nrl-premiership/2026/round-6/wests-tigers-v-knights/"
+      },
+      {
+        "result": "Won",
+        "summary": "vs Eels",
+        "score": "22-20",
+        "url": "https://www.nrl.com/draw/nrl-premiership/2026/round-5/eels-v-wests-tigers/"
+      },
+      {
+        "result": "Won",
+        "summary": "vs Warriors",
+        "score": "32-14",
+        "url": "https://www.nrl.com/draw/nrl-premiership/2026/round-4/warriors-v-wests-tigers/"
+      },
+      {
+        "result": "Lost",
+        "summary": "vs Rabbitohs",
+        "score": "16-20",
+        "url": "https://www.nrl.com/draw/nrl-premiership/2026/round-3/rabbitohs-v-wests-tigers/"
+      }
+    ],
+    "nextOpponent": {
+      "teamId": 500028,
+      "nickName": "Sharks",
+      "name": "Cronulla-Sutherland Sharks",
+      "theme": {
+        "key": "sharks",
+        "logos": {
+          "badge-basic24-light.svg": "202603300722",
+          "badge-basic24-mono.svg": "202603300722",
+          "badge-basic24.svg": "202603300722",
+          "badge-light.png": "202603300722",
+          "badge-light.svg": "202603300722",
+          "badge.png": "202603300722",
+          "badge.svg": "202603300722",
+          "header-background.png": "202603300722",
+          "header-background.svg": "202603300722",
+          "silhouette.png": "202603300722",
+          "silhouette.svg": "202603300722",
+          "text.svg": "202603300722"
+        }
+      }
+    },
+    "url": "https://www.weststigers.com.au/teams/nrl-premiership/wests-tigers/"
+  },
+  "awayTeam": {
+    "teamId": 500013,
+    "nickName": "Raiders",
+    "name": "Canberra Raiders",
+    "odds": "2.42",
+    "teamPosition": "13th",
+    "theme": {
+      "key": "raiders",
+      "logos": {
+        "badge-basic24-mono.svg": "202603300722",
+        "badge-basic24.svg": "202603300722",
+        "badge-light.png": "202603300722",
+        "badge-light.svg": "202603300722",
+        "badge.png": "202603300722",
+        "badge.svg": "202603300722",
+        "header-background.png": "202603300722",
+        "header-background.svg": "202603300722",
+        "silhouette.png": "202603300722",
+        "silhouette.svg": "202603300722",
+        "text.svg": "202603300722"
+      }
+    },
+    "recentForm": [
+      {
+        "result": "Won",
+        "summary": "vs Storm",
+        "score": "26-22",
+        "url": "https://www.nrl.com/draw/nrl-premiership/2026/round-7/raiders-v-storm/"
+      },
+      {
+        "result": "Won",
+        "summary": "vs Rabbitohs",
+        "score": "36-34",
+        "url": "https://www.nrl.com/draw/nrl-premiership/2026/round-6/rabbitohs-v-raiders/"
+      },
+      {
+        "result": "Lost",
+        "summary": "vs Knights",
+        "score": "12-32",
+        "url": "https://www.nrl.com/draw/nrl-premiership/2026/round-5/knights-v-raiders/"
+      },
+      {
+        "result": "Lost",
+        "summary": "vs Sharks",
+        "score": "22-34",
+        "url": "https://www.nrl.com/draw/nrl-premiership/2026/round-4/raiders-v-sharks/"
+      },
+      {
+        "result": "Lost",
+        "summary": "vs Bulldogs",
+        "score": "10-14",
+        "url": "https://www.nrl.com/draw/nrl-premiership/2026/round-3/raiders-v-bulldogs/"
+      }
+    ],
+    "nextOpponent": {
+      "teamId": 500004,
+      "nickName": "Titans",
+      "name": "Gold Coast Titans",
+      "theme": {
+        "key": "titans",
+        "logos": {
+          "badge-basic24-mono.svg": "202603300722",
+          "badge-basic24.svg": "202603300722",
+          "badge.png": "202603300722",
+          "badge.svg": "202603300722",
+          "header-background.png": "202603300722",
+          "header-background.svg": "202603300722",
+          "silhouette.png": "202603300722",
+          "silhouette.svg": "202603300722",
+          "text.svg": "202603300722"
+        }
+      }
+    },
+    "url": "https://www.raiders.com.au/teams/nrl-premiership/canberra-raiders/"
+  },
+  "venue": "Leichhardt Oval",
+  "venueCity": "Sydney",
+  "broadcastChannels": [
+    "Nine Network",
+    "Nine Now",
+    "Kayo",
+    "Foxtel"
+  ],
+  "animateMatchClock": true,
+  "competition": {
+    "competitionId": 111,
+    "name": "Telstra Premiership",
+    "theme": {
+      "key": "nrl-premiership",
+      "logos": {
+        "badge-light.png": "202603300722",
+        "badge-light.svg": "202603300722",
+        "badge.png": "202603300722",
+        "badge.svg": "202603300722"
+      }
+    }
+  },
+  "groundConditions": "Good",
+  "hasExtraTime": true,
+  "hasOnFieldTracking": true,
+  "segmentCount": 2,
+  "segmentDuration": 2400,
+  "showTeamPositions": true,
+  "showPlayerPositions": true,
+  "stats": {
+    "groups": [
+      {
+        "title": "Current Season",
+        "stats": [
+          {
+            "title": "Wins this season",
+            "type": "PercentageAndFraction",
+            "homeValue": {
+              "value": 67.0,
+              "numerator": 4,
+              "denominator": 6,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 43.0,
+              "numerator": 3,
+              "denominator": 7,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Points Scored",
+            "type": "Number",
+            "homeValue": {
+              "value": 176.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 141.0,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Points Conceded",
+            "type": "Number",
+            "homeValue": {
+              "value": 113.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 204.0,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Completion Rate",
+            "type": "Percentage",
+            "homeValue": {
+              "value": 78.0,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 78.0,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Tackle Efficiency",
+            "type": "Percentage",
+            "homeValue": {
+              "value": 88.8,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 88.3,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Average Points Scored",
+            "type": "Number",
+            "homeValue": {
+              "value": 29.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 20.0,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Average Points Conceded",
+            "type": "Number",
+            "homeValue": {
+              "value": 18.0,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 29.0,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Average Play The Ball",
+            "type": "Range",
+            "units": "Seconds",
+            "homeValue": {
+              "value": 3.59,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 3.5,
+              "isLeader": true
+            },
+            "maxValue": 5.0
+          }
+        ]
+      },
+      {
+        "title": "Key Stats",
+        "stats": [
+          {
+            "title": "Wins at this venue",
+            "type": "PercentageAndFraction",
+            "homeValue": {
+              "value": 56.0,
+              "numerator": 57,
+              "denominator": 102,
+              "isLeader": true
+            },
+            "awayValue": {
+              "value": 67.0,
+              "numerator": 4,
+              "denominator": 6,
+              "isLeader": false
+            }
+          },
+          {
+            "title": "Wins overall",
+            "type": "PercentageAndFraction",
+            "homeValue": {
+              "value": 39.0,
+              "numerator": 257,
+              "denominator": 660,
+              "isLeader": false
+            },
+            "awayValue": {
+              "value": 48.0,
+              "numerator": 350,
+              "denominator": 730,
+              "isLeader": true
+            }
+          }
+        ]
+      }
+    ],
+    "history": {
+      "played": 46,
+      "draws": 0,
+      "homeWins": 20,
+      "awayWins": 26,
+      "recentMatches": [
+        {
+          "matchId": "20251112640",
+          "roundNumber": 26,
+          "roundName": "Round 26",
+          "startTime": "2025-08-30T05:00:00Z",
+          "homeTeam": {
+            "teamId": 500013,
+            "nickName": "Raiders",
+            "score": 24
+          },
+          "awayTeam": {
+            "teamId": 500023,
+            "nickName": "Wests Tigers",
+            "score": 10
+          },
+          "url": "https://www.nrl.com/draw/nrl-premiership/2025/round-26/raiders-v-wests-tigers/"
+        },
+        {
+          "matchId": "20251111610",
+          "roundNumber": 16,
+          "roundName": "Round 16",
+          "startTime": "2025-06-20T10:00:00Z",
+          "homeTeam": {
+            "teamId": 500023,
+            "nickName": "Wests Tigers",
+            "score": 12
+          },
+          "awayTeam": {
+            "teamId": 500013,
+            "nickName": "Raiders",
+            "score": 16
+          },
+          "url": "https://www.nrl.com/draw/nrl-premiership/2025/round-16/wests-tigers-v-raiders/"
+        }
+      ]
+    }
+  },
+  "videoProviders": [
+    {
+      "id": "NINE",
+      "name": "Nine Network",
+      "url": "https://www.9now.com.au/",
+      "logoSmallUrl": "https://www.nrl.com/globalassets/media-stream-providers/video-providers/nine-small.svg"
+    },
+    {
+      "id": "9NOW",
+      "name": "Nine Now",
+      "url": "https://www.9now.com.au/",
+      "logoSmallUrl": "https://www.nrl.com/globalassets/media-stream-providers/video-providers/nine-now.svg"
+    },
+    {
+      "id": "KAYO",
+      "name": "Kayo",
+      "url": "https://kayosports.app.link/xtDzpvGKaHb",
+      "logoSmallUrl": "https://www.nrl.com/globalassets/media-stream-providers/video-providers/kayo.svg"
+    },
+    {
+      "id": "FOX",
+      "name": "Foxtel",
+      "url": "https://www.foxtel.com.au/foxtel-go.html",
+      "logoSmallUrl": "https://www.nrl.com/globalassets/media-stream-providers/video-providers/foxtel.svg"
+    }
+  ],
+  "weather": "Fine"
+}

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from fantasy_coach.features import (
+    MatchRow,
+    PlayerRow,
+    TeamRow,
+    TeamStat,
+    extract_match_features,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def test_extract_2024_full_time_match() -> None:
+    raw = _load("match-2024-rd1-sea-eagles-v-rabbitohs.json")
+
+    row = extract_match_features(raw)
+
+    assert isinstance(row, MatchRow)
+    assert row.match_id == 20241110110
+    assert row.season == 2024
+    assert row.round == 1
+    assert row.start_time == datetime(2024, 3, 3, 2, 30, tzinfo=UTC)
+    assert row.match_state == "FullTime"
+    assert row.venue == "Allegiant Stadium"
+    assert row.weather is None  # absent from 2024 payloads
+
+    assert isinstance(row.home, TeamRow)
+    assert row.home.team_id == 500002
+    assert row.home.name == "Manly-Warringah Sea Eagles"
+    assert row.home.nick_name == "Sea Eagles"
+    assert row.home.score == 36
+    assert len(row.home.players) == 18
+
+    assert row.away.team_id == 500005
+    assert row.away.score == 24
+
+    fullback = row.home.players[0]
+    assert isinstance(fullback, PlayerRow)
+    assert fullback.player_id == 501505
+    assert fullback.jersey_number == 1
+    assert fullback.position == "Fullback"
+    assert fullback.first_name == "Tom"
+    assert fullback.last_name == "Trbojevic"
+
+    assert row.team_stats, "expected team-level stats for a completed match"
+    possession = next(s for s in row.team_stats if s.title == "Possession %")
+    assert isinstance(possession, TeamStat)
+    assert possession.home_value == 51.0
+    assert possession.away_value == 49.0
+
+
+def test_extract_2026_upcoming_match_has_optional_fields() -> None:
+    raw = _load("match-2026-rd8-wests-tigers-v-raiders.json")
+
+    row = extract_match_features(raw)
+
+    assert row.match_id == 20261110810
+    assert row.season == 2026
+    assert row.round == 8
+    assert row.match_state == "Upcoming"
+    assert row.weather == "Fine"  # 2026 payloads include weather
+
+    # Upcoming matches have no scores or rosters yet — extractor must accept this.
+    assert row.home.score is None
+    assert row.away.score is None
+    assert row.home.players == []
+    assert row.away.players == []
+
+
+def test_unknown_top_level_keys_are_logged_not_fatal(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    raw = _load("match-2024-rd1-sea-eagles-v-rabbitohs.json")
+    raw = {**raw, "newMysteryField": {"surprise": True}}
+
+    with caplog.at_level(logging.WARNING, logger="fantasy_coach.features"):
+        row = extract_match_features(raw)
+
+    assert isinstance(row, MatchRow)
+    assert any("newMysteryField" in r.message for r in caplog.records)
+
+
+def test_unknown_team_keys_are_logged_not_fatal(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    raw = _load("match-2024-rd1-sea-eagles-v-rabbitohs.json")
+    raw = {**raw, "homeTeam": {**raw["homeTeam"], "shinyNewKey": 1}}
+
+    with caplog.at_level(logging.WARNING, logger="fantasy_coach.features"):
+        extract_match_features(raw)
+
+    assert any("shinyNewKey" in r.message for r in caplog.records)

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from fantasy_coach import scraper
+
+
+@pytest.fixture(autouse=True)
+def reset_throttle() -> None:
+    scraper._throttle._last_request_at = 0.0
+
+
+@pytest.fixture(autouse=True)
+def sleep_calls(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    calls: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        calls.append(seconds)
+
+    monkeypatch.setattr(scraper.time, "sleep", fake_sleep)
+    return calls
+
+
+@pytest.fixture(autouse=True)
+def fast_throttle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FANTASY_COACH_SCRAPE_INTERVAL_SECONDS", "0")
+
+
+MATCH_URL = "https://www.nrl.com/draw/nrl-premiership/2026/round-8/wests-tigers-v-raiders/data"
+
+
+@respx.mock
+def test_fetch_match_returns_parsed_json() -> None:
+    payload = {"matchId": 111, "homeTeam": {"nickName": "Wests Tigers"}}
+    respx.get(MATCH_URL).mock(return_value=httpx.Response(200, json=payload))
+
+    result = scraper.fetch_match(2026, 8, "wests-tigers", "raiders")
+
+    assert result == payload
+
+
+@respx.mock
+def test_fetch_match_sends_expected_headers() -> None:
+    route = respx.get(MATCH_URL).mock(return_value=httpx.Response(200, json={}))
+
+    scraper.fetch_match(2026, 8, "wests-tigers", "raiders")
+
+    request = route.calls.last.request
+    assert "fantasy-coach" in request.headers["user-agent"]
+    assert request.headers["accept"] == "application/json"
+
+
+@respx.mock
+def test_fetch_match_returns_none_on_404() -> None:
+    respx.get(MATCH_URL).mock(return_value=httpx.Response(404))
+
+    result = scraper.fetch_match(2026, 8, "wests-tigers", "raiders")
+
+    assert result is None
+
+
+@respx.mock
+def test_fetch_match_retries_on_5xx_then_succeeds() -> None:
+    payload = {"matchId": 222}
+    route = respx.get(MATCH_URL).mock(
+        side_effect=[
+            httpx.Response(503),
+            httpx.Response(502),
+            httpx.Response(200, json=payload),
+        ]
+    )
+
+    result = scraper.fetch_match(2026, 8, "wests-tigers", "raiders")
+
+    assert result == payload
+    assert route.call_count == 3
+
+
+@respx.mock
+def test_fetch_match_raises_when_5xx_exhausts_retries() -> None:
+    route = respx.get(MATCH_URL).mock(return_value=httpx.Response(503))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        scraper.fetch_match(2026, 8, "wests-tigers", "raiders")
+
+    assert route.call_count == scraper.DEFAULT_MAX_RETRIES
+
+
+@respx.mock
+def test_fetch_match_retries_on_network_error() -> None:
+    payload = {"matchId": 333}
+    route = respx.get(MATCH_URL).mock(
+        side_effect=[httpx.ConnectError("boom"), httpx.Response(200, json=payload)]
+    )
+
+    result = scraper.fetch_match(2026, 8, "wests-tigers", "raiders")
+
+    assert result == payload
+    assert route.call_count == 2
+
+
+@respx.mock
+def test_fetch_match_network_error_exhausts() -> None:
+    route = respx.get(MATCH_URL).mock(side_effect=httpx.ConnectError("boom"))
+
+    with pytest.raises(httpx.ConnectError):
+        scraper.fetch_match(2026, 8, "wests-tigers", "raiders")
+
+    assert route.call_count == scraper.DEFAULT_MAX_RETRIES
+
+
+@respx.mock
+def test_fetch_match_respects_throttle_interval(
+    monkeypatch: pytest.MonkeyPatch,
+    sleep_calls: list[float],
+) -> None:
+    monkeypatch.setenv("FANTASY_COACH_SCRAPE_INTERVAL_SECONDS", "1.0")
+    fake_now = [100.0]
+
+    def fake_monotonic() -> float:
+        return fake_now[0]
+
+    monkeypatch.setattr(scraper.time, "monotonic", fake_monotonic)
+    respx.get(MATCH_URL).mock(return_value=httpx.Response(200, json={}))
+
+    # First call: no prior request, no throttle sleep.
+    scraper.fetch_match(2026, 8, "wests-tigers", "raiders")
+    assert sleep_calls == []
+
+    # Second call 0.3s later should sleep ~0.7s to reach the 1s interval.
+    fake_now[0] = 100.3
+    scraper.fetch_match(2026, 8, "wests-tigers", "raiders")
+    throttle_sleeps = [s for s in sleep_calls if s > 0]
+    assert len(throttle_sleeps) == 1
+    assert throttle_sleeps[0] == pytest.approx(0.7, abs=1e-6)
+
+
+@respx.mock
+def test_fetch_match_uses_provided_client() -> None:
+    respx.get(MATCH_URL).mock(return_value=httpx.Response(200, json={"ok": True}))
+    client = httpx.Client(base_url=scraper.BASE_URL, timeout=5.0)
+    try:
+        result = scraper.fetch_match(2026, 8, "wests-tigers", "raiders", client=client)
+    finally:
+        client.close()
+    assert result == {"ok": True}

--- a/tests/test_storage_sqlite.py
+++ b/tests/test_storage_sqlite.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from fantasy_coach.features import extract_match_features
+from fantasy_coach.storage import SQLiteRepository
+from fantasy_coach.storage.sqlite import SCHEMA_VERSION
+
+FIXTURES = Path(__file__).parent / "fixtures"
+FULLTIME_FIXTURE = "match-2024-rd1-sea-eagles-v-rabbitohs.json"
+UPCOMING_FIXTURE = "match-2026-rd8-wests-tigers-v-raiders.json"
+
+
+def _match(fixture: str):
+    return extract_match_features(json.loads((FIXTURES / fixture).read_text()))
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Iterator[SQLiteRepository]:
+    db = SQLiteRepository(tmp_path / "test.db")
+    yield db
+    db.close()
+
+
+def test_sqlite_repo_exposes_protocol_methods(repo: SQLiteRepository) -> None:
+    for name in ("upsert_match", "get_match", "list_matches"):
+        assert callable(getattr(repo, name))
+
+
+def test_round_trip_full_time_match(repo: SQLiteRepository) -> None:
+    row = _match(FULLTIME_FIXTURE)
+
+    repo.upsert_match(row)
+    loaded = repo.get_match(row.match_id)
+
+    assert loaded is not None
+    assert loaded == row
+
+
+def test_round_trip_upcoming_match(repo: SQLiteRepository) -> None:
+    row = _match(UPCOMING_FIXTURE)
+
+    repo.upsert_match(row)
+    loaded = repo.get_match(row.match_id)
+
+    assert loaded is not None
+    assert loaded == row
+    assert loaded.home.score is None
+    assert loaded.home.players == []
+
+
+def test_get_match_missing_returns_none(repo: SQLiteRepository) -> None:
+    assert repo.get_match(999_999) is None
+
+
+def test_upsert_is_idempotent(repo: SQLiteRepository) -> None:
+    row = _match(FULLTIME_FIXTURE)
+
+    repo.upsert_match(row)
+    repo.upsert_match(row)
+    repo.upsert_match(row)
+
+    # Should still only have one row — and child-row counts should match the source.
+    loaded = repo.get_match(row.match_id)
+    assert loaded == row
+
+
+def test_upsert_replaces_stale_children_when_match_transitions(
+    repo: SQLiteRepository,
+) -> None:
+    upcoming = _match(UPCOMING_FIXTURE)
+    # Pretend the same match later comes back with roster + stats
+    # (just reuse the 2024 row but patch its id/season/round to match).
+    fulltime = _match(FULLTIME_FIXTURE).model_copy(
+        update={
+            "match_id": upcoming.match_id,
+            "season": upcoming.season,
+            "round": upcoming.round,
+        }
+    )
+
+    repo.upsert_match(upcoming)
+    repo.upsert_match(fulltime)
+
+    loaded = repo.get_match(upcoming.match_id)
+    assert loaded == fulltime
+    assert len(loaded.home.players) == len(fulltime.home.players)
+    assert len(loaded.team_stats) == len(fulltime.team_stats)
+
+
+def test_list_matches_by_season(repo: SQLiteRepository) -> None:
+    a = _match(FULLTIME_FIXTURE)  # 2024
+    b = _match(UPCOMING_FIXTURE)  # 2026
+    repo.upsert_match(a)
+    repo.upsert_match(b)
+
+    assert [m.match_id for m in repo.list_matches(2024)] == [a.match_id]
+    assert [m.match_id for m in repo.list_matches(2026)] == [b.match_id]
+    assert repo.list_matches(2025) == []
+
+
+def test_list_matches_by_season_and_round(repo: SQLiteRepository) -> None:
+    a = _match(FULLTIME_FIXTURE)  # season=2024 round=1
+    repo.upsert_match(a)
+
+    assert repo.list_matches(2024, round=1) == [a]
+    assert repo.list_matches(2024, round=2) == []
+
+
+def test_schema_version_is_recorded(tmp_path: Path) -> None:
+    db_path = tmp_path / "v.db"
+    SQLiteRepository(db_path).close()
+
+    with sqlite3.connect(db_path) as conn:
+        (version,) = conn.execute("SELECT version FROM schema_version").fetchone()
+
+    assert version == SCHEMA_VERSION
+
+
+def test_mismatched_schema_version_rejects_open(tmp_path: Path) -> None:
+    db_path = tmp_path / "old.db"
+    SQLiteRepository(db_path).close()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE schema_version SET version = 999")
+        conn.commit()
+
+    with pytest.raises(RuntimeError, match="schema v999"):
+        SQLiteRepository(db_path)

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,827 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "fantasy-coach"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "respx" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = ">=0.115" },
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pydantic", specifier = ">=2.9" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pre-commit", specifier = ">=4.0" },
+    { name = "pytest", specifier = ">=8.3" },
+    { name = "pytest-cov", specifier = ">=5.0" },
+    { name = "respx", specifier = ">=0.21" },
+    { name = "ruff", specifier = ">=0.7" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/d9/e66315807e41e69e7f6a1b42a162dada2f249c5f06ad3f1a95f84ab336ef/fastapi-0.136.0.tar.gz", hash = "sha256:cf08e067cc66e106e102d9ba659463abfac245200752f8a5b7b1e813de4ff73e", size = 396607, upload-time = "2026-04-16T11:47:13.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/a3/0bd5f0cdb0bbc92650e8dc457e9250358411ee5d1b65e42b6632387daf81/fastapi-0.136.0-py3-none-any.whl", hash = "sha256:8793d44ec7378e2be07f8a013cf7f7aa47d6327d0dfe9804862688ec4541a6b4", size = 117556, upload-time = "2026-04-16T11:47:11.922Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
+    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/cb/5b47425556ecc1f3fe18ed2a0083188aa46e1dd812b06e406475b3a5d536/pydantic_core-2.46.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b11b59b3eee90a80a36701ddb4576d9ae31f93f05cb9e277ceaa09e6bf074a67", size = 2101946, upload-time = "2026-04-20T14:40:52.581Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4f/2fb62c2267cae99b815bbf4a7b9283812c88ca3153ef29f7707200f1d4e5/pydantic_core-2.46.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af8653713055ea18a3abc1537fe2ebc42f5b0bbb768d1eb79fd74eb47c0ac089", size = 1951612, upload-time = "2026-04-20T14:42:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/b7348fd30d6556d132cddd5bd79f37f96f2601fe0608afac4f5fb01ec0b3/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75a519dab6d63c514f3a81053e5266c549679e4aa88f6ec57f2b7b854aceb1b0", size = 1977027, upload-time = "2026-04-20T14:42:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/82/11/31d60ee2b45540d3fb0b29302a393dbc01cd771c473f5b5147bcd353e593/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6cd87cb1575b1ad05ba98894c5b5c96411ef678fa2f6ed2576607095b8d9789", size = 2063008, upload-time = "2026-04-20T14:44:17.952Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/db/3a9d1957181b59258f44a2300ab0f0be9d1e12d662a4f57bb31250455c52/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f80a55484b8d843c8ada81ebf70a682f3f00a3d40e378c06cf17ecb44d280d7d", size = 2233082, upload-time = "2026-04-20T14:40:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e1/3277c38792aeb5cfb18c2f0c5785a221d9ff4e149abbe1184d53d5f72273/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3861f1731b90c50a3266316b9044f5c9b405eecb8e299b0a7120596334e4fe9c", size = 2304615, upload-time = "2026-04-20T14:42:12.584Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d5/e3d9717c9eba10855325650afd2a9cba8e607321697f18953af9d562da2f/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395", size = 2094380, upload-time = "2026-04-20T14:43:05.522Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/20/abac35dedcbfd66c6f0b03e4e3564511771d6c9b7ede10a362d03e110d9b/pydantic_core-2.46.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:367508faa4973b992b271ba1494acaab36eb7e8739d1e47be5035fb1ea225396", size = 2135429, upload-time = "2026-04-20T14:41:55.549Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a5/41bfd1df69afad71b5cf0535055bccc73022715ad362edbc124bc1e021d7/pydantic_core-2.46.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ad3c826fe523e4becf4fe39baa44286cff85ef137c729a2c5e269afbfd0905d", size = 2174582, upload-time = "2026-04-20T14:41:45.96Z" },
+    { url = "https://files.pythonhosted.org/packages/79/65/38d86ea056b29b2b10734eb23329b7a7672ca604df4f2b6e9c02d4ee22fe/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ec638c5d194ef8af27db69f16c954a09797c0dc25015ad6123eb2c73a4d271ca", size = 2187533, upload-time = "2026-04-20T14:40:55.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a1129141678a2026badc539ad1dee0a71d06f54c2f06a4bd68c030ac781b/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:28ed528c45446062ee66edb1d33df5d88828ae167de76e773a3c7f64bd14e976", size = 2332985, upload-time = "2026-04-20T14:44:13.05Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/60/cb26f4077719f709e54819f4e8e1d43f4091f94e285eb6bd21e1190a7b7c/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aed19d0c783886d5bd86d80ae5030006b45e28464218747dcf83dabfdd092c7b", size = 2373670, upload-time = "2026-04-20T14:41:53.421Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/7e/c3f21882bdf1d8d086876f81b5e296206c69c6082551d776895de7801fa0/pydantic_core-2.46.3-cp312-cp312-win32.whl", hash = "sha256:06d5d8820cbbdb4147578c1fe7ffcd5b83f34508cb9f9ab76e807be7db6ff0a4", size = 1966722, upload-time = "2026-04-20T14:44:30.588Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/6b5e757b859013ebfbd7adba02f23b428f37c86dcbf78b5bb0b4ffd36e99/pydantic_core-2.46.3-cp312-cp312-win_amd64.whl", hash = "sha256:c3212fda0ee959c1dd04c60b601ec31097aaa893573a3a1abd0a47bcac2968c1", size = 2072970, upload-time = "2026-04-20T14:42:54.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f8/a989b21cc75e9a32d24192ef700eea606521221a89faa40c919ce884f2b1/pydantic_core-2.46.3-cp312-cp312-win_arm64.whl", hash = "sha256:f1f8338dd7a7f31761f1f1a3c47503a9a3b34eea3c8b01fa6ee96408affb5e72", size = 2035963, upload-time = "2026-04-20T14:44:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/9b5e8eb9821936d065439c3b0fb1490ffa64163bfe7e1595985a47896073/pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37", size = 2102109, upload-time = "2026-04-20T14:41:24.219Z" },
+    { url = "https://files.pythonhosted.org/packages/91/97/1c41d1f5a19f241d8069f1e249853bcce378cdb76eec8ab636d7bc426280/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f", size = 1951820, upload-time = "2026-04-20T14:42:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b4/d03a7ae14571bc2b6b3c7b122441154720619afe9a336fa3a95434df5e2f/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8", size = 1977785, upload-time = "2026-04-20T14:42:31.648Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0c/4086f808834b59e3c8f1aa26df8f4b6d998cdcf354a143d18ef41529d1fe/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad", size = 2062761, upload-time = "2026-04-20T14:40:37.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/a649be5a5064c2df0db06e0a512c2281134ed2fcc981f52a657936a7527c/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c", size = 2232989, upload-time = "2026-04-20T14:42:59.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/7756e75763e810b3a710f4724441d1ecc5883b94aacb07ca71c5fb5cfb69/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f", size = 2303975, upload-time = "2026-04-20T14:41:32.287Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/35/68a762e0c1e31f35fa0dac733cbd9f5b118042853698de9509c8e5bf128b/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35", size = 2095325, upload-time = "2026-04-20T14:42:47.685Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bf/1bf8c9a8e91836c926eae5e3e51dce009bf495a60ca56060689d3df3f340/pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687", size = 2133368, upload-time = "2026-04-20T14:41:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/50/87d818d6bab915984995157ceb2380f5aac4e563dddbed6b56f0ed057aba/pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3", size = 2173908, upload-time = "2026-04-20T14:42:52.044Z" },
+    { url = "https://files.pythonhosted.org/packages/91/88/a311fb306d0bd6185db41fa14ae888fb81d0baf648a761ae760d30819d33/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022", size = 2186422, upload-time = "2026-04-20T14:43:29.55Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/79/28fd0d81508525ab2054fef7c77a638c8b5b0afcbbaeee493cf7c3fef7e1/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23", size = 2332709, upload-time = "2026-04-20T14:42:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/21/795bf5fe5c0f379308b8ef19c50dedab2e7711dbc8d0c2acf08f1c7daa05/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7", size = 2372428, upload-time = "2026-04-20T14:41:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b3/ed14c659cbe7605e3ef063077680a64680aec81eb1a04763a05190d49b7f/pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13", size = 1965601, upload-time = "2026-04-20T14:41:42.128Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/adb70d9a762ddd002d723fbf1bd492244d37da41e3af7b74ad212609027e/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0", size = 2071517, upload-time = "2026-04-20T14:43:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/52/eb/66faefabebfe68bd7788339c9c9127231e680b11906368c67ce112fdb47f/pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec", size = 2035802, upload-time = "2026-04-20T14:43:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/db/a7bcb4940183fda36022cd18ba8dd12f2dff40740ec7b58ce7457befa416/pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b", size = 2097614, upload-time = "2026-04-20T14:44:38.374Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/e4066358a22e3e99519db370494c7528f5a2aa1367370e80e27e20283543/pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018", size = 1951896, upload-time = "2026-04-20T14:40:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/87/92/37cf4049d1636996e4b888c05a501f40a43ff218983a551d57f9d5e14f0d/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34", size = 1979314, upload-time = "2026-04-20T14:41:49.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/9ff4d676dfbdfb2d591cf43f3d90ded01e15b1404fd101180ed2d62a2fd3/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7", size = 2056133, upload-time = "2026-04-20T14:42:23.574Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f0/405b442a4d7ba855b06eec8b2bf9c617d43b8432d099dfdc7bf999293495/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2", size = 2228726, upload-time = "2026-04-20T14:44:22.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f8/65cd92dd5a0bd89ba277a98ecbfaf6fc36bbd3300973c7a4b826d6ab1391/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba", size = 2301214, upload-time = "2026-04-20T14:44:48.792Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/86/ef96a4c6e79e7a2d0410826a68fbc0eccc0fd44aa733be199d5fcac3bb87/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f", size = 2099927, upload-time = "2026-04-20T14:41:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/53/269caf30e0096e0a8a8f929d1982a27b3879872cca2d917d17c2f9fdf4fe/pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22", size = 2128789, upload-time = "2026-04-20T14:41:15.868Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b0/1a6d9b6a587e118482910c244a1c5acf4d192604174132efd12bf0ac486f/pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f", size = 2173815, upload-time = "2026-04-20T14:44:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/87/56/e7e00d4041a7e62b5a40815590114db3b535bf3ca0bf4dca9f16cef25246/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127", size = 2181608, upload-time = "2026-04-20T14:41:28.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/22/4bd23c3d41f7c185d60808a1de83c76cf5aeabf792f6c636a55c3b1ec7f9/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c", size = 2326968, upload-time = "2026-04-20T14:42:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ac/66cd45129e3915e5ade3b292cb3bc7fd537f58f8f8dbdaba6170f7cabb74/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1", size = 2369842, upload-time = "2026-04-20T14:41:35.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/dd4248abb84113615473aa20d5545b7c4cd73c8644003b5259686f93996c/pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505", size = 1959661, upload-time = "2026-04-20T14:41:00.042Z" },
+    { url = "https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e", size = 2071686, upload-time = "2026-04-20T14:43:16.471Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/db/1cf77e5247047dfee34bc01fa9bca134854f528c8eb053e144298893d370/pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df", size = 2026907, upload-time = "2026-04-20T14:43:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c0/b3df9f6a543276eadba0a48487b082ca1f201745329d97dbfa287034a230/pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf", size = 2095047, upload-time = "2026-04-20T14:42:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/57/886a938073b97556c168fd99e1a7305bb363cd30a6d2c76086bf0587b32a/pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee", size = 1934329, upload-time = "2026-04-20T14:43:49.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7c/b42eaa5c34b13b07ecb51da21761297a9b8eb43044c864a035999998f328/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a", size = 1974847, upload-time = "2026-04-20T14:42:10.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9b/92b42db6543e7de4f99ae977101a2967b63122d4b6cf7773812da2d7d5b5/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c", size = 2041742, upload-time = "2026-04-20T14:40:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/19/46fbe1efabb5aa2834b43b9454e70f9a83ad9c338c1291e48bdc4fecf167/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1", size = 2236235, upload-time = "2026-04-20T14:41:27.307Z" },
+    { url = "https://files.pythonhosted.org/packages/77/da/b3f95bc009ad60ec53120f5d16c6faa8cabdbe8a20d83849a1f2b8728148/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64", size = 2282633, upload-time = "2026-04-20T14:44:33.271Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/401336117722e28f32fb8220df676769d28ebdf08f2f4469646d404c43a3/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb", size = 2109679, upload-time = "2026-04-20T14:44:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/53/b289f9bc8756a32fe718c46f55afaeaf8d489ee18d1a1e7be1db73f42cc4/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6", size = 2108342, upload-time = "2026-04-20T14:42:50.144Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5b/8292fc7c1f9111f1b2b7c1b0dcf1179edcd014fc3ea4517499f50b829d71/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c", size = 2157208, upload-time = "2026-04-20T14:42:08.133Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9e/f80044e9ec07580f057a89fc131f78dda7a58751ddf52bbe05eaf31db50f/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47", size = 2167237, upload-time = "2026-04-20T14:42:25.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/6781a1b037f3b96be9227edbd1101f6d3946746056231bf4ac48cdff1a8d/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab", size = 2312540, upload-time = "2026-04-20T14:40:40.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/db/19c0839feeb728e7df03255581f198dfdf1c2aeb1e174a8420b63c5252e5/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba", size = 2369556, upload-time = "2026-04-20T14:41:09.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756, upload-time = "2026-04-20T14:41:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305, upload-time = "2026-04-20T14:43:18.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310, upload-time = "2026-04-20T14:41:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/34/42/f426db557e8ab2791bc7562052299944a118655496fbff99914e564c0a94/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b12dd51f1187c2eb489af8e20f880362db98e954b54ab792fa5d92e8bcc6b803", size = 2091877, upload-time = "2026-04-20T14:43:27.091Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428, upload-time = "2026-04-20T14:40:45.781Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550, upload-time = "2026-04-20T14:44:02.425Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657, upload-time = "2026-04-20T14:42:45.149Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
+    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/da/6eee1ff8b6cbeed47eeb5229749168e81eb4b7b999a1a15a7176e51410c9/uvicorn-0.44.0.tar.gz", hash = "sha256:6c942071b68f07e178264b9152f1f16dfac5da85880c4ce06366a96d70d4f31e", size = 86947, upload-time = "2026-04-06T09:23:22.826Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/23/a5bbd9600dd607411fa644c06ff4951bec3a4d82c4b852374024359c19c0/uvicorn-0.44.0-py3-none-any.whl", hash = "sha256:ce937c99a2cc70279556967274414c087888e8cec9f9c94644dfca11bd3ced89", size = 69425, upload-time = "2026-04-06T09:23:21.524Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]


### PR DESCRIPTION
## Summary
- Adds `fantasy_coach.storage.Repository` Protocol with `upsert_match` / `get_match` / `list_matches(season, round=None)`.
- Adds `SQLiteRepository` — stdlib `sqlite3`, no ORM. Schema in `schema.sql`, version tracked in `schema_version`, mismatched versions refuse to open the DB.
- Upserts are `DELETE + INSERT` inside a single transaction so child rows (`match_players`, `match_team_stats`) stay consistent across Upcoming → Live → FullTime transitions.
- Firestore implementation is out of scope (deployment milestone).

Closes #8.

> Stacked on #31 (feature extraction), which is stacked on #30 (scraper). Re-targets to `main` automatically as the parent PRs merge.

## Test plan
- [x] `uv run pytest` — 24 passed (10 new + existing 14)
- [x] `uv run ruff format .` + `uv run ruff check .` — clean
- [x] `uv build` — verified `schema.sql` is packaged into the wheel alongside the storage module

🤖 Generated with [Claude Code](https://claude.com/claude-code)