### PR TITLE
feat(api): GET /predictions endpoint with scrape-on-miss caching (#18)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "SIM"]
 "src/fantasy_coach/models/logistic.py" = ["N803", "N806"]
 "src/fantasy_coach/feature_engineering.py" = ["N806"]
 "tests/test_logistic.py" = ["N806"]
+# JSON API spec requires camelCase field names in the response schema.
+"src/fantasy_coach/predictions.py" = ["N815"]
 
 [tool.pytest.ini_options]
 addopts = "-ra -q --strict-markers"

--- a/src/fantasy_coach/app.py
+++ b/src/fantasy_coach/app.py
@@ -1,20 +1,64 @@
 import os
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Query
 
 from fantasy_coach import __version__
 from fantasy_coach.auth import FirebaseAuthMiddleware
+from fantasy_coach.config import get_repository
+from fantasy_coach.predictions import PredictionOut, PredictionStore, compute_predictions
 
-app = FastAPI(title="Fantasy Coach", version=__version__)
+app = FastAPI(
+    title="Fantasy Coach",
+    version=__version__,
+    description="NRL match prediction API. All non-health endpoints require a Firebase ID token.",
+)
 
 # Enable Firebase token verification when a project ID is configured.
-# Omitting FIREBASE_PROJECT_ID disables the check (useful for local SQLite dev),
-# but the middleware is always installed — a missing project ID will reject all
-# protected requests rather than silently pass them.
+# Omitting FIREBASE_PROJECT_ID disables the check (useful for local SQLite dev).
 if os.getenv("FIREBASE_PROJECT_ID") or os.getenv("GOOGLE_CLOUD_PROJECT"):
     app.add_middleware(FirebaseAuthMiddleware)
+
+# Module-level prediction store — created lazily on first use.
+_store: PredictionStore | None = None
+
+
+def _get_store() -> PredictionStore:
+    global _store
+    if _store is None:
+        _store = PredictionStore()
+    return _store
 
 
 @app.get("/healthz")
 def healthz() -> dict[str, str]:
     return {"status": "ok", "version": __version__}
+
+
+@app.get(
+    "/predictions",
+    response_model=list[PredictionOut],
+    summary="Get predictions for a season/round",
+    description=(
+        "Returns predicted winner and home-win probability for every match in "
+        "the requested round. Results are cached on first call; subsequent calls "
+        "return stored predictions without re-scraping."
+    ),
+)
+def get_predictions(
+    season: int = Query(..., description="NRL season year, e.g. 2026"),
+    round: int = Query(..., description="Round number, e.g. 7", alias="round"),
+) -> list[PredictionOut]:
+    repo = get_repository()
+    try:
+        return compute_predictions(season, round, repo, _get_store())
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                f"Model not available ({exc}). "
+                "Train one with: python -m fantasy_coach train-logistic"
+            ),
+        ) from exc
+    finally:
+        if hasattr(repo, "close"):
+            repo.close()

