### PR TITLE
feat: Elo baseline rating model (closes #10)

### DIFF
--- a/src/fantasy_coach/models/elo.py
+++ b/src/fantasy_coach/models/elo.py
@@ -1,0 +1,96 @@
+"""Elo rating system — baseline pairwise predictor.
+
+Standard Elo with two NRL-flavoured knobs:
+- `home_advantage`: points added to the home team's effective rating before the
+  expected-score calc. ~55 points ≈ the historical NRL home edge (~62% home
+  win rate, equivalent to ~3–4 spread points).
+- `season_regression`: at each season boundary the sweep can pull every team's
+  rating fractionally back to the league mean (1500). 0.0 = no regression,
+  1.0 = full reset. ~0.25 is a common choice for sports with roster turnover.
+
+Draws are scored as 0.5/0.5. Margin of victory is *not* used here — that's a
+follow-up if Elo proves competitive enough to be worth tuning.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+DEFAULT_INITIAL_RATING = 1500.0
+DEFAULT_K = 20.0
+DEFAULT_HOME_ADVANTAGE = 55.0
+DEFAULT_SEASON_REGRESSION = 0.25
+
+
+@dataclass
+class Elo:
+    """In-memory Elo rating book.
+
+    Teams are inserted lazily at first appearance, all starting at
+    `initial_rating`. Mutating; not thread-safe.
+    """
+
+    k: float = DEFAULT_K
+    home_advantage: float = DEFAULT_HOME_ADVANTAGE
+    initial_rating: float = DEFAULT_INITIAL_RATING
+    season_regression: float = DEFAULT_SEASON_REGRESSION
+
+    def __post_init__(self) -> None:
+        self._ratings: dict[int, float] = {}
+
+    # ----- read-only -----
+
+    def rating(self, team_id: int) -> float:
+        return self._ratings.get(team_id, self.initial_rating)
+
+    def ratings(self) -> dict[int, float]:
+        """A defensive copy of the rating book."""
+        return dict(self._ratings)
+
+    def predict(self, home_id: int, away_id: int) -> float:
+        """Return the home team's win probability (treats draws as half-wins)."""
+        home_eff = self.rating(home_id) + self.home_advantage
+        away_eff = self.rating(away_id)
+        return _expected_score(home_eff, away_eff)
+
+    # ----- mutations -----
+
+    def update(
+        self, home_id: int, away_id: int, home_score: int, away_score: int
+    ) -> tuple[float, float]:
+        """Apply one match. Returns the (home, away) rating deltas."""
+        expected_home = self.predict(home_id, away_id)
+        actual_home = _result(home_score, away_score)
+        delta = self.k * (actual_home - expected_home)
+
+        new_home = self.rating(home_id) + delta
+        new_away = self.rating(away_id) - delta
+        self._ratings[home_id] = new_home
+        self._ratings[away_id] = new_away
+        return delta, -delta
+
+    def regress_to_mean(self, weight: float | None = None) -> None:
+        """Pull every rating fractionally toward `initial_rating`.
+
+        Call between seasons. `weight=0` no-ops, `weight=1` resets the book.
+        Defaults to `self.season_regression`.
+        """
+        w = self.season_regression if weight is None else weight
+        if w <= 0:
+            return
+        if w > 1:
+            raise ValueError(f"regression weight must be in [0, 1], got {w}")
+        for team_id, rating in self._ratings.items():
+            self._ratings[team_id] = rating + w * (self.initial_rating - rating)
+
+
+def _expected_score(rating_a: float, rating_b: float) -> float:
+    return 1.0 / (1.0 + 10.0 ** ((rating_b - rating_a) / 400.0))
+
+
+def _result(home_score: int, away_score: int) -> float:
+    if home_score > away_score:
+        return 1.0
+    if home_score < away_score:
+        return 0.0
+    return 0.5

--- a/src/fantasy_coach/models/rating_sweep.py
+++ b/src/fantasy_coach/models/rating_sweep.py
@@ -1,0 +1,71 @@
+"""Walk a Repository chronologically and apply Elo updates.
+
+Rebuilds the rating book from scratch — call after each backfill or to test a
+new K / home-advantage / regression combo. Cheap (one rating update per
+match), so re-running is preferred over incremental persistence.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+
+from fantasy_coach.features import MatchRow
+from fantasy_coach.models.elo import Elo
+from fantasy_coach.storage.repository import Repository
+
+logger = logging.getLogger(__name__)
+
+# Final state we treat as a result-bearing match. Anything else (Upcoming,
+# Pre, Live mid-game) is skipped — its scores are missing or provisional.
+RATEABLE_STATES = frozenset({"FullTime", "FullTimeED"})
+
+
+def sweep_repository(
+    repo: Repository,
+    seasons: Iterable[int],
+    *,
+    elo: Elo | None = None,
+) -> Elo:
+    """Apply Elo updates for every completed match across `seasons`, in order.
+
+    Between seasons the rating book is regressed toward the mean per
+    `elo.season_regression`. Returns the (mutated) `Elo` instance.
+    """
+
+    elo = elo or Elo()
+    seasons = sorted(seasons)
+    for index, season in enumerate(seasons):
+        if index > 0:
+            elo.regress_to_mean()
+        applied = _apply_season(repo, season, elo)
+        logger.info("Season %d: applied %d rated matches", season, applied)
+    return elo
+
+
+def _apply_season(repo: Repository, season: int, elo: Elo) -> int:
+    matches = sorted(repo.list_matches(season), key=_match_order_key)
+    applied = 0
+    for match in matches:
+        if not _is_rateable(match):
+            continue
+        elo.update(
+            match.home.team_id,
+            match.away.team_id,
+            int(match.home.score or 0),
+            int(match.away.score or 0),
+        )
+        applied += 1
+    return applied
+
+
+def _is_rateable(match: MatchRow) -> bool:
+    if match.match_state not in RATEABLE_STATES:
+        return False
+    return match.home.score is not None and match.away.score is not None
+
+
+def _match_order_key(match: MatchRow) -> tuple:
+    # list_matches already orders by start_time, but be defensive — Elo is
+    # path-dependent and an out-of-order match would silently bias ratings.
+    return (match.start_time, match.match_id)

--- a/tests/test_elo.py
+++ b/tests/test_elo.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from fantasy_coach.models.elo import (
+    DEFAULT_HOME_ADVANTAGE,
+    DEFAULT_INITIAL_RATING,
+    DEFAULT_K,
+    Elo,
+)
+
+
+def test_new_team_starts_at_initial_rating() -> None:
+    elo = Elo()
+    assert elo.rating(1) == DEFAULT_INITIAL_RATING
+
+
+def test_predict_with_equal_ratings_reflects_home_advantage() -> None:
+    elo = Elo()
+    p_home = elo.predict(1, 2)
+    # Pure 0 home advantage would give 0.5; any positive HA pushes >0.5.
+    assert p_home > 0.5
+    expected = 1.0 / (1.0 + 10.0 ** (-DEFAULT_HOME_ADVANTAGE / 400.0))
+    assert math.isclose(p_home, expected, rel_tol=1e-9)
+
+
+def test_update_arithmetic_for_equal_ratings_home_win() -> None:
+    elo = Elo()
+    expected_home = elo.predict(1, 2)
+    delta_home, delta_away = elo.update(1, 2, 30, 10)
+
+    expected_delta = DEFAULT_K * (1.0 - expected_home)
+    assert math.isclose(delta_home, expected_delta, rel_tol=1e-9)
+    assert math.isclose(delta_away, -expected_delta, rel_tol=1e-9)
+
+
+def test_update_is_zero_sum() -> None:
+    elo = Elo()
+    elo.update(1, 2, 24, 18)
+    total = sum(elo.ratings().values())
+    assert math.isclose(total, 2 * DEFAULT_INITIAL_RATING, rel_tol=1e-9)
+
+
+def test_draw_pulls_higher_rated_team_down() -> None:
+    elo = Elo()
+    elo._ratings[1] = 1700.0
+    elo._ratings[2] = 1300.0
+
+    elo.update(1, 2, 12, 12)
+
+    assert elo.rating(1) < 1700.0
+    assert elo.rating(2) > 1300.0
+
+
+def test_underdog_win_swings_more_than_favorite_win() -> None:
+    fav_wins = Elo()
+    fav_wins._ratings[1] = 1700.0
+    fav_wins._ratings[2] = 1300.0
+    delta_fav, _ = fav_wins.update(1, 2, 30, 0)
+
+    upset = Elo()
+    upset._ratings[1] = 1700.0
+    upset._ratings[2] = 1300.0
+    _, delta_underdog = upset.update(1, 2, 0, 30)
+
+    assert abs(delta_underdog) > abs(delta_fav)
+
+
+def test_home_advantage_actually_affects_predictions() -> None:
+    no_ha = Elo(home_advantage=0.0)
+    with_ha = Elo(home_advantage=100.0)
+    assert with_ha.predict(1, 2) > no_ha.predict(1, 2)
+
+
+def test_repeated_home_wins_inflate_home_rating() -> None:
+    elo = Elo()
+    for _ in range(50):
+        elo.update(1, 2, 24, 12)
+    assert elo.rating(1) > elo.rating(2) + 200
+
+
+def test_regress_to_mean_pulls_ratings_toward_initial() -> None:
+    elo = Elo(season_regression=0.5)
+    elo._ratings[1] = 1800.0
+    elo._ratings[2] = 1200.0
+
+    elo.regress_to_mean()
+
+    assert elo.rating(1) == 1650.0  # 1800 - 0.5 * (1800 - 1500)
+    assert elo.rating(2) == 1350.0
+
+
+def test_regression_weight_zero_is_noop() -> None:
+    elo = Elo()
+    elo._ratings[1] = 1800.0
+    elo.regress_to_mean(weight=0.0)
+    assert elo.rating(1) == 1800.0
+
+
+def test_regression_weight_one_resets() -> None:
+    elo = Elo()
+    elo._ratings[1] = 1800.0
+    elo.regress_to_mean(weight=1.0)
+    assert elo.rating(1) == DEFAULT_INITIAL_RATING
+
+
+def test_regression_weight_out_of_range_raises() -> None:
+    elo = Elo()
+    with pytest.raises(ValueError):
+        elo.regress_to_mean(weight=1.5)
+
+
+def test_predict_probabilities_sum_to_one_when_swapped() -> None:
+    elo = Elo(home_advantage=0.0)  # symmetric, so a swap is the complement
+    elo._ratings[1] = 1600.0
+    elo._ratings[2] = 1400.0
+    p1 = elo.predict(1, 2)
+    p2 = elo.predict(2, 1)
+    assert math.isclose(p1 + p2, 1.0, rel_tol=1e-9)

--- a/tests/test_rating_sweep.py
+++ b/tests/test_rating_sweep.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from fantasy_coach.features import MatchRow, TeamRow
+from fantasy_coach.models.elo import DEFAULT_INITIAL_RATING, Elo
+from fantasy_coach.models.rating_sweep import sweep_repository
+from fantasy_coach.storage import SQLiteRepository
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Iterator[SQLiteRepository]:
+    db = SQLiteRepository(tmp_path / "ratings.db")
+    yield db
+    db.close()
+
+
+def _make_match(
+    *,
+    match_id: int,
+    season: int,
+    round: int,
+    start: datetime,
+    home_id: int,
+    away_id: int,
+    home_score: int | None,
+    away_score: int | None,
+    state: str = "FullTime",
+) -> MatchRow:
+    return MatchRow(
+        match_id=match_id,
+        season=season,
+        round=round,
+        start_time=start,
+        match_state=state,
+        venue=None,
+        venue_city=None,
+        weather=None,
+        home=TeamRow(
+            team_id=home_id,
+            name=f"Team {home_id}",
+            nick_name=str(home_id),
+            score=home_score,
+            players=[],
+        ),
+        away=TeamRow(
+            team_id=away_id,
+            name=f"Team {away_id}",
+            nick_name=str(away_id),
+            score=away_score,
+            players=[],
+        ),
+        team_stats=[],
+    )
+
+
+def test_sweep_applies_completed_matches_in_order(repo: SQLiteRepository) -> None:
+    repo.upsert_match(
+        _make_match(
+            match_id=1,
+            season=2024,
+            round=1,
+            start=datetime(2024, 3, 1, tzinfo=UTC),
+            home_id=10,
+            away_id=20,
+            home_score=30,
+            away_score=12,
+        )
+    )
+    repo.upsert_match(
+        _make_match(
+            match_id=2,
+            season=2024,
+            round=2,
+            start=datetime(2024, 3, 8, tzinfo=UTC),
+            home_id=20,
+            away_id=10,
+            home_score=6,
+            away_score=24,
+        )
+    )
+
+    elo = sweep_repository(repo, [2024])
+
+    # Team 10 won both matches → should be highest-rated.
+    ratings = elo.ratings()
+    assert ratings[10] > DEFAULT_INITIAL_RATING
+    assert ratings[20] < DEFAULT_INITIAL_RATING
+
+
+def test_sweep_skips_unfinished_matches(repo: SQLiteRepository) -> None:
+    repo.upsert_match(
+        _make_match(
+            match_id=1,
+            season=2024,
+            round=1,
+            start=datetime(2024, 3, 1, tzinfo=UTC),
+            home_id=10,
+            away_id=20,
+            home_score=None,
+            away_score=None,
+            state="Upcoming",
+        )
+    )
+
+    elo = sweep_repository(repo, [2024])
+    assert elo.ratings() == {}
+
+
+def test_sweep_regresses_between_seasons(repo: SQLiteRepository) -> None:
+    # Team 10 dominates in 2023; new season should pull it back toward 1500.
+    repo.upsert_match(
+        _make_match(
+            match_id=1,
+            season=2023,
+            round=1,
+            start=datetime(2023, 3, 1, tzinfo=UTC),
+            home_id=10,
+            away_id=20,
+            home_score=40,
+            away_score=0,
+        )
+    )
+    repo.upsert_match(
+        _make_match(
+            match_id=2,
+            season=2024,
+            round=1,
+            start=datetime(2024, 3, 1, tzinfo=UTC),
+            home_id=10,
+            away_id=20,
+            home_score=24,
+            away_score=18,
+        )
+    )
+
+    no_regress = sweep_repository(repo, [2023, 2024], elo=Elo(season_regression=0.0))
+    with_regress = sweep_repository(repo, [2023, 2024], elo=Elo(season_regression=0.5))
+
+    # Team 10's lead over Team 20 should be smaller when regression is on.
+    spread_no = no_regress.rating(10) - no_regress.rating(20)
+    spread_yes = with_regress.rating(10) - with_regress.rating(20)
+    assert spread_yes < spread_no


### PR DESCRIPTION
Replaces #34 (auto-closed when its base branch was deleted on merge of #40).

## Summary
- `fantasy_coach.models.elo.Elo` — configurable K (default 20), home-advantage points (default 55 ≈ NRL home edge), 1500 init rating, optional season regression toward the mean.
- `fantasy_coach.models.rating_sweep.sweep_repository` walks completed matches in a `Repository` chronologically across seasons, applying updates and regressing the book between seasons.

Closes #10. Original PR: #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)