### PR TITLE
feat(web): round predictions UI with match cards (closes #21)

### DIFF
--- a/web/src/components/MatchCard.tsx
+++ b/web/src/components/MatchCard.tsx
@@ -1,0 +1,58 @@
+import type { Prediction } from "../types";
+
+function formatKickoff(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function MatchCard({ prediction, preview }: { prediction: Prediction; preview?: string }) {
+  const p = prediction;
+  const homePct = Math.round(p.homeWinProbability * 100);
+  const awayPct = 100 - homePct;
+  const winnerName = p.predictedWinner === "home" ? p.home.name : p.away.name;
+  const winnerPct = p.predictedWinner === "home" ? homePct : awayPct;
+
+  return (
+    <article className="match-card" aria-label={`${p.home.name} vs ${p.away.name}`}>
+      <header className="match-card-head">
+        <div className="teams">
+          <span className="team home">{p.home.name}</span>
+          <span className="muted"> vs </span>
+          <span className="team away">{p.away.name}</span>
+        </div>
+        <time className="kickoff muted" dateTime={p.kickoff}>
+          {formatKickoff(p.kickoff)}
+        </time>
+      </header>
+
+      <div className="prob-bar" role="img" aria-label={`Home win probability ${homePct}%`}>
+        <span
+          className="prob-bar-home"
+          style={{ width: `${homePct}%` }}
+          aria-hidden="true"
+        />
+      </div>
+      <div className="prob-labels">
+        <span>
+          <strong>{p.home.name}</strong> {homePct}%
+        </span>
+        <span>
+          {awayPct}% <strong>{p.away.name}</strong>
+        </span>
+      </div>
+
+      <p className="pick">
+        Pick: <strong>{winnerName}</strong> ({winnerPct}%)
+      </p>
+
+      {preview ? <p className="preview">{preview}</p> : null}
+    </article>
+  );
+}

--- a/web/src/components/RoundSelector.tsx
+++ b/web/src/components/RoundSelector.tsx
@@ -1,0 +1,45 @@
+import { useState, type FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+
+type Props = {
+  initialSeason?: number;
+  initialRound?: number;
+};
+
+export function RoundSelector({ initialSeason, initialRound }: Props) {
+  const now = new Date();
+  const [season, setSeason] = useState<number>(initialSeason ?? now.getFullYear());
+  const [round, setRound] = useState<number>(initialRound ?? 1);
+  const navigate = useNavigate();
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    navigate(`/round/${season}/${round}`);
+  }
+
+  return (
+    <form className="round-selector" onSubmit={handleSubmit}>
+      <label>
+        Season
+        <input
+          type="number"
+          value={season}
+          min={2020}
+          max={now.getFullYear() + 1}
+          onChange={(e) => setSeason(Number(e.target.value))}
+        />
+      </label>
+      <label>
+        Round
+        <input
+          type="number"
+          value={round}
+          min={1}
+          max={30}
+          onChange={(e) => setRound(Number(e.target.value))}
+        />
+      </label>
+      <button type="submit">View predictions</button>
+    </form>
+  );
+}

--- a/web/src/routes/Home.tsx
+++ b/web/src/routes/Home.tsx
@@ -1,20 +1,23 @@
-import { Link } from "react-router-dom";
+import { useAuth } from "../auth";
+import { RoundSelector } from "../components/RoundSelector";
+import { SignInRequired } from "../components/SignInRequired";
 
 export default function Home() {
-  const now = new Date();
-  const season = now.getFullYear();
+  const { user, loading } = useAuth();
+
+  if (loading) return <p>Loading…</p>;
+
   return (
     <section>
       <h1>Predictions</h1>
       <p>
         Pick a round to see predicted winners and home-win probabilities for every match.
       </p>
-      <p>
-        Example:{" "}
-        <Link to={`/round/${season}/1`}>
-          /round/{season}/1
-        </Link>
-      </p>
+      {user ? (
+        <RoundSelector />
+      ) : (
+        <SignInRequired message="Sign in to pick a round and view predictions." />
+      )}
     </section>
   );
 }

--- a/web/src/routes/Round.tsx
+++ b/web/src/routes/Round.tsx
@@ -1,21 +1,91 @@
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
+import { apiFetch, ApiError, NotSignedInError } from "../api";
 import { useAuth } from "../auth";
+import { MatchCard } from "../components/MatchCard";
+import { RoundSelector } from "../components/RoundSelector";
 import { SignInRequired } from "../components/SignInRequired";
+import type { Prediction } from "../types";
+
+type Status =
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "ok"; predictions: Prediction[] };
 
 export default function Round() {
-  const { season, round } = useParams();
-  const { user, loading } = useAuth();
+  const { season: seasonParam, round: roundParam } = useParams();
+  const { user, loading: authLoading } = useAuth();
+  const [status, setStatus] = useState<Status>({ kind: "loading" });
 
-  if (loading) return <p>Loading…</p>;
+  const season = Number(seasonParam);
+  const round = Number(roundParam);
+  const paramsValid = Number.isFinite(season) && Number.isFinite(round);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) return;
+    if (!paramsValid) {
+      setStatus({ kind: "error", message: "Season and round must be numbers." });
+      return;
+    }
+
+    let cancelled = false;
+    setStatus({ kind: "loading" });
+    apiFetch<Prediction[]>(`/predictions?season=${season}&round=${round}`)
+      .then((predictions) => {
+        if (!cancelled) setStatus({ kind: "ok", predictions });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof NotSignedInError) {
+          setStatus({ kind: "error", message: "Sign in required." });
+        } else if (err instanceof ApiError) {
+          setStatus({
+            kind: "error",
+            message: `Couldn't load predictions (HTTP ${err.status}). ${err.message}`,
+          });
+        } else {
+          setStatus({ kind: "error", message: "Couldn't reach the prediction API." });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, user, paramsValid, season, round]);
+
+  if (authLoading) return <p>Loading…</p>;
   if (!user) return <SignInRequired message="Sign in to see predictions for this round." />;
 
   return (
     <section>
-      <h1>
-        Round {round}, {season}
-      </h1>
-      <p>Predictions UI lands in #21.</p>
+      <header className="round-header">
+        <h1>
+          Round {round}, {season}
+        </h1>
+        <RoundSelector initialSeason={season} initialRound={round} />
+      </header>
+
+      {status.kind === "loading" && <p>Loading predictions…</p>}
+
+      {status.kind === "error" && (
+        <div className="error-box" role="alert">
+          {status.message}
+        </div>
+      )}
+
+      {status.kind === "ok" && status.predictions.length === 0 && (
+        <p className="muted">No predictions for this round yet.</p>
+      )}
+
+      {status.kind === "ok" && status.predictions.length > 0 && (
+        <div className="match-grid">
+          {status.predictions.map((p) => (
+            <MatchCard key={p.matchId} prediction={p} />
+          ))}
+        </div>
+      )}
     </section>
   );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -76,3 +76,133 @@ button:hover {
 .sign-in-required p {
   margin-top: 0;
 }
+
+.round-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+  margin: 1rem 0 2rem;
+}
+
+.round-selector label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: #444;
+}
+
+.round-selector input {
+  font: inherit;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  width: 6.5rem;
+}
+
+.round-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.round-header h1 {
+  margin: 0;
+}
+
+.round-header .round-selector {
+  margin: 0;
+}
+
+.error-box {
+  padding: 1rem 1.25rem;
+  border-left: 3px solid #c0392b;
+  background: #fdecea;
+  border-radius: 4px;
+  color: #5a1a13;
+}
+
+.match-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 640px) {
+  .match-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 960px) {
+  .match-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.match-card {
+  padding: 1rem;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.match-card-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
+.teams {
+  font-size: 1.05rem;
+}
+
+.team {
+  font-weight: 600;
+}
+
+.kickoff {
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.prob-bar {
+  height: 0.6rem;
+  background: #e0e0e0;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.prob-bar-home {
+  display: block;
+  height: 100%;
+  background: #1a1a1a;
+}
+
+.prob-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: #444;
+}
+
+.pick {
+  margin: 0.25rem 0 0;
+  font-size: 0.95rem;
+}
+
+.preview {
+  margin: 0.5rem 0 0;
+  color: #333;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,0 +1,15 @@
+export type Team = {
+  id: number;
+  name: string;
+};
+
+export type Prediction = {
+  matchId: number;
+  home: Team;
+  away: Team;
+  kickoff: string; // ISO 8601 UTC
+  predictedWinner: "home" | "away";
+  homeWinProbability: number; // 0..1
+  modelVersion: string;
+  featureHash: string;
+};


### PR DESCRIPTION
## Summary
- Stacked on #69 (auth wiring). Base will be re-targeted to `main` before merge.
- Adds a round selector (season + round inputs) that navigates to `/round/:season/:round`.
- Fetches `GET /predictions?season=…&round=…` via `apiFetch`, with distinct **loading** / **error** / **empty** / **ok** states.
- Match cards render teams, kickoff in the user's local timezone, home-win probability as a bar + % labels, a pick line, and a preview slot that renders only when populated (graceful fallback until the Gemini commentary issue lands).

## Out of scope / follow-ups
- **"Next upcoming round" default**: AC asks for this; we currently default to the current calendar year + round 1. Needs an API endpoint exposing next fixture, which is a separate backlog item.
- Team logos, calibration tooltips, and model-version badges are intentionally deferred to the match-detail page (#58) so this view stays skim-friendly.

## Acceptance criteria
- [x] Round selector (season + round picker)
- [x] Match cards: home vs away, predicted winner, home-win probability visualised (bar), kickoff in user's local TZ
- [x] Slot for preview paragraph (rendered only when populated)
- [x] Distinct loading and error states
- [x] Responsive grid — 1 / 2 / 3 cols at 0 / 640 / 960 px
- [x] Works without Gemini previews (preview slot is a no-op when absent)
- [ ] "Next upcoming round" default — deferred, noted above

## Test plan
- [x] `npm run build` green (101 kB gzipped, +1 kB over auth wiring)
- [x] `npm run dev` starts cleanly on :5173
- [ ] Web CI green on this PR
- [ ] Manual round-selector → fetch path once Cloud Run URL + Firebase config are in env (covered by follow-up with live secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)