### PR TITLE
feat: Cloud Run deploy docs + GHA workflow (kicks off #14)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,90 @@
+name: Deploy to Cloud Run
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "Dockerfile"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/deploy.yml"
+  workflow_dispatch:
+
+# Only one deploy at a time — Cloud Run rejects concurrent revision rolls anyway,
+# and serialising prevents two CI runs racing each other to the same SHA.
+concurrency:
+  group: cloud-run-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write   # required for keyless WIF auth to GCP
+
+env:
+  REGION: australia-southeast1
+  SERVICE: fantasy-coach-api
+  REPO: fantasy-coach
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: auth
+        name: Authenticate to GCP via Workload Identity Federation
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.FANTASY_COACH_WIF_PROVIDER }}
+          service_account: ${{ secrets.FANTASY_COACH_DEPLOYER_SA }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker "${{ env.REGION }}-docker.pkg.dev" --quiet
+
+      - name: Build and push image
+        env:
+          PROJECT_ID: ${{ secrets.FANTASY_COACH_PROJECT_ID }}
+        run: |
+          IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/api:${GITHUB_SHA::7}"
+          echo "IMAGE=${IMAGE}" >> "$GITHUB_ENV"
+          docker buildx build --platform linux/amd64 -t "$IMAGE" --push .
+
+      - name: Deploy revision
+        env:
+          PROJECT_ID: ${{ secrets.FANTASY_COACH_PROJECT_ID }}
+        run: |
+          gcloud run deploy "${SERVICE}" \
+            --project "${PROJECT_ID}" \
+            --region "${REGION}" \
+            --image "${IMAGE}" \
+            --platform managed \
+            --no-allow-unauthenticated \
+            --min-instances 0 \
+            --max-instances 2 \
+            --cpu 1 \
+            --memory 512Mi \
+            --cpu-throttling \
+            --port 8080 \
+            --execution-environment gen2 \
+            --service-account "fantasy-coach-runtime@${PROJECT_ID}.iam.gserviceaccount.com" \
+            --quiet
+
+      - name: Smoke-test /healthz
+        env:
+          PROJECT_ID: ${{ secrets.FANTASY_COACH_PROJECT_ID }}
+        run: |
+          URL=$(gcloud run services describe "${SERVICE}" \
+                  --project "${PROJECT_ID}" --region "${REGION}" \
+                  --format 'value(status.url)')
+          TOKEN=$(gcloud auth print-identity-token)
+          STATUS=$(curl -s -o /tmp/healthz -w "%{http_code}" \
+                     -H "Authorization: Bearer ${TOKEN}" "${URL}/healthz")
+          cat /tmp/healthz
+          if [ "${STATUS}" != "200" ]; then
+            echo "::error::healthz returned ${STATUS}"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -47,3 +47,5 @@ Dockerfile           Cloud Run image
 ## Infrastructure
 
 All GCP infrastructure (Cloud Run service, Firestore, Secret Manager, Firebase, Vertex AI, IAM) is provisioned via Terraform in [`lopeztech/platform-infra`](https://github.com/lopeztech/platform-infra) — not in this repo.
+
+See [`docs/deploy.md`](docs/deploy.md) for the Cloud Run deploy command and the GitHub Actions workflow that ships every push to `main`.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,110 @@
+# Deployment
+
+The fantasy-coach API runs on Cloud Run, scaled to zero so idle cost is $0.
+Image lives in Artifact Registry. Region: **`australia-southeast1`** (Sydney)
+to keep `nrl.com` scrape latency low and host data near the predicted matches.
+
+## One-time setup (paired with `lopeztech/platform-infra`)
+
+The GCP project, Cloud Run service, Artifact Registry repo, service account,
+and Workload Identity Federation pool are provisioned via Terraform in
+[`lopeztech/platform-infra`](https://github.com/lopeztech/platform-infra) under
+`projects/fantasy-coach/`. Don't `gcloud iam create` anything by hand — that
+state will get overwritten on the next `terraform apply`.
+
+After the platform-infra PR lands and `terraform apply` runs, three GitHub
+secrets must be added to **this** repo:
+
+| Secret | Source | What it's for |
+|--------|--------|----------------|
+| `FANTASY_COACH_WIF_PROVIDER` | platform-infra `output "wif_provider"` | OIDC issuer for keyless `gcloud auth` |
+| `FANTASY_COACH_DEPLOYER_SA` | platform-infra `output "deployer_sa_email"` | Service account the workflow impersonates |
+| `FANTASY_COACH_PROJECT_ID` | platform-infra `output "project_id"` | GCP project the deploy targets |
+
+## Automatic deploy (preferred)
+
+`.github/workflows/deploy.yml` runs on every push to `main` that touches
+`src/`, `Dockerfile`, `pyproject.toml`, `uv.lock`, or the workflow itself.
+It builds the image, pushes to Artifact Registry, and rolls a new Cloud Run
+revision over the previous one. No manual step required after the secrets
+are in place.
+
+To trigger a deploy without a code change:
+
+```bash
+gh workflow run deploy.yml --repo lopeztech/fantasy-coach
+```
+
+## Manual deploy (escape hatch)
+
+If CI is wedged or you need to ship a one-off image, this is the equivalent
+locally. It assumes you've authenticated with `gcloud auth login` and have
+`roles/run.developer` + `roles/artifactregistry.writer` on the project.
+
+```bash
+PROJECT_ID=fantasy-coach-lcd
+REGION=australia-southeast1
+SERVICE=fantasy-coach-api
+REPO=fantasy-coach
+TAG=$(git rev-parse --short HEAD)
+IMAGE="$REGION-docker.pkg.dev/$PROJECT_ID/$REPO/api:$TAG"
+
+# 1. Build a linux/amd64 image (Cloud Run doesn't accept arm64).
+docker buildx build --platform linux/amd64 -t "$IMAGE" --push .
+
+# 2. Roll a new revision.
+gcloud run deploy "$SERVICE" \
+    --project "$PROJECT_ID" \
+    --region "$REGION" \
+    --image "$IMAGE" \
+    --platform managed \
+    --no-allow-unauthenticated \
+    --min-instances 0 \
+    --max-instances 2 \
+    --cpu 1 \
+    --memory 512Mi \
+    --cpu-throttling \
+    --port 8080 \
+    --execution-environment gen2 \
+    --service-account "fantasy-coach-runtime@$PROJECT_ID.iam.gserviceaccount.com"
+```
+
+`--cpu-throttling` is the flag that achieves "CPU allocated only during
+requests" — without it, the container is billed for CPU even when idle.
+
+## Smoke test
+
+The Cloud Run URL is in the deploy output (`gcloud run services describe
+$SERVICE --region $REGION --format 'value(status.url)'`). With auth still
+required (it is — see #17), use an identity token:
+
+```bash
+URL=$(gcloud run services describe $SERVICE --region $REGION --format 'value(status.url)')
+curl -H "Authorization: Bearer $(gcloud auth print-identity-token)" "$URL/healthz"
+# → {"status":"ok","version":"0.1.0"}
+```
+
+## Service account least-privilege
+
+The runtime SA (`fantasy-coach-runtime`) holds only:
+
+- `roles/datastore.user` (Firestore read/write — for #15)
+- `roles/secretmanager.secretAccessor` (config secrets — for #16)
+- `roles/aiplatform.user` (Vertex Gemini — for #22)
+
+The deployer SA (`fantasy-coach-deployer`) holds only the roles needed to
+build, push, and roll a revision — `roles/run.developer`,
+`roles/artifactregistry.writer`, `roles/iam.serviceAccountUser` (to
+impersonate the runtime SA at deploy time).
+
+Both SA definitions live in platform-infra and are the source of truth.
+
+## Rolling back
+
+Cloud Run keeps every revision. To roll back:
+
+```bash
+gcloud run services update-traffic $SERVICE \
+    --project $PROJECT_ID --region $REGION \
+    --to-revisions $SERVICE-00042-abc=100  # the revision name from the console
+```


### PR DESCRIPTION
App-side half of #14. Pairs with a forthcoming `lopeztech/platform-infra` PR that provisions the GCP project, service account, Artifact Registry repo, and WIF pool. The two halves split exactly per the [Infrastructure note on #14](https://github.com/lopeztech/fantasy-coach/issues/14#issuecomment-).

## What's in here
- `docs/deploy.md`: secrets matrix (three values produced by platform-infra outputs), auto-deploy flow, manual escape hatch, smoke test, runtime/deployer SA scope, rollback recipe.
- `.github/workflows/deploy.yml`: builds `linux/amd64` image, pushes to Artifact Registry at `australia-southeast1`, rolls a Cloud Run revision with `--min-instances 0` + `--cpu-throttling` (idle cost = $0), curls `/healthz` with an OIDC token to verify.
- Keyless WIF — no SA JSON keys in repo secrets.
- README pointer to `docs/deploy.md`.

## What's still required to land an actual deploy
1. The platform-infra PR must merge and `terraform apply` must run (creates the GCP project, SA, AR repo, WIF pool).
2. Three repo secrets must be added to `lopeztech/fantasy-coach`:
   - `FANTASY_COACH_WIF_PROVIDER` (from platform-infra `output "wif_provider"`)
   - `FANTASY_COACH_DEPLOYER_SA` (from platform-infra `output "deployer_sa_email"`)
   - `FANTASY_COACH_PROJECT_ID` (from platform-infra `output "project_id"`)

After that, the next push to `main` touching `src/` deploys automatically.

## Acceptance criteria mapping (#14)
- [x] Image built and pushed to Artifact Registry (workflow does it on every push)
- [x] `gcloud run deploy` documented in `docs/deploy.md` with all flags
- [ ] Dedicated SA with least-privilege IAM — defined in docs, **provisioned in the platform-infra PR**
- [x] `min-instances=0`, `max=2`, CPU only during requests
- [x] Region documented — `australia-southeast1` (Sydney)
- [ ] Smoke test `/healthz` — wired into the workflow; **only verifiable once the deploy actually runs end-to-end**

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` — valid YAML
- [x] Existing test suite: `uv run pytest` — 86 passed (unchanged from main)
- [ ] Live deploy — gated on the platform-infra PR + secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)