### PR TITLE
feat: walk-forward evaluation harness (closes #12)

### DIFF
--- a/src/fantasy_coach/__main__.py
+++ b/src/fantasy_coach/__main__.py
@@ -12,9 +12,23 @@ from fantasy_coach.backfill import (
     RetryLog,
     backfill_season,
 )
+from fantasy_coach.evaluation import (
+    EloPredictor,
+    HomePickPredictor,
+    LogisticPredictor,
+    Predictor,
+)
+from fantasy_coach.evaluation.harness import walk_forward_from_repo
+from fantasy_coach.evaluation.report import write_markdown
 from fantasy_coach.feature_engineering import build_training_frame
 from fantasy_coach.models.logistic import save_model, train_logistic
 from fantasy_coach.storage import SQLiteRepository
+
+_PREDICTOR_FACTORIES: dict[str, type[Predictor]] = {
+    "home": HomePickPredictor,
+    "elo": EloPredictor,
+    "logistic": LogisticPredictor,
+}
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -56,6 +70,34 @@ def main(argv: list[str] | None = None) -> int:
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
     )
 
+    ev = sub.add_parser(
+        "evaluate",
+        help="Walk-forward evaluation across one or more models.",
+    )
+    ev.add_argument(
+        "--model",
+        action="append",
+        choices=sorted(_PREDICTOR_FACTORIES),
+        required=True,
+        help="May be specified multiple times to compare models.",
+    )
+    ev.add_argument(
+        "--seasons",
+        required=True,
+        help="Comma-separated season list, e.g. 2024,2025",
+    )
+    ev.add_argument("--db", type=Path, default=Path("data/nrl.db"))
+    ev.add_argument(
+        "--report",
+        type=Path,
+        default=Path("reports/evaluation.md"),
+    )
+    ev.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+
     args = parser.parse_args(argv)
     logging.basicConfig(
         level=args.log_level,
@@ -66,6 +108,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_backfill(args)
     if args.command == "train-logistic":
         return _run_train_logistic(args)
+    if args.command == "evaluate":
+        return _run_evaluate(args)
     parser.error(f"unknown command {args.command!r}")
     return 2  # unreachable
 
@@ -115,6 +159,28 @@ def _run_train_logistic(args: argparse.Namespace) -> int:
         f"test acc={result.test_accuracy:.3f}. "
         f"Saved to {args.out}"
     )
+    return 0
+
+
+def _run_evaluate(args: argparse.Namespace) -> int:
+    seasons = [int(s) for s in args.seasons.split(",") if s.strip()]
+    repo = SQLiteRepository(args.db)
+    try:
+        results = []
+        for model_name in args.model:
+            factory = _PREDICTOR_FACTORIES[model_name]
+            results.append(walk_forward_from_repo(repo, seasons, factory))
+    finally:
+        repo.close()
+
+    write_markdown(args.report, results, seasons=seasons)
+    for r in results:
+        m = r.metrics()
+        print(
+            f"{r.predictor_name}: n={r.n} "
+            f"acc={m['accuracy']:.3f} log_loss={m['log_loss']:.3f} brier={m['brier']:.3f}"
+        )
+    print(f"Report written to {args.report}")
     return 0
 
 

--- a/src/fantasy_coach/evaluation/__init__.py
+++ b/src/fantasy_coach/evaluation/__init__.py
@@ -1,0 +1,25 @@
+from fantasy_coach.evaluation.harness import (
+    EvaluationResult,
+    Prediction,
+    walk_forward,
+)
+from fantasy_coach.evaluation.metrics import accuracy, brier_score, log_loss
+from fantasy_coach.evaluation.predictors import (
+    EloPredictor,
+    HomePickPredictor,
+    LogisticPredictor,
+    Predictor,
+)
+
+__all__ = [
+    "EloPredictor",
+    "EvaluationResult",
+    "HomePickPredictor",
+    "LogisticPredictor",
+    "Prediction",
+    "Predictor",
+    "accuracy",
+    "brier_score",
+    "log_loss",
+    "walk_forward",
+]

