### PR TITLE
feat: backfill CLI for historical seasons (closes #9)

### DIFF
--- a/src/fantasy_coach/__main__.py
+++ b/src/fantasy_coach/__main__.py
@@ -1,0 +1,82 @@
+"""`python -m fantasy_coach` entry point."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from fantasy_coach.backfill import (
+    BackfillState,
+    RetryLog,
+    backfill_season,
+)
+from fantasy_coach.storage import SQLiteRepository
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m fantasy_coach")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    bf = sub.add_parser("backfill", help="Backfill a season's matches into a SQLite DB.")
+    bf.add_argument("--season", type=int, required=True)
+    bf.add_argument("--db", type=Path, default=Path("data/nrl.db"))
+    bf.add_argument(
+        "--state",
+        type=Path,
+        default=None,
+        help="Sidecar JSON tracking processed match URLs. Defaults to <db>.backfill.json",
+    )
+    bf.add_argument(
+        "--retry-file",
+        type=Path,
+        default=None,
+        help="Append failed matches here for a second pass. Defaults to <db>.retry.tsv",
+    )
+    bf.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=args.log_level,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    if args.command == "backfill":
+        return _run_backfill(args)
+    parser.error(f"unknown command {args.command!r}")
+    return 2  # unreachable
+
+
+def _run_backfill(args: argparse.Namespace) -> int:
+    db_path: Path = args.db
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path: Path = args.state or db_path.with_suffix(db_path.suffix + ".backfill.json")
+    retry_path: Path = args.retry_file or db_path.with_suffix(db_path.suffix + ".retry.tsv")
+
+    repo = SQLiteRepository(db_path)
+    state = BackfillState.load(state_path)
+    retry_log = RetryLog(retry_path)
+    try:
+        summaries = backfill_season(args.season, repo, state, retry_log)
+    finally:
+        repo.close()
+
+    totals = {
+        "fetched": sum(s.fetched for s in summaries),
+        "skipped": sum(s.skipped for s in summaries),
+        "failed": sum(s.failed for s in summaries),
+    }
+    print(
+        f"Season {args.season}: rounds={len(summaries)} "
+        f"fetched={totals['fetched']} skipped={totals['skipped']} failed={totals['failed']}"
+    )
+    return 0 if totals["failed"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/fantasy_coach/backfill.py
+++ b/src/fantasy_coach/backfill.py
@@ -1,0 +1,141 @@
+"""One-shot historical backfill orchestrator.
+
+Walks every round of a season via the fixtures-list endpoint, fetches each
+match's per-match payload, extracts a `MatchRow`, and upserts it into a
+`Repository`. Idempotent and resumable: a JSON sidecar tracks processed
+match URLs, and re-runs skip anything already recorded there.
+
+CLI: `python -m fantasy_coach backfill --season 2024 --db data/nrl.db`
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from fantasy_coach.features import extract_match_features
+from fantasy_coach.scraper import fetch_match_from_url, fetch_round
+from fantasy_coach.storage.repository import Repository
+
+logger = logging.getLogger(__name__)
+
+# Generous upper bound: 27 regular rounds + 4 finals weeks. We stop early
+# the first time the fixtures endpoint returns no matches.
+MAX_ROUNDS = 31
+
+
+@dataclass
+class RoundSummary:
+    season: int
+    round: int
+    fetched: int = 0
+    skipped: int = 0
+    failed: int = 0
+
+
+@dataclass
+class BackfillState:
+    """Sidecar record of which match URLs have been successfully processed."""
+
+    path: Path
+    processed: set[str] = field(default_factory=set)
+
+    @classmethod
+    def load(cls, path: Path) -> BackfillState:
+        if path.exists():
+            data = json.loads(path.read_text())
+            return cls(path=path, processed=set(data.get("processed", [])))
+        return cls(path=path)
+
+    def mark(self, url: str) -> None:
+        self.processed.add(url)
+        self.flush()
+
+    def flush(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps({"processed": sorted(self.processed)}, indent=2))
+
+
+class RetryLog:
+    """Append-only log of (url, reason) pairs for matches that failed to ingest."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def record(self, url: str, reason: str) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as fp:
+            fp.write(f"{url}\t{reason}\n")
+
+
+def backfill_season(
+    season: int,
+    repo: Repository,
+    state: BackfillState,
+    retry_log: RetryLog,
+    *,
+    fetch_round_fn: Callable[..., dict[str, Any] | None] = fetch_round,
+    fetch_match_fn: Callable[..., dict[str, Any] | None] = fetch_match_from_url,
+    max_rounds: int = MAX_ROUNDS,
+) -> list[RoundSummary]:
+    """Run a full-season backfill. Returns a per-round summary list.
+
+    `fetch_round_fn` and `fetch_match_fn` are injectable so tests can drive the
+    orchestrator without hitting the network.
+    """
+
+    summaries: list[RoundSummary] = []
+    for round_ in range(1, max_rounds + 1):
+        round_payload = fetch_round_fn(season, round_)
+        fixtures = (round_payload or {}).get("fixtures") or []
+        if not fixtures:
+            # Past the end of the season — finals already played or round
+            # doesn't exist for this year.
+            logger.info("Season %d round %d: no fixtures, stopping", season, round_)
+            break
+
+        summary = RoundSummary(season=season, round=round_)
+        for fixture in fixtures:
+            url = fixture.get("matchCentreUrl")
+            if not url:
+                summary.failed += 1
+                retry_log.record("<unknown>", "missing matchCentreUrl in fixture")
+                continue
+            if url in state.processed:
+                summary.skipped += 1
+                continue
+            try:
+                raw = fetch_match_fn(url)
+            except Exception as exc:  # network / 5xx exhausted
+                summary.failed += 1
+                retry_log.record(url, f"fetch failed: {exc}")
+                continue
+            if raw is None:
+                summary.failed += 1
+                retry_log.record(url, "404 from /data")
+                continue
+            try:
+                row = extract_match_features(raw)
+                repo.upsert_match(row)
+            except Exception as exc:
+                summary.failed += 1
+                retry_log.record(url, f"extract/upsert failed: {exc}")
+                continue
+            state.mark(url)
+            summary.fetched += 1
+
+        logger.info(
+            "Season %d round %d: fetched=%d skipped=%d failed=%d",
+            season,
+            round_,
+            summary.fetched,
+            summary.skipped,
+            summary.failed,
+        )
+        summaries.append(summary)
+
+    return summaries

--- a/src/fantasy_coach/scraper.py
+++ b/src/fantasy_coach/scraper.py
@@ -1,9 +1,9 @@
-"""NRL match /data scraper.
+"""NRL endpoint scrapers.
 
-Thin wrapper around the per-match endpoint documented in `docs/nrl-endpoints.md`.
-Throttled to be polite and retrying on transient failures; 404s return None
-because a wrong slug order (away-v-home vs home-v-away) is a common caller bug,
-not a server error worth crashing on.
+Thin wrappers around the two `nrl.com` JSON endpoints documented in
+`docs/nrl-endpoints.md`. Throttled to be polite and retrying on transient
+failures; 404s return None because a wrong slug order (away-v-home vs
+home-v-away) is a common caller bug, not a server error worth crashing on.
 """
 
 from __future__ import annotations
@@ -14,6 +14,7 @@ import random
 import threading
 import time
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -73,16 +74,72 @@ def fetch_match(
     client: httpx.Client | None = None,
     max_retries: int = DEFAULT_MAX_RETRIES,
 ) -> dict[str, Any] | None:
-    """Fetch a single match's per-match JSON.
+    """Fetch a single regular-season match's per-match JSON.
 
-    Returns the parsed JSON body on 200, or None on 404. Raises `httpx.HTTPError`
-    after exhausting retries on 5xx / network errors.
+    For finals matches use `fetch_match_from_url(matchCentreUrl)` — finals
+    slugs (`finals-week-{n}/game-{m}`) don't fit this signature.
 
-    Slug order must be `home-v-away` (source from the fixtures endpoint —
-    wrong order returns 404 and is treated as a missing match, not an error).
+    Returns the parsed JSON body on 200, or None on 404. Raises
+    `httpx.HTTPError` after exhausting retries on 5xx / network errors.
     """
 
     path = _match_path(year, round_, home_slug, away_slug)
+    return _fetch_json(path, client=client, max_retries=max_retries)
+
+
+def fetch_match_from_url(
+    match_centre_url: str,
+    *,
+    client: httpx.Client | None = None,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> dict[str, Any] | None:
+    """Fetch a per-match payload using a `matchCentreUrl` from the fixtures list.
+
+    Accepts either a relative path (`/draw/.../`) or a full URL. Appends `data`
+    to the trailing slash. Use this for finals weeks where slugs are
+    `finals-week-{n}/game-{m}` rather than home-v-away.
+    """
+
+    path = _normalize_match_path(match_centre_url)
+    return _fetch_json(path, client=client, max_retries=max_retries)
+
+
+def fetch_round(
+    year: int,
+    round_: int,
+    *,
+    competition: int = 111,
+    client: httpx.Client | None = None,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> dict[str, Any] | None:
+    """Fetch the fixtures-list payload for a given round.
+
+    Returns the parsed JSON (with `fixtures`, `byes`, filter metadata) on 200,
+    or None on 404 (e.g. a round that doesn't exist for that season).
+    """
+
+    path = "/draw/data"
+    params = {"competition": competition, "round": round_, "season": year}
+    return _fetch_json(path, params=params, client=client, max_retries=max_retries)
+
+
+def _normalize_match_path(match_centre_url: str) -> str:
+    parsed = urlparse(match_centre_url)
+    path = parsed.path or match_centre_url
+    if not path.startswith("/"):
+        path = "/" + path
+    if not path.endswith("/"):
+        path += "/"
+    return path + "data"
+
+
+def _fetch_json(
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    client: httpx.Client | None = None,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> dict[str, Any] | None:
     headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
     interval = _min_interval_seconds()
 
@@ -92,7 +149,7 @@ def fetch_match(
         for attempt in range(1, max_retries + 1):
             _throttle.wait(interval)
             try:
-                response = http.get(path, headers=headers)
+                response = http.get(path, params=params, headers=headers)
             except httpx.HTTPError as exc:
                 if attempt == max_retries:
                     logger.error(
@@ -115,10 +172,7 @@ def fetch_match(
                 continue
 
             if response.status_code == 404:
-                logger.warning(
-                    "404 for %s — check slug order (expected home-v-away)",
-                    path,
-                )
+                logger.warning("404 for %s", path)
                 return None
             if 500 <= response.status_code < 600:
                 if attempt == max_retries:
@@ -138,9 +192,7 @@ def fetch_match(
             response.raise_for_status()
             return response.json()
 
-        # Loop fell through without returning — should be unreachable because
-        # the last attempt either returns, raises, or is a 404 short-circuit.
-        raise RuntimeError("fetch_match retry loop exited without resolution")
+        raise RuntimeError(f"fetch retry loop exited without resolution for {path}")
     finally:
         if owns_client:
             http.close()

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from fantasy_coach.backfill import (
+    BackfillState,
+    RetryLog,
+    backfill_season,
+)
+from fantasy_coach.storage import SQLiteRepository
+
+FIXTURES = Path(__file__).parent / "fixtures"
+FULLTIME = json.loads((FIXTURES / "match-2024-rd1-sea-eagles-v-rabbitohs.json").read_text())
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Iterator[SQLiteRepository]:
+    db = SQLiteRepository(tmp_path / "test.db")
+    yield db
+    db.close()
+
+
+def _round_payload(*urls: str) -> dict:
+    return {"fixtures": [{"matchCentreUrl": u} for u in urls]}
+
+
+def _make_round_fn(payloads: dict[int, dict | None]):
+    def f(season: int, round_: int):
+        return payloads.get(round_)
+
+    return f
+
+
+def _make_match_fn(by_url: dict[str, dict | None | Exception]):
+    def f(url: str):
+        v = by_url[url]
+        if isinstance(v, Exception):
+            raise v
+        return v
+
+    return f
+
+
+def test_backfill_ingests_all_fixtures_in_a_round(repo: SQLiteRepository, tmp_path: Path) -> None:
+    state = BackfillState.load(tmp_path / "state.json")
+    retry = RetryLog(tmp_path / "retry.tsv")
+
+    summaries = backfill_season(
+        2024,
+        repo,
+        state,
+        retry,
+        fetch_round_fn=_make_round_fn(
+            {1: _round_payload("/draw/nrl-premiership/2024/round-1/sea-eagles-v-rabbitohs/")}
+        ),
+        fetch_match_fn=_make_match_fn(
+            {"/draw/nrl-premiership/2024/round-1/sea-eagles-v-rabbitohs/": FULLTIME}
+        ),
+        max_rounds=2,
+    )
+
+    assert len(summaries) == 1
+    assert summaries[0].fetched == 1
+    assert summaries[0].failed == 0
+    assert repo.get_match(FULLTIME["matchId"]) is not None
+
+
+def test_backfill_stops_when_round_has_no_fixtures(repo: SQLiteRepository, tmp_path: Path) -> None:
+    state = BackfillState.load(tmp_path / "state.json")
+    retry = RetryLog(tmp_path / "retry.tsv")
+
+    summaries = backfill_season(
+        2024,
+        repo,
+        state,
+        retry,
+        fetch_round_fn=_make_round_fn(
+            {
+                1: _round_payload("/draw/nrl-premiership/2024/round-1/a-v-b/"),
+                2: {"fixtures": []},
+                3: _round_payload("/should/not/be/fetched/"),
+            }
+        ),
+        fetch_match_fn=_make_match_fn({"/draw/nrl-premiership/2024/round-1/a-v-b/": FULLTIME}),
+    )
+
+    assert [s.round for s in summaries] == [1]
+
+
+def test_backfill_skips_already_processed_urls(repo: SQLiteRepository, tmp_path: Path) -> None:
+    state = BackfillState.load(tmp_path / "state.json")
+    retry = RetryLog(tmp_path / "retry.tsv")
+    url = "/draw/nrl-premiership/2024/round-1/sea-eagles-v-rabbitohs/"
+    state.mark(url)
+
+    fetched_urls: list[str] = []
+
+    def match_fn(u: str):
+        fetched_urls.append(u)
+        return FULLTIME
+
+    summaries = backfill_season(
+        2024,
+        repo,
+        state,
+        retry,
+        fetch_round_fn=_make_round_fn({1: _round_payload(url), 2: {"fixtures": []}}),
+        fetch_match_fn=match_fn,
+    )
+
+    assert summaries[0].skipped == 1
+    assert summaries[0].fetched == 0
+    assert fetched_urls == []  # never re-fetched
+
+
+def test_backfill_records_failures_to_retry_log(repo: SQLiteRepository, tmp_path: Path) -> None:
+    state = BackfillState.load(tmp_path / "state.json")
+    retry_path = tmp_path / "retry.tsv"
+    retry = RetryLog(retry_path)
+    boom = "/draw/nrl-premiership/2024/round-1/team-a-v-team-b/"
+
+    summaries = backfill_season(
+        2024,
+        repo,
+        state,
+        retry,
+        fetch_round_fn=_make_round_fn({1: _round_payload(boom), 2: {"fixtures": []}}),
+        fetch_match_fn=_make_match_fn({boom: RuntimeError("kaboom")}),
+    )
+
+    assert summaries[0].failed == 1
+    assert boom not in state.processed
+    log_lines = retry_path.read_text().splitlines()
+    assert any(boom in line and "kaboom" in line for line in log_lines)
+
+
+def test_backfill_treats_404_as_failure_and_continues(
+    repo: SQLiteRepository, tmp_path: Path
+) -> None:
+    state = BackfillState.load(tmp_path / "state.json")
+    retry = RetryLog(tmp_path / "retry.tsv")
+    missing = "/draw/nrl-premiership/2024/round-1/missing-v-match/"
+    good = "/draw/nrl-premiership/2024/round-1/sea-eagles-v-rabbitohs/"
+
+    summaries = backfill_season(
+        2024,
+        repo,
+        state,
+        retry,
+        fetch_round_fn=_make_round_fn({1: _round_payload(missing, good), 2: {"fixtures": []}}),
+        fetch_match_fn=_make_match_fn({missing: None, good: FULLTIME}),
+    )
+
+    assert summaries[0].fetched == 1
+    assert summaries[0].failed == 1
+
+
+def test_backfill_handles_finals_round_slugs(repo: SQLiteRepository, tmp_path: Path) -> None:
+    state = BackfillState.load(tmp_path / "state.json")
+    retry = RetryLog(tmp_path / "retry.tsv")
+    finals_url = "/draw/nrl-premiership/2024/finals-week-1/game-1/"
+
+    summaries = backfill_season(
+        2024,
+        repo,
+        state,
+        retry,
+        fetch_round_fn=_make_round_fn(
+            {
+                1: {"fixtures": []},  # immediate stop in this scenario
+            }
+        ),
+        fetch_match_fn=_make_match_fn({finals_url: FULLTIME}),
+    )
+
+    # Round 1 empty → backfill stops without trying finals (finals would be
+    # later rounds in real data — this test asserts the empty-round halt).
+    assert summaries == []
+
+
+def test_backfill_state_persists_across_runs(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.json"
+    state = BackfillState.load(state_path)
+    state.mark("/draw/foo/")
+    state.mark("/draw/bar/")
+
+    reloaded = BackfillState.load(state_path)
+    assert reloaded.processed == {"/draw/foo/", "/draw/bar/"}
+
+
+def test_state_flush_creates_parent_dirs(tmp_path: Path) -> None:
+    nested = tmp_path / "deep" / "deeper" / "state.json"
+    state = BackfillState.load(nested)
+    state.mark("/draw/x/")
+    assert nested.exists()

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -146,3 +146,43 @@ def test_fetch_match_uses_provided_client() -> None:
     finally:
         client.close()
     assert result == {"ok": True}
+
+
+@respx.mock
+def test_fetch_round_returns_payload() -> None:
+    payload = {"fixtures": [{"matchCentreUrl": "/draw/x/"}], "byes": []}
+    respx.get(
+        "https://www.nrl.com/draw/data",
+        params={"competition": "111", "round": "8", "season": "2026"},
+    ).mock(return_value=httpx.Response(200, json=payload))
+
+    result = scraper.fetch_round(2026, 8)
+
+    assert result == payload
+
+
+@respx.mock
+def test_fetch_round_returns_none_on_404() -> None:
+    respx.get("https://www.nrl.com/draw/data").mock(return_value=httpx.Response(404))
+
+    assert scraper.fetch_round(2026, 99) is None
+
+
+@respx.mock
+def test_fetch_match_from_url_appends_data_segment() -> None:
+    finals_url = "/draw/nrl-premiership/2024/finals-week-1/game-1/"
+    respx.get(f"https://www.nrl.com{finals_url}data").mock(
+        return_value=httpx.Response(200, json={"matchId": 1})
+    )
+
+    result = scraper.fetch_match_from_url(finals_url)
+
+    assert result == {"matchId": 1}
+
+
+@respx.mock
+def test_fetch_match_from_url_accepts_full_url() -> None:
+    full = "https://www.nrl.com/draw/nrl-premiership/2024/round-1/sea-eagles-v-rabbitohs/"
+    respx.get(full + "data").mock(return_value=httpx.Response(200, json={"ok": True}))
+
+    assert scraper.fetch_match_from_url(full) == {"ok": True}


### PR DESCRIPTION
Replaces #33 (auto-closed when its base branch was deleted on merge of #39).

## Summary
- `python -m fantasy_coach backfill --season YEAR [--db ...] [--state ...] [--retry-file ...]`.
- Walks the fixtures-list endpoint round-by-round, fetches each match's `/data`, extracts `MatchRow`, upserts into `SQLiteRepository`.
- Idempotent / resumable via JSON sidecar tracking processed `matchCentreUrl`s.
- Failures stream to a TSV retry log.
- Scraper grows `fetch_round` and `fetch_match_from_url` (handles finals slugs).

Closes #9. Original PR: #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)