### PR TITLE
feat: Vertex AI Gemini Flash client with retries and token logging (#22)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "openpyxl>=3.1.5",
     "google-cloud-firestore>=2.19",
     "firebase-admin>=6.5",
+    "google-auth>=2.30",
 ]
 
 [build-system]

--- a/src/fantasy_coach/commentary/__init__.py
+++ b/src/fantasy_coach/commentary/__init__.py
@@ -1,0 +1,5 @@
+"""Gemini-powered commentary and preview generation."""
+
+from fantasy_coach.commentary.client import GeminiClient, GeminiResponse
+
+__all__ = ["GeminiClient", "GeminiResponse"]

--- a/src/fantasy_coach/commentary/client.py
+++ b/src/fantasy_coach/commentary/client.py
@@ -1,0 +1,163 @@
+"""Vertex AI Gemini Flash client.
+
+Model pin: gemini-2.0-flash-001 (latest stable as of 2026-04; bump when Vertex retires it).
+Auth:      Application Default Credentials / Workload Identity — no API keys stored here.
+Retries:   exponential back-off on 429 / 5xx.
+Tokens:    usage logged per call at INFO level for cost visibility.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Pin to a specific stable revision; update when the model is retired.
+DEFAULT_MODEL = "gemini-2.0-flash-001"
+DEFAULT_LOCATION = "us-central1"
+
+_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+_RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+
+
+@dataclass(frozen=True)
+class GeminiResponse:
+    """Parsed response from a single generateContent call."""
+
+    text: str
+    input_tokens: int
+    output_tokens: int
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+
+class GeminiClient:
+    """Thin wrapper around the Vertex AI generateContent REST endpoint.
+
+    Uses Application Default Credentials (service account / Workload Identity)
+    — never API keys.  Retries on 429 / 5xx with exponential back-off.
+
+    Usage::
+
+        client = GeminiClient(project="my-gcp-project")
+        response = client.generate(
+            "Which team will win Saturday's game?",
+            system="You are a concise NRL analyst.",
+        )
+        print(response.text)
+    """
+
+    def __init__(
+        self,
+        project: str,
+        *,
+        location: str = DEFAULT_LOCATION,
+        model: str = DEFAULT_MODEL,
+        max_retries: int = 3,
+        timeout: float = 30.0,
+    ) -> None:
+        self._project = project
+        self._location = location
+        self._model = model
+        self._max_retries = max_retries
+        self._timeout = timeout
+        self._endpoint = (
+            f"https://{location}-aiplatform.googleapis.com/v1"
+            f"/projects/{project}/locations/{location}"
+            f"/publishers/google/models/{model}:generateContent"
+        )
+
+    # ------------------------------------------------------------------
+    # Auth
+    # ------------------------------------------------------------------
+
+    def _auth_token(self) -> str:
+        """Return a valid OAuth2 bearer token from Application Default Credentials."""
+        import google.auth
+        import google.auth.transport.requests
+
+        creds, _ = google.auth.default(scopes=_SCOPES)
+        creds.refresh(google.auth.transport.requests.Request())
+        return creds.token  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        system: str = "",
+        max_output_tokens: int = 512,
+    ) -> GeminiResponse:
+        """Call generateContent and return the parsed response.
+
+        Retries up to ``max_retries`` times on transient HTTP errors (429 / 5xx).
+        Raises ``RuntimeError`` when all retries are exhausted.
+        """
+        body: dict = {
+            "contents": [{"role": "user", "parts": [{"text": prompt}]}],
+            "generationConfig": {"maxOutputTokens": max_output_tokens},
+        }
+        if system:
+            body["systemInstruction"] = {"parts": [{"text": system}]}
+
+        token = self._auth_token()
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+        last_exc: Exception | None = None
+        for attempt in range(self._max_retries):
+            if attempt:
+                time.sleep(2**attempt)
+            try:
+                resp = httpx.post(
+                    self._endpoint,
+                    json=body,
+                    headers=headers,
+                    timeout=self._timeout,
+                )
+                if resp.status_code in _RETRYABLE_STATUS:
+                    last_exc = httpx.HTTPStatusError(
+                        f"HTTP {resp.status_code}",
+                        request=resp.request,
+                        response=resp,
+                    )
+                    logger.warning("gemini_retry attempt=%d status=%d", attempt + 1, resp.status_code)
+                    continue
+                resp.raise_for_status()
+                return self._parse(resp.json())
+            except httpx.TimeoutException as exc:
+                last_exc = exc
+                logger.warning("gemini_timeout attempt=%d", attempt + 1)
+
+        raise RuntimeError(
+            f"Gemini generateContent failed after {self._max_retries} attempts"
+        ) from last_exc
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse(data: dict) -> GeminiResponse:
+        text = data["candidates"][0]["content"]["parts"][0]["text"]
+        usage = data.get("usageMetadata", {})
+        input_tokens = int(usage.get("promptTokenCount", 0))
+        output_tokens = int(usage.get("candidatesTokenCount", 0))
+        logger.info(
+            "gemini_tokens input=%d output=%d total=%d",
+            input_tokens,
+            output_tokens,
+            input_tokens + output_tokens,
+        )
+        return GeminiResponse(text=text, input_tokens=input_tokens, output_tokens=output_tokens)

--- a/tests/test_gemini_client.py
+++ b/tests/test_gemini_client.py
@@ -1,0 +1,204 @@
+"""Tests for GeminiClient — no live Vertex AI calls made."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import httpx
+import pytest
+import respx
+
+from fantasy_coach.commentary.client import GeminiClient, GeminiResponse
+
+PROJECT = "test-project"
+LOCATION = "us-central1"
+MODEL = "gemini-2.0-flash-001"
+ENDPOINT = (
+    f"https://{LOCATION}-aiplatform.googleapis.com/v1"
+    f"/projects/{PROJECT}/locations/{LOCATION}"
+    f"/publishers/google/models/{MODEL}:generateContent"
+)
+
+_FAKE_RESPONSE = {
+    "candidates": [
+        {
+            "content": {
+                "parts": [{"text": "Panthers should win by 10."}],
+                "role": "model",
+            }
+        }
+    ],
+    "usageMetadata": {
+        "promptTokenCount": 42,
+        "candidatesTokenCount": 8,
+        "totalTokenCount": 50,
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def patch_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent any real credential fetch in every test."""
+    monkeypatch.setattr(
+        GeminiClient,
+        "_auth_token",
+        lambda self: "fake-bearer-token",
+    )
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Skip real sleeps between retries."""
+    import fantasy_coach.commentary.client as _mod
+
+    monkeypatch.setattr(_mod.time, "sleep", lambda _: None)
+
+
+def _make_client(**kwargs: object) -> GeminiClient:
+    return GeminiClient(PROJECT, location=LOCATION, model=MODEL, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_generate_returns_parsed_response() -> None:
+    respx.post(ENDPOINT).mock(return_value=httpx.Response(200, json=_FAKE_RESPONSE))
+
+    result = _make_client().generate("Who will win?")
+
+    assert isinstance(result, GeminiResponse)
+    assert result.text == "Panthers should win by 10."
+    assert result.input_tokens == 42
+    assert result.output_tokens == 8
+    assert result.total_tokens == 50
+
+
+@respx.mock
+def test_generate_sends_correct_body() -> None:
+    route = respx.post(ENDPOINT).mock(return_value=httpx.Response(200, json=_FAKE_RESPONSE))
+
+    _make_client().generate("Analyse the match.", system="You are an NRL expert.")
+
+    body = json.loads(route.calls.last.request.content)
+    assert body["contents"][0]["parts"][0]["text"] == "Analyse the match."
+    assert body["systemInstruction"]["parts"][0]["text"] == "You are an NRL expert."
+    assert body["generationConfig"]["maxOutputTokens"] == 512
+
+
+@respx.mock
+def test_generate_omits_system_instruction_when_empty() -> None:
+    route = respx.post(ENDPOINT).mock(return_value=httpx.Response(200, json=_FAKE_RESPONSE))
+
+    _make_client().generate("Who wins?")
+
+    body = json.loads(route.calls.last.request.content)
+    assert "systemInstruction" not in body
+
+
+@respx.mock
+def test_generate_uses_bearer_token() -> None:
+    route = respx.post(ENDPOINT).mock(return_value=httpx.Response(200, json=_FAKE_RESPONSE))
+
+    _make_client().generate("Test.")
+
+    assert route.calls.last.request.headers["Authorization"] == "Bearer fake-bearer-token"
+
+
+@respx.mock
+def test_generate_custom_max_output_tokens() -> None:
+    route = respx.post(ENDPOINT).mock(return_value=httpx.Response(200, json=_FAKE_RESPONSE))
+
+    _make_client().generate("Test.", max_output_tokens=128)
+
+    body = json.loads(route.calls.last.request.content)
+    assert body["generationConfig"]["maxOutputTokens"] == 128
+
+
+# ---------------------------------------------------------------------------
+# Token usage logging
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_generate_logs_token_usage(caplog: pytest.LogCaptureFixture) -> None:
+    respx.post(ENDPOINT).mock(return_value=httpx.Response(200, json=_FAKE_RESPONSE))
+
+    with caplog.at_level(logging.INFO, logger="fantasy_coach.commentary.client"):
+        _make_client().generate("Test.")
+
+    assert "gemini_tokens" in caplog.text
+    assert "input=42" in caplog.text
+    assert "output=8" in caplog.text
+    assert "total=50" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Retry logic
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_generate_retries_on_429_then_succeeds() -> None:
+    call_count = 0
+
+    def side_effect(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return httpx.Response(429)
+        return httpx.Response(200, json=_FAKE_RESPONSE)
+
+    respx.post(ENDPOINT).mock(side_effect=side_effect)
+
+    result = _make_client(max_retries=3).generate("Test.")
+
+    assert result.text == "Panthers should win by 10."
+    assert call_count == 2
+
+
+@respx.mock
+def test_generate_retries_on_503() -> None:
+    call_count = 0
+
+    def side_effect(request: httpx.Request) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            return httpx.Response(503)
+        return httpx.Response(200, json=_FAKE_RESPONSE)
+
+    respx.post(ENDPOINT).mock(side_effect=side_effect)
+
+    result = _make_client(max_retries=3).generate("Test.")
+    assert result.text == "Panthers should win by 10."
+    assert call_count == 3
+
+
+@respx.mock
+def test_generate_raises_after_all_retries_exhausted() -> None:
+    respx.post(ENDPOINT).mock(return_value=httpx.Response(503))
+
+    with pytest.raises(RuntimeError, match="failed after 2 attempts"):
+        _make_client(max_retries=2).generate("Test.")
+
+
+@respx.mock
+def test_generate_raises_on_non_retryable_error() -> None:
+    respx.post(ENDPOINT).mock(return_value=httpx.Response(400, json={"error": "bad request"}))
+
+    with pytest.raises(httpx.HTTPStatusError):
+        _make_client().generate("Test.")
+
+
+# ---------------------------------------------------------------------------
+# GeminiResponse helpers
+# ---------------------------------------------------------------------------
+
+
+def test_gemini_response_total_tokens() -> None:
+    r = GeminiResponse(text="hi", input_tokens=10, output_tokens=5)
+    assert r.total_tokens == 15

--- a/uv.lock
+++ b/uv.lock
@@ -382,6 +382,7 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "firebase-admin" },
+    { name = "google-auth" },
     { name = "google-cloud-firestore" },
     { name = "httpx" },
     { name = "joblib" },
@@ -405,6 +406,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "firebase-admin", specifier = ">=6.5" },
+    { name = "google-auth", specifier = ">=2.30" },
     { name = "google-cloud-firestore", specifier = ">=2.19" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "joblib", specifier = ">=1.4" },


### PR DESCRIPTION
## Summary

Closes #22

- Adds `fantasy_coach.commentary.GeminiClient` wrapping the Vertex AI `generateContent` REST endpoint
- Auth via Application Default Credentials / Workload Identity — no API keys stored
- Exponential back-off retries on 429 / 5xx (configurable `max_retries`)
- Token usage (`input`, `output`, `total`) logged at INFO per call for cost visibility
- Model pinned to `gemini-2.0-flash-001` (latest stable); see `DEFAULT_MODEL` constant to bump

## Test plan
- [ ] 11 new unit tests in `tests/test_gemini_client.py`; all HTTP calls mocked via `respx`, auth patched via `monkeypatch` — no live Vertex AI calls in CI
- [ ] Happy path: correct body, bearer token, system instruction, custom token limit
- [ ] Retry paths: succeeds after 429, succeeds after two 503s, raises after all retries exhausted
- [ ] Non-retryable 400 propagates as `httpx.HTTPStatusError`
- [ ] Token logging captured via `caplog`
- [ ] Full suite: 97 tests, all passing

https://claude.ai/code/session_015kmGAV8wkUGiv8mpv8UriL