--- a/src/fantasy_coach/evaluation/harness.py
+++ b/src/fantasy_coach/evaluation/harness.py
@@ -1,0 +1,126 @@
+"""Walk-forward evaluation: refit per round, predict that round, score.
+
+For each (season, round) in evaluation order:
+1. Build the history = every completed match strictly before this round.
+2. `predictor.fit(history)`.
+3. For every match in this round, call `predictor.predict_home_win_prob(m)`
+   and store (match_id, p_home_win, actual).
+
+Yields one `EvaluationResult` per (predictor, run) so the report writer can
+diff metrics across models.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, field
+
+from fantasy_coach.evaluation.metrics import accuracy, brier_score, log_loss
+from fantasy_coach.evaluation.predictors import Predictor
+from fantasy_coach.features import MatchRow
+from fantasy_coach.storage.repository import Repository
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Prediction:
+    season: int
+    round: int
+    match_id: int
+    home_id: int
+    away_id: int
+    p_home_win: float
+    actual_home_win: int
+
+
+@dataclass
+class EvaluationResult:
+    predictor_name: str
+    predictions: list[Prediction] = field(default_factory=list)
+
+    @property
+    def n(self) -> int:
+        return len(self.predictions)
+
+    @property
+    def probs(self) -> list[float]:
+        return [p.p_home_win for p in self.predictions]
+
+    @property
+    def actuals(self) -> list[int]:
+        return [p.actual_home_win for p in self.predictions]
+
+    def metrics(self) -> dict[str, float]:
+        return {
+            "accuracy": accuracy(self.probs, self.actuals),
+            "log_loss": log_loss(self.probs, self.actuals),
+            "brier": brier_score(self.probs, self.actuals),
+        }
+
+
+def walk_forward(
+    matches_by_round: Sequence[tuple[int, int, list[MatchRow]]],
+    predictor_factory: Callable[[], Predictor],
+) -> EvaluationResult:
+    """Score `predictor_factory()` over (season, round, matches) in order.
+
+    Caller is responsible for ordering and grouping matches into rounds —
+    `walk_forward_from_repo` is the convenience that does this from a
+    `Repository`.
+    """
+    predictor = predictor_factory()
+    history: list[MatchRow] = []
+    result = EvaluationResult(predictor_name=predictor.name)
+
+    for season, round_, round_matches in matches_by_round:
+        rateable = [m for m in round_matches if _has_outcome(m)]
+        if not rateable:
+            logger.info("Skip %d/round %d: no completed matches", season, round_)
+            continue
+
+        predictor.fit(history)
+        for match in rateable:
+            if match.home.score == match.away.score:
+                # Drop draws from scoring — binary metrics expect {0, 1}.
+                continue
+            p = predictor.predict_home_win_prob(match)
+            result.predictions.append(
+                Prediction(
+                    season=season,
+                    round=round_,
+                    match_id=match.match_id,
+                    home_id=match.home.team_id,
+                    away_id=match.away.team_id,
+                    p_home_win=p,
+                    actual_home_win=1 if (match.home.score or 0) > (match.away.score or 0) else 0,
+                )
+            )
+        history.extend(rateable)
+
+    return result
+
+
+def walk_forward_from_repo(
+    repo: Repository,
+    seasons: Iterable[int],
+    predictor_factory: Callable[[], Predictor],
+) -> EvaluationResult:
+    grouped: list[tuple[int, int, list[MatchRow]]] = []
+    for season in sorted(seasons):
+        matches = sorted(repo.list_matches(season), key=lambda m: (m.start_time, m.match_id))
+        rounds: dict[int, list[MatchRow]] = {}
+        for match in matches:
+            rounds.setdefault(match.round, []).append(match)
+        for round_ in sorted(rounds.keys()):
+            grouped.append((season, round_, rounds[round_]))
+    return walk_forward(grouped, predictor_factory)
+
+
+def _has_outcome(match: MatchRow) -> bool:
+    return (
+        match.match_state in {"FullTime", "FullTimeED"}
+        and match.home.score is not None
+        and match.away.score is not None
+    )

--- a/src/fantasy_coach/evaluation/metrics.py
+++ b/src/fantasy_coach/evaluation/metrics.py
@@ -1,0 +1,31 @@
+"""Scoring metrics for the walk-forward harness."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+EPS = 1e-15
+
+
+def accuracy(probs: Sequence[float], outcomes: Sequence[int]) -> float:
+    if not probs:
+        return float("nan")
+    correct = sum(1 for p, y in zip(probs, outcomes, strict=True) if (p >= 0.5) == (y == 1))
+    return correct / len(probs)
+
+
+def log_loss(probs: Sequence[float], outcomes: Sequence[int]) -> float:
+    if not probs:
+        return float("nan")
+    total = 0.0
+    for p, y in zip(probs, outcomes, strict=True):
+        p = min(max(p, EPS), 1.0 - EPS)
+        total += -(y * math.log(p) + (1 - y) * math.log(1 - p))
+    return total / len(probs)
+
+
+def brier_score(probs: Sequence[float], outcomes: Sequence[int]) -> float:
+    if not probs:
+        return float("nan")
+    return sum((p - y) ** 2 for p, y in zip(probs, outcomes, strict=True)) / len(probs)