--- a/src/fantasy_coach/predictions.py
+++ b/src/fantasy_coach/predictions.py
@@ -1,0 +1,266 @@
+"""Prediction caching and computation for the /predictions API endpoint.
+
+Cache hit:  stored predictions returned, no scraping.
+Cache miss: fixtures scraped, features computed from the saved model,
+            predictions stored and returned.
+
+Predictions are persisted in a SQLite file (``FANTASY_COACH_PREDICTIONS_DB_PATH``,
+default ``data/predictions.db``) for the lifetime of the process. On Cloud Run
+this survives within a container instance; a future issue can move to Firestore
+for true cross-restart persistence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from pydantic import BaseModel
+
+from fantasy_coach.feature_engineering import FEATURE_NAMES, FeatureBuilder
+from fantasy_coach.features import MatchRow, extract_match_features
+from fantasy_coach.models.logistic import load_model
+from fantasy_coach.scraper import fetch_match_from_url, fetch_round
+
+logger = logging.getLogger(__name__)
+
+PREDICTIONS_DB_ENV = "FANTASY_COACH_PREDICTIONS_DB_PATH"
+MODEL_PATH_ENV = "FANTASY_COACH_MODEL_PATH"
+DEFAULT_MODEL_PATH = "artifacts/logistic.joblib"
+DEFAULT_PREDICTIONS_DB = "data/predictions.db"
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS predictions (
+    season           INTEGER NOT NULL,
+    round            INTEGER NOT NULL,
+    match_id         INTEGER NOT NULL,
+    home_id          INTEGER NOT NULL,
+    home_name        TEXT    NOT NULL,
+    away_id          INTEGER NOT NULL,
+    away_name        TEXT    NOT NULL,
+    kickoff          TEXT    NOT NULL,
+    predicted_winner TEXT    NOT NULL,
+    home_win_prob    REAL    NOT NULL,
+    model_version    TEXT    NOT NULL,
+    feature_hash     TEXT    NOT NULL,
+    created_at       TEXT    NOT NULL,
+    PRIMARY KEY (season, round, match_id)
+);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Response schema (also used for OpenAPI docs via FastAPI)
+# ---------------------------------------------------------------------------
+
+
+class TeamInfo(BaseModel):
+    id: int
+    name: str
+
+
+class PredictionOut(BaseModel):
+    matchId: int
+    home: TeamInfo
+    away: TeamInfo
+    kickoff: str  # ISO 8601 UTC
+    predictedWinner: str  # "home" | "away"
+    homeWinProbability: float
+    modelVersion: str  # first 12 hex chars of SHA-256 of the model file
+    featureHash: str  # first 12 hex chars of SHA-256 of feature names
+
+
+# ---------------------------------------------------------------------------
+# Prediction store (SQLite-backed cache)
+# ---------------------------------------------------------------------------
+
+
+class PredictionStore:
+    """SQLite-backed cache for computed predictions."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        db_path = Path(path or os.getenv(PREDICTIONS_DB_ENV, DEFAULT_PREDICTIONS_DB))
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(db_path))
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(_CREATE_TABLE)
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def get(self, season: int, round_: int) -> list[PredictionOut]:
+        rows = self._conn.execute(
+            "SELECT * FROM predictions WHERE season=? AND round=? ORDER BY match_id",
+            (season, round_),
+        ).fetchall()
+        return [_row_to_out(r) for r in rows]
+
+    def put(self, season: int, round_: int, predictions: list[PredictionOut]) -> None:
+        now = datetime.now(UTC).isoformat()
+        with self._conn:
+            for p in predictions:
+                self._conn.execute(
+                    """
+                    INSERT OR REPLACE INTO predictions
+                        (season, round, match_id,
+                         home_id, home_name, away_id, away_name,
+                         kickoff, predicted_winner, home_win_prob,
+                         model_version, feature_hash, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        season,
+                        round_,
+                        p.matchId,
+                        p.home.id,
+                        p.home.name,
+                        p.away.id,
+                        p.away.name,
+                        p.kickoff,
+                        p.predictedWinner,
+                        p.homeWinProbability,
+                        p.modelVersion,
+                        p.featureHash,
+                        now,
+                    ),
+                )
+
+
+def _row_to_out(r: sqlite3.Row) -> PredictionOut:
+    return PredictionOut(
+        matchId=r["match_id"],
+        home=TeamInfo(id=r["home_id"], name=r["home_name"]),
+        away=TeamInfo(id=r["away_id"], name=r["away_name"]),
+        kickoff=r["kickoff"],
+        predictedWinner=r["predicted_winner"],
+        homeWinProbability=r["home_win_prob"],
+        modelVersion=r["model_version"],
+        featureHash=r["feature_hash"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _model_version(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
+
+
+def _feature_hash() -> str:
+    return hashlib.sha256(",".join(sorted(FEATURE_NAMES)).encode()).hexdigest()[:12]
+
+
+def _build_inference_state(history: list[MatchRow]) -> FeatureBuilder:
+    builder = FeatureBuilder()
+    for match in sorted(history, key=lambda m: (m.start_time, m.match_id)):
+        if match.home.score is None or match.away.score is None:
+            continue
+        builder.advance_season_if_needed(match)
+        builder.record(match)
+    return builder
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def compute_predictions(
+    season: int,
+    round_: int,
+    repo: Any,
+    store: PredictionStore,
+    *,
+    model_path: Path | None = None,
+    fetch_round_fn: Any = fetch_round,
+    fetch_match_fn: Any = fetch_match_from_url,
+) -> list[PredictionOut]:
+    """Return predictions for season/round; compute and cache them on miss.
+
+    Raises ``FileNotFoundError`` if the model artefact does not exist (caller
+    should surface this as HTTP 503).
+    """
+    cached = store.get(season, round_)
+    if cached:
+        logger.info(
+            "Cache hit: returning %d stored predictions for %d r%d", len(cached), season, round_
+        )
+        return cached
+
+    # Resolve and load the model
+    path = model_path or Path(os.getenv(MODEL_PATH_ENV, DEFAULT_MODEL_PATH))
+    if not path.exists():
+        raise FileNotFoundError(path)
+
+    loaded = load_model(path)
+    mv = _model_version(path)
+    fh = _feature_hash()
+
+    # Scrape fixtures for the requested round
+    round_payload = fetch_round_fn(season, round_)
+    fixtures = (round_payload or {}).get("fixtures") or []
+    logger.info("Scraping %d fixtures for %d r%d", len(fixtures), season, round_)
+
+    round_matches: list[MatchRow] = []
+    for fixture in fixtures:
+        url = fixture.get("matchCentreUrl")
+        if not url:
+            continue
+        try:
+            raw = fetch_match_fn(url)
+        except Exception:
+            logger.exception("Failed to fetch match from %s", url)
+            continue
+        if raw is None:
+            continue
+        try:
+            row = extract_match_features(raw)
+            repo.upsert_match(row)
+            round_matches.append(row)
+        except Exception:
+            logger.exception("Failed to extract/store match from %s", url)
+
+    if not round_matches:
+        return []
+
+    # Build feature state from prior completed matches (current season + up to 3 prior seasons)
+    history: list[MatchRow] = []
+    for s in range(max(2020, season - 3), season + 1):
+        try:
+            season_matches = repo.list_matches(s)
+        except Exception:
+            continue
+        for m in season_matches:
+            if m.season < season or (m.season == season and m.round < round_):
+                history.append(m)
+
+    builder = _build_inference_state(history)
+
+    predictions: list[PredictionOut] = []
+    for match in sorted(round_matches, key=lambda m: (m.start_time, m.match_id)):
+        x = np.asarray([builder.feature_row(match)], dtype=float)
+        prob = round(float(loaded.predict_home_win_prob(x)[0]), 4)
+        predictions.append(
+            PredictionOut(
+                matchId=match.match_id,
+                home=TeamInfo(id=match.home.team_id, name=match.home.name),
+                away=TeamInfo(id=match.away.team_id, name=match.away.name),
+                kickoff=match.start_time.isoformat(),
+                predictedWinner="home" if prob >= 0.5 else "away",
+                homeWinProbability=prob,
+                modelVersion=mv,
+                featureHash=fh,
+            )
+        )
+
+    store.put(season, round_, predictions)
+    logger.info("Computed and cached %d predictions for %d r%d", len(predictions), season, round_)
+    return predictions

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -1,0 +1,276 @@
+"""Tests for the /predictions endpoint and PredictionStore.
+
+Network calls (fetch_round, fetch_match_from_url) are mocked with respx so
+no real NRL.com traffic is generated. Model loading is also mocked so no
+trained artefact is required.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+from fantasy_coach.app import app
+from fantasy_coach.features import extract_match_features
+from fantasy_coach.predictions import (
+    PredictionOut,
+    PredictionStore,
+    TeamInfo,
+    _feature_hash,
+    compute_predictions,
+)
+from fantasy_coach.storage.sqlite import SQLiteRepository
+
+FIXTURES = Path(__file__).parent / "fixtures"
+UPCOMING_FIXTURE = "match-2026-rd8-wests-tigers-v-raiders.json"
+FULLTIME_FIXTURE = "match-2024-rd1-sea-eagles-v-rabbitohs.json"
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> PredictionStore:
+    return PredictionStore(path=tmp_path / "pred.db")
+
+
+@pytest.fixture
+def sqlite_repo(tmp_path: Path) -> SQLiteRepository:
+    return SQLiteRepository(tmp_path / "matches.db")
+
+
+def _make_mock_model(prob: float = 0.65) -> MagicMock:
+    model = MagicMock()
+    model.predict_home_win_prob.return_value = np.array([prob])
+    return model
+
+
+def _sample_round_payload(match_url: str) -> dict:
+    return {"fixtures": [{"matchCentreUrl": match_url}]}
+
+
+# ---------------------------------------------------------------------------
+# PredictionStore unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_store_get_empty(store: PredictionStore) -> None:
+    assert store.get(2026, 8) == []
+
+
+def test_store_put_and_get(store: PredictionStore) -> None:
+    pred = PredictionOut(
+        matchId=12345,
+        home=TeamInfo(id=1, name="Tigers"),
+        away=TeamInfo(id=2, name="Raiders"),
+        kickoff="2026-05-01T08:00:00+00:00",
+        predictedWinner="home",
+        homeWinProbability=0.65,
+        modelVersion="abc123",
+        featureHash=_feature_hash(),
+    )
+    store.put(2026, 8, [pred])
+    loaded = store.get(2026, 8)
+    assert len(loaded) == 1
+    assert loaded[0].matchId == pred.matchId
+    assert loaded[0].homeWinProbability == pred.homeWinProbability
+    assert loaded[0].predictedWinner == "home"
+
+
+def test_store_put_is_idempotent(store: PredictionStore) -> None:
+    pred = PredictionOut(
+        matchId=99,
+        home=TeamInfo(id=3, name="A"),
+        away=TeamInfo(id=4, name="B"),
+        kickoff="2026-05-01T08:00:00+00:00",
+        predictedWinner="away",
+        homeWinProbability=0.3,
+        modelVersion="v1",
+        featureHash="fh1",
+    )
+    store.put(2026, 8, [pred])
+    store.put(2026, 8, [pred])  # second put replaces
+    assert len(store.get(2026, 8)) == 1
+
+
+# ---------------------------------------------------------------------------
+# compute_predictions unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_compute_returns_cached_without_scraping(
+    store: PredictionStore, sqlite_repo: SQLiteRepository
+) -> None:
+    pred = PredictionOut(
+        matchId=1,
+        home=TeamInfo(id=1, name="Home"),
+        away=TeamInfo(id=2, name="Away"),
+        kickoff="2026-05-01T08:00:00+00:00",
+        predictedWinner="home",
+        homeWinProbability=0.7,
+        modelVersion="m1",
+        featureHash="f1",
+    )
+    store.put(2026, 8, [pred])
+
+    mock_fetch_round = MagicMock()
+    result = compute_predictions(2026, 8, sqlite_repo, store, fetch_round_fn=mock_fetch_round)
+    mock_fetch_round.assert_not_called()
+    assert len(result) == 1
+    assert result[0].matchId == 1
+
+
+def test_compute_raises_file_not_found_when_no_model(
+    store: PredictionStore, sqlite_repo: SQLiteRepository, tmp_path: Path
+) -> None:
+    mock_round = MagicMock(return_value=_sample_round_payload("/some/url"))
+    mock_match = MagicMock(return_value=_load_fixture(UPCOMING_FIXTURE))
+    with pytest.raises(FileNotFoundError):
+        compute_predictions(
+            2026,
+            8,
+            sqlite_repo,
+            store,
+            model_path=tmp_path / "missing.joblib",
+            fetch_round_fn=mock_round,
+            fetch_match_fn=mock_match,
+        )
+
+
+def test_compute_cache_miss_scrapes_and_stores(
+    store: PredictionStore, sqlite_repo: SQLiteRepository, tmp_path: Path
+) -> None:
+    raw_match = _load_fixture(UPCOMING_FIXTURE)
+    mock_round = MagicMock(return_value=_sample_round_payload("/match/url"))
+    mock_match = MagicMock(return_value=raw_match)
+    mock_model = _make_mock_model(0.72)
+    model_path = tmp_path / "model.joblib"
+    model_path.write_bytes(b"fake-model-bytes")
+
+    with patch("fantasy_coach.predictions.load_model", return_value=mock_model):
+        result = compute_predictions(
+            2026,
+            8,
+            sqlite_repo,
+            store,
+            model_path=model_path,
+            fetch_round_fn=mock_round,
+            fetch_match_fn=mock_match,
+        )
+
+    assert len(result) == 1
+    p = result[0]
+    match = extract_match_features(raw_match)
+    assert p.matchId == match.match_id
+    assert p.home.id == match.home.team_id
+    assert p.away.id == match.away.team_id
+    assert p.homeWinProbability == 0.72
+    assert p.predictedWinner == "home"
+
+    # Verify it's now cached
+    cached = store.get(2026, 8)
+    assert len(cached) == 1
+    assert cached[0].matchId == p.matchId
+
+
+def test_compute_returns_empty_when_no_fixtures(
+    store: PredictionStore, sqlite_repo: SQLiteRepository, tmp_path: Path
+) -> None:
+    model_path = tmp_path / "model.joblib"
+    model_path.write_bytes(b"bytes")
+    mock_round = MagicMock(return_value={"fixtures": []})
+
+    with patch("fantasy_coach.predictions.load_model", return_value=_make_mock_model()):
+        result = compute_predictions(
+            2026,
+            9,
+            sqlite_repo,
+            store,
+            model_path=model_path,
+            fetch_round_fn=mock_round,
+        )
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# /predictions endpoint integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_app_store():
+    """Reset module-level store so tests don't share state."""
+    import fantasy_coach.app as app_module
+
+    app_module._store = None
+    yield
+    app_module._store = None
+
+
+def _endpoint_patches(tmp_path: Path):
+    """Patch both IO sinks the endpoint touches so tests stay hermetic."""
+    return (
+        patch("fantasy_coach.app.get_repository", return_value=MagicMock()),
+        patch("fantasy_coach.app._get_store", return_value=PredictionStore(path=tmp_path / "p.db")),
+    )
+
+
+def test_endpoint_returns_503_when_no_model(client: TestClient, tmp_path: Path) -> None:
+    p1, p2 = _endpoint_patches(tmp_path)
+    with (
+        p1,
+        p2,
+        patch(
+            "fantasy_coach.app.compute_predictions",
+            side_effect=FileNotFoundError(tmp_path / "missing.joblib"),
+        ),
+    ):
+        response = client.get("/predictions?season=2026&round=8")
+    assert response.status_code == 503
+
+
+def test_endpoint_returns_predictions(client: TestClient, tmp_path: Path) -> None:
+    raw = _load_fixture(UPCOMING_FIXTURE)
+    match = extract_match_features(raw)
+    expected = [
+        PredictionOut(
+            matchId=match.match_id,
+            home=TeamInfo(id=match.home.team_id, name=match.home.name),
+            away=TeamInfo(id=match.away.team_id, name=match.away.name),
+            kickoff=match.start_time.isoformat(),
+            predictedWinner="home",
+            homeWinProbability=0.65,
+            modelVersion="abc123",
+            featureHash=_feature_hash(),
+        )
+    ]
+    p1, p2 = _endpoint_patches(tmp_path)
+    with p1, p2, patch("fantasy_coach.app.compute_predictions", return_value=expected):
+        response = client.get("/predictions?season=2026&round=8")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body, list)
+    assert len(body) == 1
+    pred = body[0]
+    assert pred["matchId"] == match.match_id
+    assert pred["predictedWinner"] == "home"
+    assert pred["homeWinProbability"] == 0.65
+    assert pred["modelVersion"] == "abc123"
+    assert "featureHash" in pred


