### PR TITLE
feat: SQLite repository for MatchRow (closes #8)

### DIFF
--- a/src/fantasy_coach/storage/__init__.py
+++ b/src/fantasy_coach/storage/__init__.py
@@ -1,0 +1,4 @@
+from fantasy_coach.storage.repository import Repository
+from fantasy_coach.storage.sqlite import SQLiteRepository
+
+__all__ = ["Repository", "SQLiteRepository"]

--- a/src/fantasy_coach/storage/repository.py
+++ b/src/fantasy_coach/storage/repository.py
@@ -1,0 +1,20 @@
+"""Storage abstraction for match rows.
+
+Local dev uses `SQLiteRepository`; production will add a Firestore impl.
+Kept as a `Protocol` so the swap is mechanical and callers depend on the
+interface rather than the concrete class.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from fantasy_coach.features import MatchRow
+
+
+class Repository(Protocol):
+    def upsert_match(self, row: MatchRow) -> None: ...
+
+    def get_match(self, match_id: int) -> MatchRow | None: ...
+
+    def list_matches(self, season: int, round: int | None = None) -> list[MatchRow]: ...

--- a/src/fantasy_coach/storage/schema.sql
+++ b/src/fantasy_coach/storage/schema.sql
@@ -1,0 +1,53 @@
+-- Schema version 1.
+--
+-- One row per match in `matches`, children (`match_players`, `match_team_stats`)
+-- keyed by match_id + side ('home' | 'away'). Upserts are done by deleting the
+-- existing match rows and re-inserting, so children stay consistent.
+
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS matches (
+    match_id      INTEGER PRIMARY KEY,
+    season        INTEGER NOT NULL,
+    round         INTEGER NOT NULL,
+    start_time    TEXT    NOT NULL,  -- ISO 8601 UTC
+    match_state   TEXT    NOT NULL,
+    venue         TEXT,
+    venue_city    TEXT,
+    weather       TEXT,
+    home_team_id  INTEGER NOT NULL,
+    home_name     TEXT    NOT NULL,
+    home_nick     TEXT    NOT NULL,
+    home_score    INTEGER,
+    away_team_id  INTEGER NOT NULL,
+    away_name     TEXT    NOT NULL,
+    away_nick     TEXT    NOT NULL,
+    away_score    INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_matches_season_round
+    ON matches(season, round);
+
+CREATE TABLE IF NOT EXISTS match_players (
+    match_id       INTEGER NOT NULL REFERENCES matches(match_id) ON DELETE CASCADE,
+    side           TEXT    NOT NULL CHECK (side IN ('home', 'away')),
+    player_id      INTEGER NOT NULL,
+    jersey_number  INTEGER,
+    position       TEXT,
+    first_name     TEXT,
+    last_name      TEXT,
+    PRIMARY KEY (match_id, side, player_id)
+);
+
+CREATE TABLE IF NOT EXISTS match_team_stats (
+    match_id    INTEGER NOT NULL REFERENCES matches(match_id) ON DELETE CASCADE,
+    ordinal     INTEGER NOT NULL,
+    title       TEXT    NOT NULL,
+    type        TEXT    NOT NULL,
+    units       TEXT,
+    home_value  REAL,
+    away_value  REAL,
+    PRIMARY KEY (match_id, ordinal)
+);

--- a/src/fantasy_coach/storage/sqlite.py
+++ b/src/fantasy_coach/storage/sqlite.py
@@ -1,0 +1,233 @@
+"""SQLite implementation of `Repository`.
+
+Uses `sqlite3` stdlib — no ORM needed at this size. Upserts are done as
+`DELETE + INSERT` inside a transaction so child rows (players, stats)
+stay consistent when a match transitions Upcoming → Live → FullTime.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from importlib import resources
+from pathlib import Path
+
+from fantasy_coach.features import MatchRow, PlayerRow, TeamRow, TeamStat
+
+SCHEMA_VERSION = 1
+
+
+class SQLiteRepository:
+    def __init__(self, path: str | Path) -> None:
+        self._path = str(path)
+        self._conn = sqlite3.connect(self._path)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._migrate()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> SQLiteRepository:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def upsert_match(self, row: MatchRow) -> None:
+        with self._conn:  # commit on success, rollback on exception
+            self._conn.execute("DELETE FROM matches WHERE match_id = ?", (row.match_id,))
+            self._conn.execute(
+                """
+                INSERT INTO matches (
+                    match_id, season, round, start_time, match_state,
+                    venue, venue_city, weather,
+                    home_team_id, home_name, home_nick, home_score,
+                    away_team_id, away_name, away_nick, away_score
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    row.match_id,
+                    row.season,
+                    row.round,
+                    row.start_time.isoformat(),
+                    row.match_state,
+                    row.venue,
+                    row.venue_city,
+                    row.weather,
+                    row.home.team_id,
+                    row.home.name,
+                    row.home.nick_name,
+                    row.home.score,
+                    row.away.team_id,
+                    row.away.name,
+                    row.away.nick_name,
+                    row.away.score,
+                ),
+            )
+            self._insert_players(row.match_id, "home", row.home.players)
+            self._insert_players(row.match_id, "away", row.away.players)
+            self._insert_stats(row.match_id, row.team_stats)
+
+    def get_match(self, match_id: int) -> MatchRow | None:
+        match = self._conn.execute(
+            "SELECT * FROM matches WHERE match_id = ?", (match_id,)
+        ).fetchone()
+        if match is None:
+            return None
+        return self._hydrate(match)
+
+    def list_matches(self, season: int, round: int | None = None) -> list[MatchRow]:
+        if round is None:
+            rows = self._conn.execute(
+                "SELECT * FROM matches WHERE season = ? ORDER BY start_time, match_id",
+                (season,),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM matches
+                WHERE season = ? AND round = ?
+                ORDER BY start_time, match_id
+                """,
+                (season, round),
+            ).fetchall()
+        return [self._hydrate(r) for r in rows]
+
+    # ----- internals -----
+
+    def _migrate(self) -> None:
+        schema_sql = (
+            resources.files("fantasy_coach.storage")
+            .joinpath("schema.sql")
+            .read_text(encoding="utf-8")
+        )
+        self._conn.executescript(schema_sql)
+        current = self._conn.execute("SELECT version FROM schema_version").fetchone()
+        if current is None:
+            with self._conn:
+                self._conn.execute(
+                    "INSERT INTO schema_version (version) VALUES (?)",
+                    (SCHEMA_VERSION,),
+                )
+        elif current["version"] != SCHEMA_VERSION:
+            raise RuntimeError(
+                f"SQLite DB at {self._path} is schema v{current['version']}, "
+                f"code expects v{SCHEMA_VERSION}. No migration path yet."
+            )
+
+    def _insert_players(self, match_id: int, side: str, players: list[PlayerRow]) -> None:
+        if not players:
+            return
+        self._conn.executemany(
+            """
+            INSERT INTO match_players
+                (match_id, side, player_id, jersey_number, position,
+                 first_name, last_name)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    match_id,
+                    side,
+                    p.player_id,
+                    p.jersey_number,
+                    p.position,
+                    p.first_name,
+                    p.last_name,
+                )
+                for p in players
+            ],
+        )
+
+    def _insert_stats(self, match_id: int, stats: list[TeamStat]) -> None:
+        if not stats:
+            return
+        self._conn.executemany(
+            """
+            INSERT INTO match_team_stats
+                (match_id, ordinal, title, type, units, home_value, away_value)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    match_id,
+                    ordinal,
+                    s.title,
+                    s.type,
+                    s.units,
+                    s.home_value,
+                    s.away_value,
+                )
+                for ordinal, s in enumerate(stats)
+            ],
+        )
+
+    def _hydrate(self, match: sqlite3.Row) -> MatchRow:
+        match_id = match["match_id"]
+        players = self._conn.execute(
+            """
+            SELECT side, player_id, jersey_number, position, first_name, last_name
+            FROM match_players
+            WHERE match_id = ?
+            ORDER BY side, jersey_number, player_id
+            """,
+            (match_id,),
+        ).fetchall()
+        stats = self._conn.execute(
+            """
+            SELECT title, type, units, home_value, away_value
+            FROM match_team_stats
+            WHERE match_id = ?
+            ORDER BY ordinal
+            """,
+            (match_id,),
+        ).fetchall()
+
+        home_players = [self._row_to_player(p) for p in players if p["side"] == "home"]
+        away_players = [self._row_to_player(p) for p in players if p["side"] == "away"]
+
+        return MatchRow(
+            match_id=match_id,
+            season=match["season"],
+            round=match["round"],
+            start_time=datetime.fromisoformat(match["start_time"]),
+            match_state=match["match_state"],
+            venue=match["venue"],
+            venue_city=match["venue_city"],
+            weather=match["weather"],
+            home=TeamRow(
+                team_id=match["home_team_id"],
+                name=match["home_name"],
+                nick_name=match["home_nick"],
+                score=match["home_score"],
+                players=home_players,
+            ),
+            away=TeamRow(
+                team_id=match["away_team_id"],
+                name=match["away_name"],
+                nick_name=match["away_nick"],
+                score=match["away_score"],
+                players=away_players,
+            ),
+            team_stats=[
+                TeamStat(
+                    title=s["title"],
+                    type=s["type"],
+                    units=s["units"],
+                    home_value=s["home_value"],
+                    away_value=s["away_value"],
+                )
+                for s in stats
+            ],
+        )
+
+    @staticmethod
+    def _row_to_player(p: sqlite3.Row) -> PlayerRow:
+        return PlayerRow(
+            player_id=p["player_id"],
+            jersey_number=p["jersey_number"],
+            position=p["position"],
+            first_name=p["first_name"],
+            last_name=p["last_name"],
+        )