--- a/src/fantasy_coach/evaluation/predictors.py
+++ b/src/fantasy_coach/evaluation/predictors.py
@@ -1,0 +1,138 @@
+"""Adapters that wrap each model behind a common `Predictor` interface.
+
+The walk-forward harness only knows about `Predictor.fit(matches)` and
+`Predictor.predict_home_win_prob(match)`. New models slot in by adding an
+adapter here — no harness changes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol
+
+import numpy as np
+
+from fantasy_coach.feature_engineering import (
+    FeatureBuilder,
+    build_training_frame,
+)
+from fantasy_coach.features import MatchRow
+from fantasy_coach.models.elo import Elo
+from fantasy_coach.models.logistic import train_logistic
+
+
+class Predictor(Protocol):
+    name: str
+
+    def fit(self, history: Sequence[MatchRow]) -> None: ...
+
+    def predict_home_win_prob(self, match: MatchRow) -> float: ...
+
+
+class HomePickPredictor:
+    """Trivial baseline — every prediction is `p_home_win = 0.5 + epsilon`.
+
+    Useful as a sanity floor: any real model that does worse than this is
+    actively miscalibrated, not just unlucky.
+    """
+
+    name = "home"
+
+    def fit(self, history: Sequence[MatchRow]) -> None:  # noqa: ARG002
+        return
+
+    def predict_home_win_prob(self, match: MatchRow) -> float:  # noqa: ARG002
+        return 0.55  # NRL home-win rate ≈ 55–58 % historically
+
+
+class EloPredictor:
+    name = "elo"
+
+    def __init__(
+        self,
+        *,
+        k: float | None = None,
+        home_advantage: float | None = None,
+        season_regression: float | None = None,
+    ) -> None:
+        kwargs: dict[str, float] = {}
+        if k is not None:
+            kwargs["k"] = k
+        if home_advantage is not None:
+            kwargs["home_advantage"] = home_advantage
+        if season_regression is not None:
+            kwargs["season_regression"] = season_regression
+        self._kwargs = kwargs
+        self._elo = Elo(**kwargs)
+
+    def fit(self, history: Sequence[MatchRow]) -> None:
+        # Rebuild from scratch so the harness can call fit() repeatedly with
+        # an extending history without leaking later updates into earlier
+        # predictions.
+        self._elo = Elo(**self._kwargs)
+        # `sweep_repository` consumes a Repository, but it just calls
+        # `list_matches(season)`; for a clean in-memory rebuild, walk the
+        # provided history directly.
+        seasons = sorted({m.season for m in history})
+        history_by_season = {s: [m for m in history if m.season == s] for s in seasons}
+        for index, season in enumerate(seasons):
+            if index > 0:
+                self._elo.regress_to_mean()
+            for match in sorted(
+                history_by_season[season], key=lambda m: (m.start_time, m.match_id)
+            ):
+                if match.home.score is None or match.away.score is None:
+                    continue
+                self._elo.update(
+                    match.home.team_id,
+                    match.away.team_id,
+                    int(match.home.score),
+                    int(match.away.score),
+                )
+
+    def predict_home_win_prob(self, match: MatchRow) -> float:
+        return self._elo.predict(match.home.team_id, match.away.team_id)
+
+    @property
+    def elo(self) -> Elo:
+        return self._elo
+
+
+class LogisticPredictor:
+    name = "logistic"
+
+    def __init__(self) -> None:
+        self._train_result = None
+        # Inference-time builder lets us score one match in O(1) instead of
+        # rebuilding the entire training frame per prediction.
+        self._inference_builder = FeatureBuilder()
+
+    def fit(self, history: Sequence[MatchRow]) -> None:
+        frame = build_training_frame(history)
+        if frame.X.shape[0] < 10:
+            self._train_result = None
+        else:
+            # No internal holdout — the walk-forward harness owns the split.
+            self._train_result = train_logistic(frame, test_fraction=0.0)
+
+        # Re-derive the inference-time feature state from history. We have
+        # to walk it ourselves (rather than reuse the training builder)
+        # because draws are dropped from the training frame but their
+        # outcomes still belong in the rolling state.
+        self._inference_builder = FeatureBuilder()
+        for match in sorted(history, key=lambda m: (m.start_time, m.match_id)):
+            if match.home.score is None or match.away.score is None:
+                continue
+            self._inference_builder.advance_season_if_needed(match)
+            self._inference_builder.record(match)
+
+    def predict_home_win_prob(self, match: MatchRow) -> float:
+        if self._train_result is None:
+            return 0.55  # too little history; fall back to home prior
+        # advance_season_if_needed is a no-op here — `match` hasn't been
+        # recorded yet, so the season transition is purely Elo regression
+        # and would over-pull ratings if applied speculatively. Skip it
+        # at inference time; the harness re-fits between rounds anyway.
+        x = np.asarray([self._inference_builder.feature_row(match)], dtype=float)
+        proba = self._train_result.pipeline.predict_proba(x)[0, 1]
+        return float(proba)

--- a/src/fantasy_coach/evaluation/report.py
+++ b/src/fantasy_coach/evaluation/report.py
@@ -1,0 +1,49 @@
+"""Render walk-forward results into a markdown comparison table."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+from pathlib import Path
+
+from fantasy_coach.evaluation.harness import EvaluationResult
+
+
+def render_markdown(
+    results: Sequence[EvaluationResult],
+    *,
+    seasons: Sequence[int],
+    generated_at: datetime | None = None,
+) -> str:
+    generated_at = generated_at or datetime.now()
+    lines = [
+        "# Model evaluation",
+        "",
+        f"Generated: {generated_at.isoformat(timespec='seconds')}",
+        f"Seasons: {', '.join(str(s) for s in sorted(seasons))}",
+        "",
+        "Walk-forward: for each round, train on every prior completed match, "
+        "predict that round, score against actuals. Draws are dropped from "
+        "scoring (binary metrics).",
+        "",
+        "| Model | n predictions | Accuracy | Log loss | Brier |",
+        "|-------|---------------|----------|----------|-------|",
+    ]
+    for result in results:
+        m = result.metrics()
+        lines.append(
+            f"| {result.predictor_name} | {result.n} | "
+            f"{m['accuracy']:.3f} | {m['log_loss']:.3f} | {m['brier']:.3f} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_markdown(
+    path: Path,
+    results: Sequence[EvaluationResult],
+    *,
+    seasons: Sequence[int],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_markdown(results, seasons=seasons))