### PR DESCRIPTION
## Summary

- Adds `GET /predictions?season=&round=` endpoint backed by SQLite prediction cache (`PredictionStore`)
- Cache hit returns stored predictions without re-scraping NRL.com; cache miss scrapes fixtures, runs the logistic model, stores and returns results
- Returns `503` with guidance when the model artefact is missing
- `PredictionOut` schema uses camelCase field names per JSON API spec (`matchId`, `predictedWinner`, `homeWinProbability`, `modelVersion`, `featureHash`)
- `compute_predictions()` is fully injectable (model path, fetch functions) for hermetic unit tests

## Test plan

- [x] `PredictionStore.get()` returns `[]` when empty
- [x] `PredictionStore.put()` + `get()` round-trips a prediction correctly
- [x] `put()` is idempotent (INSERT OR REPLACE)
- [x] `compute_predictions()` returns cached result without calling fetch functions
- [x] `compute_predictions()` raises `FileNotFoundError` when model artefact is missing
- [x] Cache miss: scrapes, stores, returns correct predictions
- [x] Returns `[]` when round has no fixtures
- [x] `GET /predictions` → 503 when model is missing
- [x] `GET /predictions` → 200 with correct prediction JSON

Closes #18

https://claude.ai/code/session_011iqEW7xD7ZFj3er9oFdmg8