### PR TITLE
chore(deploy): defer Firestore + Secret Manager wiring until infra lands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,9 +71,12 @@ jobs:
             --port 8080 \
             --execution-environment gen2 \
             --service-account "fantasy-coach-runtime@${PROJECT_ID}.iam.gserviceaccount.com" \
-            --set-secrets "FIREBASE_PROJECT_ID=firebase-project-id:latest" \
-            --set-env-vars "STORAGE_BACKEND=firestore" \
             --quiet
+          # Re-add once platform-infra provisions the matching infra:
+          #   --set-secrets "FIREBASE_PROJECT_ID=firebase-project-id:latest" \   # needs #16 (Secret Manager)
+          #   --set-env-vars "STORAGE_BACKEND=firestore" \                       # needs #15 (Firestore DB)
+          # Until then, auth.py falls back to GOOGLE_CLOUD_PROJECT (auto-set by
+          # Cloud Run) and config.py defaults STORAGE_BACKEND to sqlite.
 
       - name: Smoke-test /healthz
         env:


### PR DESCRIPTION
## Summary
Cloud Run deploy has been red on every push to \`main\` since #18 merged. Root cause: \`deploy.yml\` references Secret Manager + Firestore that platform-infra hasn't provisioned yet.

\`\`\`
--set-secrets \"FIREBASE_PROJECT_ID=firebase-project-id:latest\"  # needs #16
--set-env-vars \"STORAGE_BACKEND=firestore\"                      # needs #15
\`\`\`

This PR comments both out so deploy is green today. Reinstating them is a two-line change once the infra lands.

## Why this is safe
- \`src/fantasy_coach/auth.py\` already falls back to \`GOOGLE_CLOUD_PROJECT\` (Cloud Run auto-injects it) when \`FIREBASE_PROJECT_ID\` is unset.
- \`src/fantasy_coach/config.py\` defaults \`STORAGE_BACKEND\` to \`sqlite\` — so the service runs on an ephemeral per-revision SQLite file, fine for \`/healthz\` and fine until #15 lands.

Behaviour change vs. intent: the prediction cache is per-revision until Firestore is wired (Cloud Run cold starts drop it). Acceptable given there's no live traffic yet.

## Test plan
- [ ] Deploy workflow succeeds on merge to \`main\`
- [ ] \`/healthz\` returns 200 via Cloud Run's auth'd URL
- [ ] \`curl /predictions\` returns a sensible error (likely model-not-trained, not an infra error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)