--- a/tests/test_storage_sqlite.py
+++ b/tests/test_storage_sqlite.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from fantasy_coach.features import extract_match_features
+from fantasy_coach.storage import SQLiteRepository
+from fantasy_coach.storage.sqlite import SCHEMA_VERSION
+
+FIXTURES = Path(__file__).parent / "fixtures"
+FULLTIME_FIXTURE = "match-2024-rd1-sea-eagles-v-rabbitohs.json"
+UPCOMING_FIXTURE = "match-2026-rd8-wests-tigers-v-raiders.json"
+
+
+def _match(fixture: str):
+    return extract_match_features(json.loads((FIXTURES / fixture).read_text()))
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Iterator[SQLiteRepository]:
+    db = SQLiteRepository(tmp_path / "test.db")
+    yield db
+    db.close()
+
+
+def test_sqlite_repo_exposes_protocol_methods(repo: SQLiteRepository) -> None:
+    for name in ("upsert_match", "get_match", "list_matches"):
+        assert callable(getattr(repo, name))
+
+
+def test_round_trip_full_time_match(repo: SQLiteRepository) -> None:
+    row = _match(FULLTIME_FIXTURE)
+
+    repo.upsert_match(row)
+    loaded = repo.get_match(row.match_id)
+
+    assert loaded is not None
+    assert loaded == row
+
+
+def test_round_trip_upcoming_match(repo: SQLiteRepository) -> None:
+    row = _match(UPCOMING_FIXTURE)
+
+    repo.upsert_match(row)
+    loaded = repo.get_match(row.match_id)
+
+    assert loaded is not None
+    assert loaded == row
+    assert loaded.home.score is None
+    assert loaded.home.players == []
+
+
+def test_get_match_missing_returns_none(repo: SQLiteRepository) -> None:
+    assert repo.get_match(999_999) is None
+
+
+def test_upsert_is_idempotent(repo: SQLiteRepository) -> None:
+    row = _match(FULLTIME_FIXTURE)
+
+    repo.upsert_match(row)
+    repo.upsert_match(row)
+    repo.upsert_match(row)
+
+    # Should still only have one row — and child-row counts should match the source.
+    loaded = repo.get_match(row.match_id)
+    assert loaded == row
+
+
+def test_upsert_replaces_stale_children_when_match_transitions(
+    repo: SQLiteRepository,
+) -> None:
+    upcoming = _match(UPCOMING_FIXTURE)
+    # Pretend the same match later comes back with roster + stats
+    # (just reuse the 2024 row but patch its id/season/round to match).
+    fulltime = _match(FULLTIME_FIXTURE).model_copy(
+        update={
+            "match_id": upcoming.match_id,
+            "season": upcoming.season,
+            "round": upcoming.round,
+        }
+    )
+
+    repo.upsert_match(upcoming)
+    repo.upsert_match(fulltime)
+
+    loaded = repo.get_match(upcoming.match_id)
+    assert loaded == fulltime
+    assert len(loaded.home.players) == len(fulltime.home.players)
+    assert len(loaded.team_stats) == len(fulltime.team_stats)
+
+
+def test_list_matches_by_season(repo: SQLiteRepository) -> None:
+    a = _match(FULLTIME_FIXTURE)  # 2024
+    b = _match(UPCOMING_FIXTURE)  # 2026
+    repo.upsert_match(a)
+    repo.upsert_match(b)
+
+    assert [m.match_id for m in repo.list_matches(2024)] == [a.match_id]
+    assert [m.match_id for m in repo.list_matches(2026)] == [b.match_id]
+    assert repo.list_matches(2025) == []
+
+
+def test_list_matches_by_season_and_round(repo: SQLiteRepository) -> None:
+    a = _match(FULLTIME_FIXTURE)  # season=2024 round=1
+    repo.upsert_match(a)
+
+    assert repo.list_matches(2024, round=1) == [a]
+    assert repo.list_matches(2024, round=2) == []
+
+
+def test_schema_version_is_recorded(tmp_path: Path) -> None:
+    db_path = tmp_path / "v.db"
+    SQLiteRepository(db_path).close()
+
+    with sqlite3.connect(db_path) as conn:
+        (version,) = conn.execute("SELECT version FROM schema_version").fetchone()
+
+    assert version == SCHEMA_VERSION
+
+
+def test_mismatched_schema_version_rejects_open(tmp_path: Path) -> None:
+    db_path = tmp_path / "old.db"
+    SQLiteRepository(db_path).close()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE schema_version SET version = 999")
+        conn.commit()
+
+    with pytest.raises(RuntimeError, match="schema v999"):
+        SQLiteRepository(db_path)


### PR DESCRIPTION
Replaces #32 (auto-closed when its base branch was deleted on merge of #38).

## Summary
- `fantasy_coach.storage.Repository` Protocol with `upsert_match` / `get_match` / `list_matches`.
- `SQLiteRepository` — stdlib `sqlite3`, schema in `schema.sql`, version tracked in `schema_version`. Mismatched versions refuse to open.
- Upserts are `DELETE + INSERT` inside a single transaction so children stay consistent across Upcoming → Live → FullTime transitions.

Closes #8. Original PR: #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)