--- a/src/fantasy_coach/feature_engineering.py
+++ b/src/fantasy_coach/feature_engineering.py
@@ -5,12 +5,17 @@ match using *only* information observable before kickoff. This avoids the
 classic time-series leakage where a model "predicts" the past by accidentally
 using stats that include the match's own outcome.
 
+`FeatureBuilder` is the underlying state machine — call `feature_row(match)`
+to get the pre-kickoff feature vector, then `record(match)` to fold the
+outcome into the rolling state. `build_training_frame` is the
+fit-time wrapper that drives the builder over a list of completed matches.
+
 Features (all home-minus-away unless noted):
 - `elo_diff`: home Elo + home_advantage − away Elo, computed against the rolling
   Elo book that is updated *after* each match is emitted.
 - `form_diff_pf`, `form_diff_pa`: rolling-5 points-for and points-against
-  averages, home minus away. NaN-padded teams (no prior matches) are filled
-  with 0 — equivalent to "no prior info, no edge".
+  averages, home minus away. Empty deques (no prior matches) read as 0
+  — equivalent to "no prior info, no edge".
 - `days_rest_diff`: home days since last match minus away days since last
   match. First-match-of-season teams are clamped to 14 days (≈ pre-season).
 - `h2h_recent_diff`: average home-perspective score margin in the last 3
