### PR TITLE
feat(secrets): Secret Manager integration — docs, deploy wiring, .env.example (#16)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Copy this file to .env and fill in the values.
+# .env is gitignored — never commit it.
+# Variable names here must match what's in docs/secrets.md and deploy.yml.
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+# Which storage backend to use: sqlite (local dev) or firestore (production).
+STORAGE_BACKEND=sqlite
+
+# SQLite: path to the local database file (ignored when STORAGE_BACKEND=firestore).
+FANTASY_COACH_DB_PATH=data/nrl.db
+
+# ---------------------------------------------------------------------------
+# Firebase Auth (required when STORAGE_BACKEND=firestore or running the API)
+# ---------------------------------------------------------------------------
+# The Firebase project ID used to verify ID tokens (issue #17).
+# Matches the Secret Manager secret "firebase-project-id".
+FIREBASE_PROJECT_ID=your-firebase-project-id
+
+# ---------------------------------------------------------------------------
+# GCP (usually set automatically by Cloud Run; needed locally for Firestore)
+# ---------------------------------------------------------------------------
+# GOOGLE_CLOUD_PROJECT=your-gcp-project-id
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,8 @@ jobs:
             --port 8080 \
             --execution-environment gen2 \
             --service-account "fantasy-coach-runtime@${PROJECT_ID}.iam.gserviceaccount.com" \
+            --set-secrets "FIREBASE_PROJECT_ID=firebase-project-id:latest" \
+            --set-env-vars "STORAGE_BACKEND=firestore" \
             --quiet
 
       - name: Smoke-test /healthz

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ build/
 *.sqlite3
 .env
 .env.*
+!.env.example
 data/
 
 # Snapshotted DB fixture is committed deliberately — see

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,87 @@
+# Secrets
+
+All production secrets are stored in GCP Secret Manager. Cloud Run injects
+them as environment variables at deploy time via `--set-secrets`. Local
+development reads the same variable names from a `.env` file (gitignored).
+
+## Required secrets
+
+| Secret Manager name | Env var | Purpose | Who can rotate |
+|---|---|---|---|
+| `firebase-project-id` | `FIREBASE_PROJECT_ID` | Firebase project for ID-token verification (issue #17) | Project owner |
+
+## Naming convention
+
+Secrets follow the pattern `<resource>-<purpose>` in lowercase with hyphens,
+e.g. `firebase-project-id`. All secrets live in the same GCP project as the
+Cloud Run service (`fantasy-coach-lcd`).
+
+Full resource path: `projects/<PROJECT_ID>/secrets/<name>`
+
+## Creating a secret
+
+```bash
+# Create the secret (empty, no version yet)
+gcloud secrets create firebase-project-id \
+  --project=$PROJECT_ID
+
+# Add the first version
+echo -n "my-firebase-project" | \
+  gcloud secrets versions add firebase-project-id \
+    --data-file=- \
+    --project=$PROJECT_ID
+```
+
+## Rotating a secret
+
+```bash
+# Add a new version (previous version stays active until pinned)
+echo -n "new-value" | \
+  gcloud secrets versions add firebase-project-id \
+    --data-file=- \
+    --project=$PROJECT_ID
+
+# Destroy old version once Cloud Run has picked up the new one
+gcloud secrets versions destroy <OLD_VERSION_NUMBER> \
+  --secret=firebase-project-id \
+  --project=$PROJECT_ID
+```
+
+Cloud Run uses `:latest` aliases in `--set-secrets`, so a new version is
+picked up on the next revision deployment automatically.
+
+## IAM
+
+The runtime service account (`fantasy-coach-runtime`) holds
+`roles/secretmanager.secretAccessor` scoped to each secret individually —
+not project-wide. Bindings are managed in `lopeztech/platform-infra`:
+
+```hcl
+resource "google_secret_manager_secret_iam_member" "firebase_project_id" {
+  secret_id = google_secret_manager_secret.firebase_project_id.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.runtime.email}"
+}
+```
+
+## Local development
+
+Copy `.env.example` to `.env` and fill in values before running locally:
+
+```bash
+cp .env.example .env
+# edit .env — never commit this file
+```
+
+The application reads env vars directly (FastAPI/uvicorn picks them up from
+the process environment). For a local dev helper you can source the file:
+
+```bash
+set -a; source .env; set +a
+make run
+```
+
+## Future secrets
+
+If a paid bookmaker odds API is added (issue #26), its API key goes here
+under `bookmaker-odds-api-key` / `BOOKMAKER_ODDS_API_KEY`.


### PR DESCRIPTION
## Summary

Closes #16 — Secret Manager integration.

- **`docs/secrets.md`** — complete inventory of every secret (`FIREBASE_PROJECT_ID`), naming convention (`<resource>-<purpose>`), create/rotate CLI commands, IAM scoping rationale, and local dev workflow.
- **`.env.example`** — template that mirrors the exact env var names used in production; un-ignored via `.gitignore` exception so the example is tracked in git while `.env` remains ignored.
- **`.github/workflows/deploy.yml`** — adds `--set-secrets FIREBASE_PROJECT_ID=firebase-project-id:latest` and `--set-env-vars STORAGE_BACKEND=firestore` so Cloud Run injects secrets from Secret Manager at revision deploy time (no secrets baked into the image).

## Test plan

- [x] `uv run pytest` — 94 tests, all passing (no code logic changes)
- [x] `uv run ruff format --check && uv run ruff check` — clean
- [x] CI passes on this PR