### PR TITLE
feat(models): probability calibration layer — Platt & isotonic (closes #53)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,11 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "SIM"]
 [tool.ruff.lint.per-file-ignores]
 # sklearn convention: capital X for the feature matrix, capital C for regularisation.
 "src/fantasy_coach/models/logistic.py" = ["N803", "N806"]
+"src/fantasy_coach/models/calibration.py" = ["N803", "N806"]
+"src/fantasy_coach/evaluation/predictors.py" = ["N806"]
 "src/fantasy_coach/feature_engineering.py" = ["N806"]
 "tests/test_logistic.py" = ["N806"]
+"tests/test_calibration.py" = ["N806"]
 # JSON API spec requires camelCase field names in the response schema.
 "src/fantasy_coach/predictions.py" = ["N815"]
 

--- a/src/fantasy_coach/evaluation/__init__.py
+++ b/src/fantasy_coach/evaluation/__init__.py
@@ -3,8 +3,9 @@ from fantasy_coach.evaluation.harness import (
     Prediction,
     walk_forward,
 )
-from fantasy_coach.evaluation.metrics import accuracy, brier_score, log_loss
+from fantasy_coach.evaluation.metrics import accuracy, brier_score, ece, log_loss
 from fantasy_coach.evaluation.predictors import (
+    CalibratedLogisticPredictor,
     EloPredictor,
     HomePickPredictor,
     LogisticPredictor,
@@ -12,6 +13,7 @@ from fantasy_coach.evaluation.predictors import (
 )
 
 __all__ = [
+    "CalibratedLogisticPredictor",
     "EloPredictor",
     "EvaluationResult",
     "HomePickPredictor",
@@ -20,6 +22,7 @@ __all__ = [
     "Predictor",
     "accuracy",
     "brier_score",
+    "ece",
     "log_loss",
     "walk_forward",
 ]

--- a/src/fantasy_coach/evaluation/harness.py
+++ b/src/fantasy_coach/evaluation/harness.py
@@ -16,7 +16,7 @@ import logging
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 
-from fantasy_coach.evaluation.metrics import accuracy, brier_score, log_loss
+from fantasy_coach.evaluation.metrics import accuracy, brier_score, ece, log_loss
 from fantasy_coach.evaluation.predictors import Predictor
 from fantasy_coach.features import MatchRow
 from fantasy_coach.storage.repository import Repository
@@ -57,6 +57,7 @@ class EvaluationResult:
             "accuracy": accuracy(self.probs, self.actuals),
             "log_loss": log_loss(self.probs, self.actuals),
             "brier": brier_score(self.probs, self.actuals),
+            "ece": ece(self.probs, self.actuals),
         }
 
 

--- a/src/fantasy_coach/evaluation/metrics.py
+++ b/src/fantasy_coach/evaluation/metrics.py
@@ -29,3 +29,10 @@ def brier_score(probs: Sequence[float], outcomes: Sequence[int]) -> float:
     if not probs:
         return float("nan")
     return sum((p - y) ** 2 for p, y in zip(probs, outcomes, strict=True)) / len(probs)
+
+
+def ece(probs: Sequence[float], outcomes: Sequence[int], n_bins: int = 10) -> float:
+    """Expected Calibration Error — delegates to the calibration module."""
+    from fantasy_coach.models.calibration import ece as _ece
+
+    return _ece(probs, outcomes, n_bins=n_bins)

--- a/src/fantasy_coach/evaluation/predictors.py
+++ b/src/fantasy_coach/evaluation/predictors.py
@@ -17,8 +17,9 @@ from fantasy_coach.feature_engineering import (
     build_training_frame,
 )
 from fantasy_coach.features import MatchRow
+from fantasy_coach.models.calibration import CalibrationMethod, CalibrationWrapper
 from fantasy_coach.models.elo import Elo
-from fantasy_coach.models.logistic import train_logistic
+from fantasy_coach.models.logistic import TrainResult, train_logistic
 
 
 class Predictor(Protocol):
@@ -96,6 +97,74 @@ class EloPredictor:
     @property
     def elo(self) -> Elo:
         return self._elo
+
+
+class CalibratedLogisticPredictor:
+    """LogReg predictor with Platt-scaling calibration on a held-out fold.
+
+    Splits each round's available history into:
+    - first 80% (chronological) → base model training
+    - last 20% → calibration fitting
+
+    Falls back to the uncalibrated prediction when there are fewer than 20
+    rows of history (not enough for a meaningful calibration split).
+    """
+
+    name = "logistic+cal"
+
+    def __init__(self, method: CalibrationMethod = "platt") -> None:
+        self._method = method
+        self._train_result: TrainResult | None = None
+        self._calibration_wrapper: CalibrationWrapper | None = None
+        self._inference_builder = FeatureBuilder()
+
+    def fit(self, history: Sequence[MatchRow]) -> None:
+        frame = build_training_frame(history)
+        if frame.X.shape[0] < 20:
+            self._train_result = None
+            self._calibration_wrapper = None
+        else:
+            n = frame.X.shape[0]
+            order = np.argsort(frame.start_times)
+            X = frame.X[order]
+            y = frame.y[order]
+
+            split = int(n * 0.8)
+            X_train, y_train = X[:split], y[:split]
+            X_cal, y_cal = X[split:], y[split:]
+
+            # Train base model on the 80% training partition.
+            self._train_result = train_logistic(
+                frame.__class__(
+                    X=X_train,
+                    y=y_train,
+                    match_ids=frame.match_ids[order][:split],
+                    start_times=frame.start_times[order][:split],
+                    feature_names=frame.feature_names,
+                ),
+                test_fraction=0.0,
+            )
+
+            # Fit calibrator on the held-out 20%.
+            self._calibration_wrapper = CalibrationWrapper(
+                self._train_result.pipeline, method=self._method
+            )
+            self._calibration_wrapper.fit(X_cal, y_cal)
+
+        self._inference_builder = FeatureBuilder()
+        for match in sorted(history, key=lambda m: (m.start_time, m.match_id)):
+            if match.home.score is None or match.away.score is None:
+                continue
+            self._inference_builder.advance_season_if_needed(match)
+            self._inference_builder.record(match)
+
+    def predict_home_win_prob(self, match: MatchRow) -> float:
+        if self._train_result is None:
+            return 0.55
+        x = np.asarray([self._inference_builder.feature_row(match)], dtype=float)
+        if self._calibration_wrapper is not None and self._calibration_wrapper.is_fitted:
+            return float(self._calibration_wrapper.predict_home_win_prob(x)[0])
+        return float(self._train_result.pipeline.predict_proba(x)[0, 1])
 
 
 class LogisticPredictor:

--- a/src/fantasy_coach/evaluation/report.py
+++ b/src/fantasy_coach/evaluation/report.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import Path
 
 from fantasy_coach.evaluation.harness import EvaluationResult
+from fantasy_coach.models.calibration import reliability_bins
 
 
 def render_markdown(
@@ -26,16 +27,42 @@ def render_markdown(
         "predict that round, score against actuals. Draws are dropped from "
         "scoring (binary metrics).",
         "",
-        "| Model | n predictions | Accuracy | Log loss | Brier |",
-        "|-------|---------------|----------|----------|-------|",
+        "| Model | n predictions | Accuracy | Log loss | Brier | ECE |",
+        "|-------|---------------|----------|----------|-------|-----|",
     ]
     for result in results:
         m = result.metrics()
+        ece_val = m.get("ece", float("nan"))
+        ece_str = f"{ece_val:.3f}" if ece_val == ece_val else "n/a"  # NaN check
         lines.append(
             f"| {result.predictor_name} | {result.n} | "
-            f"{m['accuracy']:.3f} | {m['log_loss']:.3f} | {m['brier']:.3f} |"
+            f"{m['accuracy']:.3f} | {m['log_loss']:.3f} | {m['brier']:.3f} | {ece_str} |"
         )
     lines.append("")
+
+    # Reliability diagrams — one section per model.
+    lines.append("## Reliability diagrams")
+    lines.append("")
+    lines.append(
+        "Each row is a probability bin. A well-calibrated model has "
+        "`mean_confidence ≈ mean_accuracy` in every bin."
+    )
+    lines.append("")
+
+    for result in results:
+        if not result.predictions:
+            continue
+        bins = reliability_bins(result.probs, result.actuals)
+        lines.append(f"### {result.predictor_name}")
+        lines.append("")
+        lines.append("| Bin | Mean confidence | Mean accuracy | n |")
+        lines.append("|-----|----------------|---------------|---|")
+        for b in bins:
+            conf = f"{b['mean_confidence']:.3f}" if b["mean_confidence"] is not None else "—"
+            acc = f"{b['mean_accuracy']:.3f}" if b["mean_accuracy"] is not None else "—"
+            lines.append(f"| {b['lo']:.1f}–{b['hi']:.1f} | {conf} | {acc} | {b['n']} |")
+        lines.append("")
+
     return "\n".join(lines)
 
 

--- a/src/fantasy_coach/models/calibration.py
+++ b/src/fantasy_coach/models/calibration.py
@@ -1,0 +1,155 @@
+"""Probability calibration wrapper for sklearn-based predictors.
+
+Supports two methods:
+- 'platt' (sigmoid): linear scaling in log-odds space; default for LogReg
+- 'isotonic': non-parametric monotonic regression; default for XGBoost
+
+Fitting always uses a **held-out fold** — never the same data the base model
+trained on.  Pass the last 20% of the time-ordered training frame as the
+calibration set.
+
+Decision: use 'platt' for LogReg, 'isotonic' for XGBoost (tree models have
+more extreme confidence near 0/1 which isotonic handles better than Platt's
+linear correction).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Literal
+
+import numpy as np
+from sklearn.isotonic import IsotonicRegression
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+
+CalibrationMethod = Literal["platt", "isotonic"]
+
+
+@dataclass
+class CalibrationWrapper:
+    """Wraps a fitted sklearn Pipeline and adjusts its probability output.
+
+    Calibration is applied as a post-hoc mapping from raw probability scores
+    to calibrated probabilities, fitted on a **held-out** calibration set:
+
+    - ``platt``: logistic regression fit on log-odds(raw_prob).  Cheap,
+      assumes the raw scores are monotone and need only a linear correction.
+      Default for LogReg.
+    - ``isotonic``: non-parametric monotone regression.  More flexible but
+      needs a larger calibration set (n_cal ≥ 500 recommended).  Default for
+      XGBoost.
+
+    After ``fit(X_cal, y_cal)``, ``predict_home_win_prob`` returns calibrated
+    probabilities.  Before fitting it falls back to the raw pipeline.
+    """
+
+    pipeline: Pipeline
+    method: CalibrationMethod = "platt"
+    _calibrator: LogisticRegression | IsotonicRegression | None = field(
+        default=None, init=False, repr=False
+    )
+
+    def fit(self, X_cal: np.ndarray, y_cal: np.ndarray) -> CalibrationWrapper:
+        raw = self.pipeline.predict_proba(X_cal)[:, 1]
+        if self.method == "platt":
+            # Platt scaling: logistic regression on the raw probability scores.
+            self._calibrator = LogisticRegression(C=1.0, max_iter=1000)
+            self._calibrator.fit(raw.reshape(-1, 1), y_cal)
+        else:
+            self._calibrator = IsotonicRegression(out_of_bounds="clip")
+            self._calibrator.fit(raw, y_cal)
+        return self
+
+    def predict_proba(self, X: np.ndarray) -> np.ndarray:
+        raw = self.pipeline.predict_proba(X)[:, 1]
+        if self._calibrator is None:
+            cal = raw
+        elif isinstance(self._calibrator, LogisticRegression):
+            cal = self._calibrator.predict_proba(raw.reshape(-1, 1))[:, 1]
+        else:
+            cal = self._calibrator.predict(raw)
+        proba = np.column_stack([1.0 - cal, cal])
+        return proba
+
+    def predict_home_win_prob(self, X: np.ndarray) -> np.ndarray:
+        return self.predict_proba(X)[:, 1]
+
+    @property
+    def is_fitted(self) -> bool:
+        return self._calibrator is not None
+
+
+def ece(
+    probs: Sequence[float],
+    outcomes: Sequence[int],
+    n_bins: int = 10,
+) -> float:
+    """Expected Calibration Error (equal-width bins, weighted by bin size).
+
+    A value of 0.0 means perfectly calibrated; a well-tuned model should
+    achieve ECE < 0.05.
+    """
+    p = np.asarray(probs, dtype=float)
+    y = np.asarray(outcomes, dtype=float)
+    n = len(p)
+    if n == 0:
+        return float("nan")
+
+    bin_edges = np.linspace(0.0, 1.0, n_bins + 1)
+    total_error = 0.0
+
+    for lo, hi in zip(bin_edges[:-1], bin_edges[1:], strict=True):
+        mask = (p >= lo) & (p < hi)
+        if not np.any(mask):
+            continue
+        bin_size = int(np.sum(mask))
+        avg_conf = float(np.mean(p[mask]))
+        avg_acc = float(np.mean(y[mask]))
+        total_error += (bin_size / n) * abs(avg_acc - avg_conf)
+
+    return total_error
+
+
+def reliability_bins(
+    probs: Sequence[float],
+    outcomes: Sequence[int],
+    n_bins: int = 10,
+) -> list[dict[str, object]]:
+    """Per-bin data for a reliability diagram.
+
+    Each entry: ``{lo, hi, mean_confidence, mean_accuracy, n}``.
+    Bins with no predictions have ``mean_confidence`` and ``mean_accuracy``
+    set to ``None``.
+    """
+    p = np.asarray(probs, dtype=float)
+    y = np.asarray(outcomes, dtype=float)
+    bin_edges = np.linspace(0.0, 1.0, n_bins + 1)
+    bins: list[dict[str, object]] = []
+
+    for lo, hi in zip(bin_edges[:-1], bin_edges[1:], strict=True):
+        mask = (p >= lo) & (p < hi)
+        n = int(np.sum(mask))
+        if n == 0:
+            bins.append(
+                {
+                    "lo": float(lo),
+                    "hi": float(hi),
+                    "mean_confidence": None,
+                    "mean_accuracy": None,
+                    "n": 0,
+                }
+            )
+        else:
+            bins.append(
+                {
+                    "lo": float(lo),
+                    "hi": float(hi),
+                    "mean_confidence": float(np.mean(p[mask])),
+                    "mean_accuracy": float(np.mean(y[mask])),
+                    "n": n,
+                }
+            )
+
+    return bins

--- a/src/fantasy_coach/models/logistic.py
+++ b/src/fantasy_coach/models/logistic.py
@@ -18,6 +18,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 
 from fantasy_coach.feature_engineering import FEATURE_NAMES, TrainingFrame
+from fantasy_coach.models.calibration import CalibrationWrapper
 
 
 @dataclass(frozen=True)
@@ -80,20 +81,29 @@ def train_logistic(
     )
 
 
-def save_model(result: TrainResult, path: Path | str) -> None:
-    """Persist the trained pipeline + feature-name ordering to disk."""
+def save_model(
+    result: TrainResult,
+    path: Path | str,
+    calibration_wrapper: CalibrationWrapper | None = None,
+) -> None:
+    """Persist the trained pipeline + feature-name ordering to disk.
+
+    If ``calibration_wrapper`` is provided it is saved alongside the pipeline
+    so that ``load_model`` can return calibrated probabilities automatically.
+    """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    joblib.dump(
-        {"pipeline": result.pipeline, "feature_names": result.feature_names},
-        path,
-    )
+    blob: dict = {"pipeline": result.pipeline, "feature_names": result.feature_names}
+    if calibration_wrapper is not None:
+        blob["calibration_wrapper"] = calibration_wrapper
+    joblib.dump(blob, path)
 
 
 @dataclass(frozen=True)
 class LoadedModel:
     pipeline: Pipeline
     feature_names: tuple[str, ...]
+    calibration_wrapper: CalibrationWrapper | None = None
 
     def predict_home_win_prob(self, X: np.ndarray) -> np.ndarray:
         if X.shape[1] != len(self.feature_names):
@@ -101,6 +111,8 @@ class LoadedModel:
                 f"Expected {len(self.feature_names)} features "
                 f"({self.feature_names}), got {X.shape[1]}"
             )
+        if self.calibration_wrapper is not None and self.calibration_wrapper.is_fitted:
+            return self.calibration_wrapper.predict_home_win_prob(X)
         # Class labels in y are {0, 1}; column 1 is "home win".
         return self.pipeline.predict_proba(X)[:, 1]
 
@@ -115,4 +127,5 @@ def load_model(path: Path | str) -> LoadedModel:
     return LoadedModel(
         pipeline=blob["pipeline"],
         feature_names=tuple(blob["feature_names"]),
+        calibration_wrapper=blob.get("calibration_wrapper"),
     )

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,263 @@
+"""Tests for the probability calibration module."""
+
+from __future__ import annotations
+
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from fantasy_coach.models.calibration import (
+    CalibrationWrapper,
+    ece,
+    reliability_bins,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pipeline() -> Pipeline:
+    return Pipeline([("scale", StandardScaler()), ("lr", LogisticRegression(random_state=0))])
+
+
+def _synthetic_data(n: int = 200, seed: int = 0) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, 4))
+    # Simple linearly-separable target so the pipeline can actually fit.
+    y = (X[:, 0] + X[:, 1] > 0).astype(int)
+    return X, y
+
+
+# ---------------------------------------------------------------------------
+# CalibrationWrapper
+# ---------------------------------------------------------------------------
+
+
+def test_calibration_wrapper_platt_predict_before_fit():
+    """Before .fit(), wrapper should fall back to the raw pipeline."""
+    X, y = _synthetic_data()
+    pipe = _make_pipeline()
+    pipe.fit(X, y)
+    wrapper = CalibrationWrapper(pipe, method="platt")
+    assert not wrapper.is_fitted
+    raw = pipe.predict_proba(X)[:, 1]
+    wrapped = wrapper.predict_home_win_prob(X)
+    np.testing.assert_array_equal(raw, wrapped)
+
+
+def test_calibration_wrapper_platt_fit_and_predict():
+    """After fitting with Platt, predictions should be in [0, 1]."""
+    X, y = _synthetic_data(n=300)
+    pipe = _make_pipeline()
+    split = 200
+    pipe.fit(X[:split], y[:split])
+    wrapper = CalibrationWrapper(pipe, method="platt")
+    wrapper.fit(X[split:], y[split:])
+    assert wrapper.is_fitted
+    probs = wrapper.predict_home_win_prob(X[split:])
+    assert probs.shape == (100,)
+    assert float(probs.min()) >= 0.0
+    assert float(probs.max()) <= 1.0
+
+
+def test_calibration_wrapper_isotonic_fit_and_predict():
+    """After fitting with isotonic, predictions should be in [0, 1]."""
+    X, y = _synthetic_data(n=300)
+    pipe = _make_pipeline()
+    split = 200
+    pipe.fit(X[:split], y[:split])
+    wrapper = CalibrationWrapper(pipe, method="isotonic")
+    wrapper.fit(X[split:], y[split:])
+    assert wrapper.is_fitted
+    probs = wrapper.predict_home_win_prob(X[split:])
+    assert probs.shape == (100,)
+    assert float(probs.min()) >= 0.0
+    assert float(probs.max()) <= 1.0
+
+
+def test_calibration_wrapper_fit_is_fitted():
+    X, y = _synthetic_data(n=300)
+    pipe = _make_pipeline()
+    pipe.fit(X[:200], y[:200])
+    wrapper = CalibrationWrapper(pipe)
+    assert not wrapper.is_fitted
+    wrapper.fit(X[200:], y[200:])
+    assert wrapper.is_fitted
+
+
+def test_calibration_wrapper_platt_reduces_ece_on_overconfident_model():
+    """Platt calibration should reduce ECE relative to raw probabilities."""
+    X, y = _synthetic_data(n=500, seed=42)
+    pipe = _make_pipeline()
+    split_train, split_cal = 300, 400
+    pipe.fit(X[:split_train], y[:split_train])
+
+    raw_probs = pipe.predict_proba(X[split_cal:])[:, 1].tolist()
+    actuals = y[split_cal:].tolist()
+    raw_ece = ece(raw_probs, actuals)
+
+    wrapper = CalibrationWrapper(pipe, method="platt")
+    wrapper.fit(X[split_train:split_cal], y[split_train:split_cal])
+    cal_probs = wrapper.predict_home_win_prob(X[split_cal:]).tolist()
+    cal_ece = ece(cal_probs, actuals)
+
+    # Calibrated ECE should be <= raw (not always strictly lower with tiny
+    # datasets, but should never be materially worse — allow small tolerance).
+    assert cal_ece <= raw_ece + 0.05
+
+
+# ---------------------------------------------------------------------------
+# ece()
+# ---------------------------------------------------------------------------
+
+
+def test_ece_empty():
+    assert ece([], []) != ece([], [])  # NaN != NaN
+
+
+def test_ece_perfect_calibration():
+    # Perfect calibration: confidence == actual rate in every bin.
+    probs = [0.1] * 10 + [0.5] * 10 + [0.9] * 10
+    # Match outcomes at the exact stated probability.
+    rng = np.random.default_rng(0)
+    outcomes = []
+    for p in probs:
+        outcomes.append(int(rng.random() < p))
+    # ECE can't be exactly 0 with stochastic outcomes, but should be < 0.2.
+    result = ece(probs, outcomes)
+    assert 0.0 <= result <= 0.5
+
+
+def test_ece_overconfident():
+    # All probabilities near 1 but only 50% correct → high ECE.
+    probs = [0.95] * 20
+    outcomes = [1, 0] * 10
+    result = ece(probs, outcomes)
+    # Expected: |0.5 - 0.95| * 1.0 ≈ 0.45
+    assert result > 0.3
+
+
+def test_ece_underconfident():
+    # All probabilities near 0.5 but actual rate is 90% → high ECE.
+    probs = [0.5] * 20
+    outcomes = [1] * 18 + [0] * 2
+    result = ece(probs, outcomes)
+    # Expected: |0.9 - 0.5| = 0.4
+    assert result > 0.3
+
+
+def test_ece_single_bin():
+    probs = [0.6, 0.6, 0.6, 0.6]
+    outcomes = [1, 1, 0, 0]
+    result = ece(probs, outcomes)
+    # One bin: |0.5 - 0.6| * 1 = 0.1
+    assert abs(result - 0.1) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# reliability_bins()
+# ---------------------------------------------------------------------------
+
+
+def test_reliability_bins_count():
+    probs = list(np.linspace(0.05, 0.95, 50))
+    outcomes = [1 if p > 0.5 else 0 for p in probs]
+    bins = reliability_bins(probs, outcomes, n_bins=10)
+    assert len(bins) == 10
+
+
+def test_reliability_bins_empty_bin():
+    # All predictions in [0.9, 1.0] — first 9 bins should be empty.
+    probs = [0.95] * 20
+    outcomes = [1] * 20
+    bins = reliability_bins(probs, outcomes, n_bins=10)
+    for b in bins[:9]:
+        assert b["mean_confidence"] is None
+        assert b["mean_accuracy"] is None
+        assert b["n"] == 0
+    assert bins[9]["n"] == 20
+
+
+def test_reliability_bins_values():
+    probs = [0.15, 0.15, 0.15, 0.15]  # all in [0.1, 0.2] bin
+    outcomes = [1, 1, 0, 0]
+    bins = reliability_bins(probs, outcomes, n_bins=10)
+    populated = [b for b in bins if b["n"] > 0]
+    assert len(populated) == 1
+    b = populated[0]
+    assert abs(b["mean_confidence"] - 0.15) < 1e-9
+    assert abs(b["mean_accuracy"] - 0.5) < 1e-9
+    assert b["n"] == 4
+
+
+# ---------------------------------------------------------------------------
+# save / load round-trip via logistic.save_model / load_model
+# ---------------------------------------------------------------------------
+
+
+def test_save_load_with_calibrator(tmp_path):
+    from fantasy_coach.feature_engineering import TrainingFrame
+    from fantasy_coach.models.logistic import LoadedModel, load_model, save_model, train_logistic
+
+    rng = np.random.default_rng(0)
+    n = 60
+    X = rng.standard_normal((n, 6))
+    y = (X[:, 0] > 0).astype(int)
+    base = np.datetime64("2024-01-01", "s")
+    start_times = np.array(
+        [base + np.timedelta64(i * 7, "D") for i in range(n)], dtype="datetime64[s]"
+    )
+    match_ids = np.arange(n)
+
+    from fantasy_coach.feature_engineering import FEATURE_NAMES
+
+    frame = TrainingFrame(
+        X=X, y=y, match_ids=match_ids, start_times=start_times, feature_names=FEATURE_NAMES
+    )
+    result = train_logistic(frame, test_fraction=0.0)
+
+    cal_split = int(n * 0.8)
+    wrapper = CalibrationWrapper(result.pipeline, method="platt")
+    wrapper.fit(X[cal_split:], y[cal_split:])
+
+    path = tmp_path / "logistic.joblib"
+    save_model(result, path, calibration_wrapper=wrapper)
+
+    loaded: LoadedModel = load_model(path)
+    assert loaded.calibration_wrapper is not None
+    assert loaded.calibration_wrapper.is_fitted
+
+    # Predictions via LoadedModel should use the calibrator.
+    probs = loaded.predict_home_win_prob(X)
+    assert probs.shape == (n,)
+    assert float(probs.min()) >= 0.0
+    assert float(probs.max()) <= 1.0
+
+
+def test_save_load_without_calibrator(tmp_path):
+    from fantasy_coach.feature_engineering import FEATURE_NAMES, TrainingFrame
+    from fantasy_coach.models.logistic import load_model, save_model, train_logistic
+
+    rng = np.random.default_rng(1)
+    n = 30
+    X = rng.standard_normal((n, 6))
+    y = (X[:, 0] > 0).astype(int)
+    base = np.datetime64("2024-01-01", "s")
+    start_times = np.array(
+        [base + np.timedelta64(i * 7, "D") for i in range(n)], dtype="datetime64[s]"
+    )
+    frame = TrainingFrame(
+        X=X, y=y, match_ids=np.arange(n), start_times=start_times, feature_names=FEATURE_NAMES
+    )
+    result = train_logistic(frame, test_fraction=0.0)
+
+    path = tmp_path / "logistic_no_cal.joblib"
+    save_model(result, path)
+
+    loaded = load_model(path)
+    assert loaded.calibration_wrapper is None
+
+    probs = loaded.predict_home_win_prob(X)
+    assert probs.shape == (n,)


### PR DESCRIPTION
## Summary

- Adds `fantasy_coach.models.calibration` with `CalibrationWrapper`, `ece()`, and `reliability_bins()` helpers
- Platt scaling (logistic on raw scores) and isotonic regression; Platt is the default/decision for LogReg, isotonic for future XGBoost
- Calibration always fits on a **held-out fold** — never the base model's training data
- `save_model()` / `load_model()` now optionally persist the calibrator alongside the pipeline artefact
- ECE (Expected Calibration Error) added to `EvaluationResult.metrics()` and the evaluation markdown report table
- Reliability diagram (per-bin mean confidence vs mean accuracy) rendered as a table in evaluation reports
- New `CalibratedLogisticPredictor` splits walk-forward history 80/20 (train/calibrate) per round
- 15 new tests covering both methods, ECE edge cases (empty, over/under-confident, single-bin), and save/load round-trip

## Test plan
- [x] `uv run pytest tests/test_calibration.py` — 15 tests, all green
- [x] `uv run pytest` — full suite, 127 tests, all green
- [x] `uv run ruff check` — clean

Closes #53

https://claude.ai/code/session_01WSQdjwEw1zj4uBPiVk1TYj