### PR TITLE
chore(deploy): drop external /healthz smoke test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,18 +78,11 @@ jobs:
           # Until then, auth.py falls back to GOOGLE_CLOUD_PROJECT (auto-set by
           # Cloud Run) and config.py defaults STORAGE_BACKEND to sqlite.
 
-      - name: Smoke-test /healthz
-        env:
-          PROJECT_ID: ${{ secrets.FANTASY_COACH_PROJECT_ID }}
-        run: |
-          URL=$(gcloud run services describe "${SERVICE}" \
-                  --project "${PROJECT_ID}" --region "${REGION}" \
-                  --format 'value(status.url)')
-          TOKEN=$(gcloud auth print-identity-token)
-          STATUS=$(curl -s -o /tmp/healthz -w "%{http_code}" \
-                     -H "Authorization: Bearer ${TOKEN}" "${URL}/healthz")
-          cat /tmp/healthz
-          if [ "${STATUS}" != "200" ]; then
-            echo "::error::healthz returned ${STATUS}"
-            exit 1
-          fi
+      # The external /healthz smoke test has been dropped: `gcloud auth
+      # print-identity-token` doesn't work with WIF-federated credentials
+      # (they're OAuth2 access tokens, not OIDC ID tokens), and Cloud Run's
+      # own liveness/startup probe already fails the deploy if /healthz
+      # doesn't return 200 before the revision goes Ready. Re-adding an
+      # external smoke test would need `google-github-actions/auth@v3` with
+      # `token_format: id_token` + a known audience URL — a small follow-up
+      # if we want a second signal.


### PR DESCRIPTION
## Summary
Cloud Run deploy was red on the post-#73 run because of the smoke-test step, not the deploy itself:
\`\`\`
ERROR: (gcloud.auth.print-identity-token) No identity token can be obtained from the current credentials.
\`\`\`
WIF-federated credentials are OAuth2 access tokens, not OIDC ID tokens, so \`print-identity-token\` can't mint one.

## Why the smoke test isn't load-bearing
The Cloud Run revision already has a \`startupProbe\` *and* a \`livenessProbe\` both on \`/healthz\` (see \`cloudrun.tf\` in platform-infra). If either fails, the Revision never goes Ready and \`gcloud run deploy\` fails the step. An external curl right after that just restates what the deploy's own gate has already proven.

## Follow-up (not in this PR)
If we want a second signal from CI (e.g. to verify IAM routing), the recipe is:
- \`google-github-actions/auth@v3\` with \`token_format: id_token\` and \`id_token_audience: <service URL>\`, or
- \`gcloud auth print-identity-token --impersonate-service-account=<runtime-SA> --audiences=<URL>\`
Both need the service URL at auth time; the current workflow discovers the URL only after deploy.

## Test plan
- [ ] Deploy workflow goes green end-to-end on merge to \`main\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)