### PR TITLE
feat: bookmaker closing-line baseline (closes #13)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "numpy>=2.0",
     "scikit-learn>=1.5",
     "joblib>=1.4",
+    "openpyxl>=3.1.5",
 ]
 
 [build-system]

--- a/src/fantasy_coach/__main__.py
+++ b/src/fantasy_coach/__main__.py
@@ -12,11 +12,11 @@ from fantasy_coach.backfill import (
     RetryLog,
     backfill_season,
 )
+from fantasy_coach.bookmaker import BookmakerPredictor, load_closing_lines
 from fantasy_coach.evaluation import (
     EloPredictor,
     HomePickPredictor,
     LogisticPredictor,
-    Predictor,
 )
 from fantasy_coach.evaluation.harness import walk_forward_from_repo
 from fantasy_coach.evaluation.report import write_markdown
@@ -24,11 +24,14 @@ from fantasy_coach.feature_engineering import build_training_frame
 from fantasy_coach.models.logistic import save_model, train_logistic
 from fantasy_coach.storage import SQLiteRepository
 
-_PREDICTOR_FACTORIES: dict[str, type[Predictor]] = {
+_BUILTIN_PREDICTORS = {
     "home": HomePickPredictor,
     "elo": EloPredictor,
     "logistic": LogisticPredictor,
 }
+# `bookmaker` is appended at parse time so users see it in --help even
+# though it requires a separate --closing-lines argument.
+_PREDICTOR_CHOICES = sorted([*_BUILTIN_PREDICTORS, "bookmaker"])
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -77,7 +80,7 @@ def main(argv: list[str] | None = None) -> int:
     ev.add_argument(
         "--model",
         action="append",
-        choices=sorted(_PREDICTOR_FACTORIES),
+        choices=_PREDICTOR_CHOICES,
         required=True,
         help="May be specified multiple times to compare models.",
     )
@@ -91,6 +94,12 @@ def main(argv: list[str] | None = None) -> int:
         "--report",
         type=Path,
         default=Path("reports/evaluation.md"),
+    )
+    ev.add_argument(
+        "--closing-lines",
+        type=Path,
+        default=None,
+        help="Path to the aussportsbetting NRL xlsx. Required when --model bookmaker is used.",
     )
     ev.add_argument(
         "--log-level",
@@ -164,12 +173,26 @@ def _run_train_logistic(args: argparse.Namespace) -> int:
 
 def _run_evaluate(args: argparse.Namespace) -> int:
     seasons = [int(s) for s in args.seasons.split(",") if s.strip()]
+
+    factories = {}
+    for name in args.model:
+        if name == "bookmaker":
+            if args.closing_lines is None:
+                print(
+                    "error: --model bookmaker requires --closing-lines PATH",
+                    file=sys.stderr,
+                )
+                return 2
+            lines = load_closing_lines(args.closing_lines)
+            factories[name] = lambda lines=lines: BookmakerPredictor(lines)
+        else:
+            factories[name] = _BUILTIN_PREDICTORS[name]
+
     repo = SQLiteRepository(args.db)
     try:
         results = []
         for model_name in args.model:
-            factory = _PREDICTOR_FACTORIES[model_name]
-            results.append(walk_forward_from_repo(repo, seasons, factory))
+            results.append(walk_forward_from_repo(repo, seasons, factories[model_name]))
     finally:
         repo.close()
 

--- a/src/fantasy_coach/bookmaker/__init__.py
+++ b/src/fantasy_coach/bookmaker/__init__.py
@@ -1,0 +1,13 @@
+from fantasy_coach.bookmaker.lines import (
+    ClosingLine,
+    devig_two_way,
+    load_closing_lines,
+)
+from fantasy_coach.bookmaker.predictor import BookmakerPredictor
+
+__all__ = [
+    "BookmakerPredictor",
+    "ClosingLine",
+    "devig_two_way",
+    "load_closing_lines",
+]

--- a/src/fantasy_coach/bookmaker/lines.py
+++ b/src/fantasy_coach/bookmaker/lines.py
@@ -1,0 +1,124 @@
+"""Load historical NRL closing lines and de-vig them.
+
+Source: aussportsbetting.com NRL Excel sheet
+(`https://www.aussportsbetting.com/historical_data/nrl.xlsx`). The columns
+we read are `Date`, `Home Team`, `Away Team`, `Home Odds Close`,
+`Away Odds Close`. Everything else is ignored.
+
+Decimal odds → implied probabilities via `1 / odds`. The two implied
+probabilities sum to slightly more than 1 (the bookmaker's overround /
+"vig"). De-vigging here uses the simplest fair approach — proportional
+normalisation — which is biased on long shots but accurate enough for a
+benchmark that we're trying to *match*, not exploit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+import openpyxl
+
+from fantasy_coach.bookmaker.team_names import canonicalize
+
+
+@dataclass(frozen=True)
+class ClosingLine:
+    match_date: date
+    home_canonical: str
+    away_canonical: str
+    home_odds_close: float
+    away_odds_close: float
+    p_home_devigged: float
+
+    @property
+    def key(self) -> tuple[date, str, str]:
+        return (self.match_date, self.home_canonical, self.away_canonical)
+
+
+_REQUIRED_HEADERS = (
+    "Date",
+    "Home Team",
+    "Away Team",
+    "Home Odds Close",
+    "Away Odds Close",
+)
+
+
+def devig_two_way(home_odds: float, away_odds: float) -> float:
+    """Return the de-vigged home win probability.
+
+    Implied probs = 1/odds; normalise so they sum to 1.
+    """
+    if home_odds <= 1.0 or away_odds <= 1.0:
+        raise ValueError(f"odds must be >1, got home={home_odds}, away={away_odds}")
+    p_home_raw = 1.0 / home_odds
+    p_away_raw = 1.0 / away_odds
+    total = p_home_raw + p_away_raw
+    return p_home_raw / total
+
+
+def load_closing_lines(path: Path | str) -> dict[tuple[date, str, str], ClosingLine]:
+    """Parse the aussportsbetting NRL xlsx into a date+team-keyed dict.
+
+    Rows missing required columns or with un-mappable team names are skipped
+    silently — the dataset includes pre-NRL rep games and historical teams
+    that aren't relevant to the modern fixture list.
+    """
+    wb = openpyxl.load_workbook(Path(path), read_only=True, data_only=True)
+    ws = wb.active
+    rows = ws.iter_rows(values_only=True)
+
+    # Header row is the second physical row (the first is a freeform note).
+    next(rows, None)  # banner
+    header = next(rows, None)
+    if not header or not all(h in header for h in _REQUIRED_HEADERS):
+        raise ValueError(f"xlsx is missing required columns; saw header={header!r}")
+    cols = {name: header.index(name) for name in _REQUIRED_HEADERS}
+
+    out: dict[tuple[date, str, str], ClosingLine] = {}
+    for row in rows:
+        try:
+            line = _row_to_line(row, cols)
+        except _SkipRowError:
+            continue
+        out[line.key] = line
+    return out
+
+
+class _SkipRowError(Exception):
+    pass
+
+
+def _row_to_line(row: tuple, cols: dict[str, int]) -> ClosingLine:
+    raw_date = row[cols["Date"]]
+    home_raw = row[cols["Home Team"]]
+    away_raw = row[cols["Away Team"]]
+    home_odds = row[cols["Home Odds Close"]]
+    away_odds = row[cols["Away Odds Close"]]
+
+    if raw_date is None or home_raw is None or away_raw is None:
+        raise _SkipRowError
+    if home_odds is None or away_odds is None:
+        raise _SkipRowError
+
+    match_date = raw_date.date() if hasattr(raw_date, "date") else raw_date
+    home_canonical = canonicalize(home_raw)
+    away_canonical = canonicalize(away_raw)
+    if home_canonical is None or away_canonical is None:
+        raise _SkipRowError
+
+    try:
+        p_home = devig_two_way(float(home_odds), float(away_odds))
+    except ValueError as exc:
+        raise _SkipRowError from exc
+
+    return ClosingLine(
+        match_date=match_date,
+        home_canonical=home_canonical,
+        away_canonical=away_canonical,
+        home_odds_close=float(home_odds),
+        away_odds_close=float(away_odds),
+        p_home_devigged=p_home,
+    )

--- a/src/fantasy_coach/bookmaker/predictor.py
+++ b/src/fantasy_coach/bookmaker/predictor.py
@@ -1,0 +1,58 @@
+"""Predictor that returns the de-vigged closing-line home win probability.
+
+Looks up each match by (Sydney-local kickoff date, canonical home, canonical
+away). Matches that aren't in the closing-lines dataset fall back to 0.55
+— the same prior as `HomePickPredictor` — so the metric reflects only
+matches the bookmaker actually priced.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import date, timedelta, timezone
+from typing import ClassVar
+
+from fantasy_coach.bookmaker.lines import ClosingLine
+from fantasy_coach.bookmaker.team_names import canonicalize
+from fantasy_coach.features import MatchRow
+
+# NRL kickoffs are scheduled in Sydney local time; UTC offsets vary across
+# the season due to DST. ±1-day window when looking up by date absorbs that
+# without needing a full timezone library.
+_DATE_TOLERANCE_DAYS = 1
+_AEST_FALLBACK = timezone(timedelta(hours=10))
+
+
+class BookmakerPredictor:
+    name: ClassVar[str] = "bookmaker"
+
+    def __init__(self, closing_lines: Mapping[tuple[date, str, str], ClosingLine]) -> None:
+        self._lines = dict(closing_lines)
+        self._missing: list[int] = []
+
+    def fit(self, history: Sequence[MatchRow]) -> None:  # noqa: ARG002
+        return
+
+    def predict_home_win_prob(self, match: MatchRow) -> float:
+        line = self._lookup(match)
+        if line is None:
+            self._missing.append(match.match_id)
+            return 0.55
+        return line.p_home_devigged
+
+    @property
+    def missing_match_ids(self) -> list[int]:
+        return list(self._missing)
+
+    def _lookup(self, match: MatchRow) -> ClosingLine | None:
+        home = canonicalize(match.home.nick_name) or canonicalize(match.home.name)
+        away = canonicalize(match.away.nick_name) or canonicalize(match.away.name)
+        if home is None or away is None:
+            return None
+
+        center = match.start_time.astimezone(_AEST_FALLBACK).date()
+        for delta in range(-_DATE_TOLERANCE_DAYS, _DATE_TOLERANCE_DAYS + 1):
+            line = self._lines.get((center + timedelta(days=delta), home, away))
+            if line is not None:
+                return line
+        return None

--- a/src/fantasy_coach/bookmaker/team_names.py
+++ b/src/fantasy_coach/bookmaker/team_names.py
@@ -1,0 +1,45 @@
+"""Map between NRL nicknames and aussportsbetting full team names.
+
+The bookmaker dataset uses full club names ("Parramatta Eels"); the NRL
+endpoints use short nicknames ("Eels"). Both must collapse to a single
+canonical token before joining on (home, away).
+
+Maintained by hand — only ~17 active teams, and a name change is a once-
+every-few-years event we'd want to notice anyway.
+"""
+
+from __future__ import annotations
+
+# Canonical key → set of accepted aliases (lowercased, hyphenated where useful).
+CANONICAL_TEAMS: dict[str, frozenset[str]] = {
+    "broncos": frozenset({"broncos", "brisbane broncos"}),
+    "raiders": frozenset({"raiders", "canberra raiders"}),
+    "bulldogs": frozenset({"bulldogs", "canterbury bulldogs", "canterbury-bankstown bulldogs"}),
+    "sharks": frozenset({"sharks", "cronulla sharks", "cronulla-sutherland sharks"}),
+    "dolphins": frozenset({"dolphins", "redcliffe dolphins"}),
+    "titans": frozenset({"titans", "gold coast titans"}),
+    "sea-eagles": frozenset(
+        {"sea eagles", "sea-eagles", "manly sea eagles", "manly-warringah sea eagles"}
+    ),
+    "storm": frozenset({"storm", "melbourne storm"}),
+    "knights": frozenset({"knights", "newcastle knights"}),
+    "cowboys": frozenset({"cowboys", "north queensland cowboys"}),
+    "eels": frozenset({"eels", "parramatta eels"}),
+    "panthers": frozenset({"panthers", "penrith panthers"}),
+    "rabbitohs": frozenset({"rabbitohs", "south sydney rabbitohs"}),
+    "dragons": frozenset(
+        {"dragons", "st george illawarra dragons", "st. george illawarra dragons"}
+    ),
+    "roosters": frozenset({"roosters", "sydney roosters"}),
+    "warriors": frozenset({"warriors", "new zealand warriors", "nz warriors"}),
+    "wests-tigers": frozenset({"wests tigers", "wests-tigers", "west tigers"}),
+}
+
+
+def canonicalize(name: str) -> str | None:
+    """Return the canonical team key for a free-form team name, or None."""
+    needle = name.strip().lower()
+    for canonical, aliases in CANONICAL_TEAMS.items():
+        if needle in aliases:
+            return canonical
+    return None

--- a/tests/test_bookmaker.py
+++ b/tests/test_bookmaker.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import math
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import openpyxl
+import pytest
+
+from fantasy_coach.bookmaker import (
+    BookmakerPredictor,
+    ClosingLine,
+    devig_two_way,
+    load_closing_lines,
+)
+from fantasy_coach.bookmaker.team_names import canonicalize
+from fantasy_coach.features import MatchRow, TeamRow
+
+# ---------- de-vig math ----------
+
+
+def test_devig_normalizes_overround() -> None:
+    # Bookmaker odds with ~5 % vig: 1/1.85 + 1/2.05 ≈ 1.028
+    p_home = devig_two_way(1.85, 2.05)
+    p_away = 1.0 - p_home
+    # Sum should be exactly 1.
+    assert math.isclose(p_home + p_away, 1.0, rel_tol=1e-9)
+    # Home should be the favourite (lower odds).
+    assert p_home > 0.5
+
+
+def test_devig_rejects_invalid_odds() -> None:
+    with pytest.raises(ValueError):
+        devig_two_way(1.0, 2.0)
+
+
+# ---------- xlsx loader ----------
+
+
+def _write_test_xlsx(path: Path) -> None:
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    # Banner row (the loader ignores it).
+    ws.append(["banner"])
+    ws.append(
+        [
+            "Date",
+            "Kick-off (local)",
+            "Home Team",
+            "Away Team",
+            "Venue",
+            "Home Score",
+            "Away Score",
+            "Play Off Game?",
+            "Over Time?",
+            "Home Odds",
+            "Draw Odds",
+            "Away Odds",
+            "Bookmakers Surveyed",
+            "Home Odds Open",
+            "Home Odds Min",
+            "Home Odds Max",
+            "Home Odds Close",
+            "Away Odds Open",
+            "Away Odds Min",
+            "Away Odds Max",
+            "Away Odds Close",
+        ]
+    )
+    ws.append(
+        [
+            datetime(2024, 3, 3),
+            None,
+            "Manly-Warringah Sea Eagles",
+            "South Sydney Rabbitohs",
+            "venue",
+            36,
+            24,
+            None,
+            None,
+            1.85,
+            None,
+            2.05,
+            None,
+            None,
+            None,
+            None,
+            1.83,
+            None,
+            None,
+            None,
+            2.10,
+        ]
+    )
+    ws.append(
+        [
+            datetime(2024, 3, 4),
+            None,
+            "Mystery Team",  # un-mappable → skipped
+            "Parramatta Eels",
+            "v",
+            12,
+            18,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            2.0,
+            None,
+            None,
+            None,
+            1.85,
+        ]
+    )
+    wb.save(path)
+
+
+def test_load_closing_lines_parses_and_dedupes(tmp_path: Path) -> None:
+    path = tmp_path / "lines.xlsx"
+    _write_test_xlsx(path)
+
+    lines = load_closing_lines(path)
+
+    assert len(lines) == 1  # second row dropped (un-mappable home team)
+    [(key, line)] = lines.items()
+    assert key == (date(2024, 3, 3), "sea-eagles", "rabbitohs")
+    assert line.home_odds_close == 1.83
+    assert line.away_odds_close == 2.10
+    expected = devig_two_way(1.83, 2.10)
+    assert math.isclose(line.p_home_devigged, expected, rel_tol=1e-9)
+
+
+# ---------- team-name canonicalizer ----------
+
+
+def test_canonicalize_handles_full_and_short_names() -> None:
+    assert canonicalize("Manly-Warringah Sea Eagles") == "sea-eagles"
+    assert canonicalize("Sea Eagles") == "sea-eagles"
+    assert canonicalize("Wests Tigers") == "wests-tigers"
+    assert canonicalize("Mystery Team") is None
+
+
+# ---------- predictor ----------
+
+
+def _match(*, match_id: int, home_nick: str, away_nick: str, when: datetime) -> MatchRow:
+    return MatchRow(
+        match_id=match_id,
+        season=when.year,
+        round=1,
+        start_time=when,
+        match_state="FullTime",
+        venue=None,
+        venue_city=None,
+        weather=None,
+        home=TeamRow(team_id=1, name=home_nick, nick_name=home_nick, score=0, players=[]),
+        away=TeamRow(team_id=2, name=away_nick, nick_name=away_nick, score=0, players=[]),
+        team_stats=[],
+    )
+
+
+def test_predictor_returns_devigged_prob_for_known_match() -> None:
+    line = ClosingLine(
+        match_date=date(2024, 3, 3),
+        home_canonical="sea-eagles",
+        away_canonical="rabbitohs",
+        home_odds_close=1.83,
+        away_odds_close=2.10,
+        p_home_devigged=devig_two_way(1.83, 2.10),
+    )
+    predictor = BookmakerPredictor({line.key: line})
+
+    p = predictor.predict_home_win_prob(
+        _match(
+            match_id=1,
+            home_nick="Sea Eagles",
+            away_nick="Rabbitohs",
+            when=datetime(2024, 3, 3, 6, 30, tzinfo=UTC),
+        )
+    )
+
+    assert math.isclose(p, line.p_home_devigged, rel_tol=1e-9)
+    assert predictor.missing_match_ids == []
+
+
+def test_predictor_falls_back_when_match_missing() -> None:
+    predictor = BookmakerPredictor({})
+
+    p = predictor.predict_home_win_prob(
+        _match(
+            match_id=42,
+            home_nick="Sea Eagles",
+            away_nick="Rabbitohs",
+            when=datetime(2024, 3, 3, tzinfo=UTC),
+        )
+    )
+
+    assert p == 0.55
+    assert predictor.missing_match_ids == [42]
+
+
+def test_predictor_tolerates_one_day_drift() -> None:
+    line = ClosingLine(
+        match_date=date(2024, 3, 3),
+        home_canonical="sea-eagles",
+        away_canonical="rabbitohs",
+        home_odds_close=1.83,
+        away_odds_close=2.10,
+        p_home_devigged=devig_two_way(1.83, 2.10),
+    )
+    predictor = BookmakerPredictor({line.key: line})
+
+    # NRL kickoff at 14:00 UTC is March 4 in Sydney time (+10) — predictor
+    # should still find the line dated March 3.
+    p = predictor.predict_home_win_prob(
+        _match(
+            match_id=1,
+            home_nick="Sea Eagles",
+            away_nick="Rabbitohs",
+            when=datetime(2024, 3, 2, 18, 0, tzinfo=UTC),
+        )
+    )
+    assert math.isclose(p, line.p_home_devigged, rel_tol=1e-9)

--- a/uv.lock
+++ b/uv.lock
@@ -166,6 +166,15 @@ wheels = [
 ]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
 name = "fantasy-coach"
 version = "0.1.0"
 source = { editable = "." }
@@ -174,6 +183,7 @@ dependencies = [
     { name = "httpx" },
     { name = "joblib" },
     { name = "numpy" },
+    { name = "openpyxl" },
     { name = "pydantic" },
     { name = "scikit-learn" },
     { name = "uvicorn", extra = ["standard"] },
@@ -194,6 +204,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "joblib", specifier = ">=1.4" },
     { name = "numpy", specifier = ">=2.0" },
+    { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "scikit-learn", specifier = ">=1.5" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
@@ -403,6 +414,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
     { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
     { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replaces #37 (auto-closed when its base branch was deleted on merge of #43).

## Summary
- `lines.load_closing_lines` parses the [aussportsbetting.com NRL xlsx](https://www.aussportsbetting.com/historical_data/nrl.xlsx) into rows keyed by `(date, canonical_home, canonical_away)`. `devig_two_way` normalises implied probabilities so home/away sums to 1.
- `BookmakerPredictor` satisfies the evaluation `Predictor` protocol with ±1 day Sydney-local lookup tolerance. Misses fall back to 0.55 + a `missing_match_ids` list for diagnosis.
- `team_names.canonicalize` collapses NRL nicknames + aussportsbetting full names to a single key.
- CLI: `python -m fantasy_coach evaluate --model bookmaker --closing-lines nrl.xlsx --seasons 2024,2025`.
- New runtime dep: openpyxl. The xlsx itself isn't vendored.

Closes #13. Original PR: #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)