@@ -56,6 +61,69 @@ class TrainingFrame:
     feature_names: tuple[str, ...] = FEATURE_NAMES
 
 
+class FeatureBuilder:
+    """Stateful per-match feature computation.
+
+    Used at training time by `build_training_frame` and at inference time by
+    `LogisticPredictor` so a single match can be scored in O(1) instead of
+    rebuilding the whole frame.
+    """
+
+    def __init__(self, elo: Elo | None = None) -> None:
+        self.elo = elo or Elo()
+        self._last_played: dict[int, datetime] = {}
+        self._points_for: dict[int, deque[int]] = defaultdict(lambda: deque(maxlen=ROLLING_WINDOW))
+        self._points_against: dict[int, deque[int]] = defaultdict(
+            lambda: deque(maxlen=ROLLING_WINDOW)
+        )
+        self._h2h: dict[tuple[int, int], deque[int]] = defaultdict(lambda: deque(maxlen=H2H_WINDOW))
+        self._current_season: int | None = None
+
+    def feature_row(self, match: MatchRow) -> list[float]:
+        h_id, a_id = match.home.team_id, match.away.team_id
+        elo_diff = self.elo.rating(h_id) + self.elo.home_advantage - self.elo.rating(a_id)
+        form_pf_h = _avg(self._points_for[h_id])
+        form_pf_a = _avg(self._points_for[a_id])
+        form_pa_h = _avg(self._points_against[h_id])
+        form_pa_a = _avg(self._points_against[a_id])
+        rest_h = _days_since(self._last_played.get(h_id), match.start_time)
+        rest_a = _days_since(self._last_played.get(a_id), match.start_time)
+        h2h_avg = _avg(self._h2h[_h2h_key(h_id, a_id)])
+        h2h_recent = h2h_avg if h_id <= a_id else -h2h_avg
+        return [
+            elo_diff,
+            form_pf_h - form_pf_a,
+            form_pa_h - form_pa_a,
+            rest_h - rest_a,
+            h2h_recent,
+            1.0,
+        ]
+
+    def advance_season_if_needed(self, match: MatchRow) -> None:
+        """Apply Elo regression-to-mean when the season changes."""
+        if self._current_season is None:
+            self._current_season = match.season
+            return
+        if match.season != self._current_season:
+            self.elo.regress_to_mean()
+            self._current_season = match.season
+
+    def record(self, match: MatchRow) -> None:
+        """Fold a completed match's outcome into the rolling state."""
+        if match.home.score is None or match.away.score is None:
+            return
+        h_id, a_id = match.home.team_id, match.away.team_id
+        h_score, a_score = int(match.home.score), int(match.away.score)
+        self._points_for[h_id].append(h_score)
+        self._points_for[a_id].append(a_score)
+        self._points_against[h_id].append(a_score)
+        self._points_against[a_id].append(h_score)
+        self._h2h[_h2h_key(h_id, a_id)].append(_signed_h2h(h_id, a_id, h_score, a_score))
+        self._last_played[h_id] = match.start_time
+        self._last_played[a_id] = match.start_time
+        self.elo.update(h_id, a_id, h_score, a_score)
+
+
 def build_training_frame(
     matches: Iterable[MatchRow],
     *,
@@ -68,58 +136,32 @@ def build_training_frame(
     and NRL has very few draws, so excluding them is cleaner than relabelling.
     """
 
-    elo = elo or Elo()
     completed = sorted(
         (m for m in matches if _is_complete(m)),
         key=lambda m: (m.start_time, m.match_id),
     )
 
-    last_played: dict[int, datetime] = {}
-    points_for: dict[int, deque[int]] = defaultdict(lambda: deque(maxlen=ROLLING_WINDOW))
-    points_against: dict[int, deque[int]] = defaultdict(lambda: deque(maxlen=ROLLING_WINDOW))
-    h2h: dict[tuple[int, int], deque[int]] = defaultdict(lambda: deque(maxlen=H2H_WINDOW))
-
+    builder = FeatureBuilder(elo=elo)
     rows: list[list[float]] = []
     targets: list[int] = []
     match_ids: list[int] = []
     start_times: list[np.datetime64] = []
 
     for match in completed:
-        h_id, a_id = match.home.team_id, match.away.team_id
+        builder.advance_season_if_needed(match)
         h_score = int(match.home.score or 0)
         a_score = int(match.away.score or 0)
 
         if drop_draws and h_score == a_score:
-            _record_post_match(match, last_played, points_for, points_against, h2h, elo)
+            builder.record(match)
             continue
 
-        elo_diff = elo.rating(h_id) + elo.home_advantage - elo.rating(a_id)
-        form_pf_h = _avg(points_for[h_id])
-        form_pf_a = _avg(points_for[a_id])
-        form_pa_h = _avg(points_against[h_id])
-        form_pa_a = _avg(points_against[a_id])
-        rest_h = _days_since(last_played.get(h_id), match.start_time)
-        rest_a = _days_since(last_played.get(a_id), match.start_time)
-        # h2h is stored from the lower-team-id's perspective; flip if needed
-        # so the feature is always read from the home perspective.
-        h2h_avg = _avg(h2h[_h2h_key(h_id, a_id)])
-        h2h_recent = h2h_avg if h_id <= a_id else -h2h_avg
-
-        rows.append(
-            [
-                elo_diff,
-                form_pf_h - form_pf_a,
-                form_pa_h - form_pa_a,
-                rest_h - rest_a,
-                h2h_recent,
-                1.0,
-            ]
-        )
+        rows.append(builder.feature_row(match))
         targets.append(1 if h_score > a_score else 0)
         match_ids.append(match.match_id)
         start_times.append(np.datetime64(match.start_time.replace(tzinfo=None), "s"))
 
-        _record_post_match(match, last_played, points_for, points_against, h2h, elo)
+        builder.record(match)
 
     if not rows:
         return TrainingFrame(
@@ -135,27 +177,6 @@ def build_training_frame(
         match_ids=np.asarray(match_ids, dtype=int),
         start_times=np.asarray(start_times, dtype="datetime64[s]"),
     )
-
-
-def _record_post_match(
-    match: MatchRow,
-    last_played: dict[int, datetime],
-    points_for: dict[int, deque[int]],
-    points_against: dict[int, deque[int]],
-    h2h: dict[tuple[int, int], deque[int]],
-    elo: Elo,
-) -> None:
-    h_id, a_id = match.home.team_id, match.away.team_id
-    h_score = int(match.home.score or 0)
-    a_score = int(match.away.score or 0)
-    points_for[h_id].append(h_score)
-    points_for[a_id].append(a_score)
-    points_against[h_id].append(a_score)
-    points_against[a_id].append(h_score)
-    h2h[_h2h_key(h_id, a_id)].append(_signed_h2h(h_id, a_id, h_score, a_score))
-    last_played[h_id] = match.start_time
-    last_played[a_id] = match.start_time
-    elo.update(h_id, a_id, h_score, a_score)
 
 
 def _is_complete(match: MatchRow) -> bool:
@@ -185,8 +206,7 @@ def _h2h_key(home_id: int, away_id: int) -> tuple[int, int]:
 
 
 def _signed_h2h(home_id: int, away_id: int, home_score: int, away_score: int) -> int:
-    """Score margin from the perspective of the lower team_id, so the same
-    matchup key always reads in the same direction."""
+    """Score margin from the perspective of the lower team_id."""
     if home_id <= away_id:
         return home_score - away_score
     return away_score - home_score

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import math
+import random
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from fantasy_coach.evaluation import (
+    EloPredictor,
+    HomePickPredictor,
+    LogisticPredictor,
+    accuracy,
+    brier_score,
+    log_loss,
+    walk_forward,
+)
+from fantasy_coach.evaluation.harness import walk_forward_from_repo
+from fantasy_coach.evaluation.report import render_markdown
+from fantasy_coach.features import MatchRow, TeamRow
+from fantasy_coach.storage import SQLiteRepository
+
+
+def _match(
+    *,
+    match_id: int,
+    season: int,
+    round: int,
+    home_id: int,
+    away_id: int,
+    home_score: int,
+    away_score: int,
+    when: datetime,
+    state: str = "FullTime",
+) -> MatchRow:
+    return MatchRow(
+        match_id=match_id,
+        season=season,
+        round=round,
+        start_time=when,
+        match_state=state,
+        venue=None,
+        venue_city=None,
+        weather=None,
+        home=TeamRow(
+            team_id=home_id,
+            name=str(home_id),
+            nick_name=str(home_id),
+            score=home_score,
+            players=[],
+        ),
+        away=TeamRow(
+            team_id=away_id,
+            name=str(away_id),
+            nick_name=str(away_id),
+            score=away_score,
+            players=[],
+        ),
+        team_stats=[],
+    )
+
+
+# ---------- metrics ----------
+
+
+def test_accuracy_threshold_at_half() -> None:
+    assert accuracy([0.6, 0.4, 0.51], [1, 0, 1]) == 1.0
+    assert accuracy([0.6, 0.4, 0.49], [1, 0, 1]) == 2 / 3
+
+
+def test_log_loss_perfect_is_near_zero_and_wrong_is_huge() -> None:
+    assert log_loss([0.99], [1]) < 0.02
+    assert log_loss([0.01], [1]) > 4.0
+
+
+def test_brier_known_value() -> None:
+    # ((0.7-1)^2 + (0.2-0)^2) / 2 = (0.09 + 0.04) / 2 = 0.065
+    assert math.isclose(brier_score([0.7, 0.2], [1, 0]), 0.065, rel_tol=1e-9)
+
+
+def test_metrics_handle_empty() -> None:
+    assert math.isnan(accuracy([], []))
+    assert math.isnan(log_loss([], []))
+    assert math.isnan(brier_score([], []))
+
+
+# ---------- walk-forward harness ----------
+
+
+def _two_round_season() -> list[tuple[int, int, list[MatchRow]]]:
+    base = datetime(2024, 3, 1, tzinfo=UTC)
+    round1 = [
+        _match(
+            match_id=i,
+            season=2024,
+            round=1,
+            home_id=10 + i * 2,
+            away_id=11 + i * 2,
+            home_score=24,
+            away_score=12,
+            when=base + timedelta(hours=i),
+        )
+        for i in range(4)
+    ]
+    round2 = [
+        _match(
+            match_id=100 + i,
+            season=2024,
+            round=2,
+            home_id=10 + i * 2,
+            away_id=11 + i * 2,
+            home_score=20,
+            away_score=14,
+            when=base + timedelta(days=7, hours=i),
+        )
+        for i in range(4)
+    ]
+    return [(2024, 1, round1), (2024, 2, round2)]
+
+
+def test_walk_forward_records_one_prediction_per_match() -> None:
+    rounds = _two_round_season()
+    result = walk_forward(rounds, HomePickPredictor)
+    assert result.n == 8
+    assert result.predictor_name == "home"
+    # All predictions should be the constant 0.55.
+    assert all(p.p_home_win == 0.55 for p in result.predictions)
+
+
+def test_walk_forward_drops_draws_from_scoring() -> None:
+    base = datetime(2024, 3, 1, tzinfo=UTC)
+    rounds = [
+        (
+            2024,
+            1,
+            [
+                _match(
+                    match_id=1,
+                    season=2024,
+                    round=1,
+                    home_id=10,
+                    away_id=20,
+                    home_score=12,
+                    away_score=12,
+                    when=base,
+                ),
+                _match(
+                    match_id=2,
+                    season=2024,
+                    round=1,
+                    home_id=30,
+                    away_id=40,
+                    home_score=24,
+                    away_score=18,
+                    when=base + timedelta(hours=1),
+                ),
+            ],
+        )
+    ]
+    result = walk_forward(rounds, HomePickPredictor)
+    assert [p.match_id for p in result.predictions] == [2]
+
+
+def test_walk_forward_uses_only_prior_rounds_for_training() -> None:
+    base = datetime(2024, 3, 1, tzinfo=UTC)
+    # Round 1: team 10 beats team 20 by a lot.
+    # Round 2: same matchup. EloPredictor should pick team 10 strongly.
+    rounds = [
+        (
+            2024,
+            1,
+            [
+                _match(
+                    match_id=1,
+                    season=2024,
+                    round=1,
+                    home_id=10,
+                    away_id=20,
+                    home_score=40,
+                    away_score=10,
+                    when=base,
+                )
+            ],
+        ),
+        (
+            2024,
+            2,
+            [
+                _match(
+                    match_id=2,
+                    season=2024,
+                    round=2,
+                    home_id=10,
+                    away_id=20,
+                    home_score=24,
+                    away_score=18,
+                    when=base + timedelta(days=7),
+                )
+            ],
+        ),
+    ]
+    result = walk_forward(rounds, EloPredictor)
+    # Round 1 prediction is from a fresh book → ~0.5 + home-advantage.
+    # Round 2 prediction should be higher because team 10 just won by 30.
+    p1, p2 = result.predictions
+    assert p2.p_home_win > p1.p_home_win
+
+
+def test_logistic_predictor_falls_back_when_history_too_small() -> None:
+    base = datetime(2024, 3, 1, tzinfo=UTC)
+    rounds = [
+        (
+            2024,
+            1,
+            [
+                _match(
+                    match_id=1,
+                    season=2024,
+                    round=1,
+                    home_id=10,
+                    away_id=20,
+                    home_score=24,
+                    away_score=12,
+                    when=base,
+                )
+            ],
+        )
+    ]
+    result = walk_forward(rounds, LogisticPredictor)
+    assert result.predictions[0].p_home_win == 0.55
+
+
+# ---------- end-to-end via SQLite repository ----------
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Iterator[SQLiteRepository]:
+    db = SQLiteRepository(tmp_path / "eval.db")
+    yield db
+    db.close()
+
+
+def _stack_season(repo: SQLiteRepository) -> None:
+    rng = random.Random(0)
+    base = datetime(2024, 3, 1, tzinfo=UTC)
+    for i in range(40):
+        # Team 10 always wins; alternates home/away to get a real signal.
+        if i % 2 == 0:
+            home, away, hs, as_ = 10, 20, rng.randint(20, 36), rng.randint(6, 18)
+        else:
+            home, away, hs, as_ = 20, 10, rng.randint(6, 18), rng.randint(20, 36)
+        repo.upsert_match(
+            _match(
+                match_id=i + 1,
+                season=2024,
+                round=(i // 8) + 1,
+                home_id=home,
+                away_id=away,
+                home_score=hs,
+                away_score=as_,
+                when=base + timedelta(days=i),
+            )
+        )
+
+
+def test_walk_forward_from_repo_orders_seasons_and_rounds(
+    repo: SQLiteRepository,
+) -> None:
+    _stack_season(repo)
+    result = walk_forward_from_repo(repo, [2024], EloPredictor)
+    assert result.n > 0
+    rounds_seen = [p.round for p in result.predictions]
+    assert rounds_seen == sorted(rounds_seen)
+
+
+def test_render_markdown_contains_metrics_for_each_model() -> None:
+    rounds = _two_round_season()
+    home = walk_forward(rounds, HomePickPredictor)
+    elo = walk_forward(rounds, EloPredictor)
+
+    md = render_markdown([home, elo], seasons=[2024])
+
+    assert "| home |" in md
+    assert "| elo |" in md
+    assert "Accuracy" in md
+    assert "Brier" in md


### PR DESCRIPTION
Replaces #36 (auto-closed when its base branch was deleted on merge of #42).

## Summary
- Common `Predictor` Protocol + adapters: `HomePickPredictor`, `EloPredictor`, `LogisticPredictor`.
- `walk_forward(matches_by_round, factory)` and `walk_forward_from_repo(repo, seasons, factory)`: refit per round on prior completed matches, predict the new round, score against actuals.
- Metrics: accuracy, log loss, Brier (own implementations).
- Refactored `feature_engineering` into a stateful `FeatureBuilder` so logistic inference is O(1).
- Markdown report writer + CLI: `python -m fantasy_coach evaluate --model elo --model logistic --seasons 2024,2025`.

Closes #12. Original PR: #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)