### PR TITLE
feat: Gemini response cache + token budget guard (closes #66)

### DIFF
--- a/src/fantasy_coach/commentary/__init__.py
+++ b/src/fantasy_coach/commentary/__init__.py
@@ -1,5 +1,18 @@
 """Gemini-powered commentary and preview generation."""
 
+from fantasy_coach.commentary.cache import (
+    BudgetExceededError,
+    CachingGeminiClient,
+    ResponseCache,
+    TokenBudget,
+)
 from fantasy_coach.commentary.client import GeminiClient, GeminiResponse
 
-__all__ = ["GeminiClient", "GeminiResponse"]
+__all__ = [
+    "BudgetExceededError",
+    "CachingGeminiClient",
+    "GeminiClient",
+    "GeminiResponse",
+    "ResponseCache",
+    "TokenBudget",
+]

--- a/src/fantasy_coach/commentary/cache.py
+++ b/src/fantasy_coach/commentary/cache.py
@@ -1,0 +1,272 @@
+"""Response caching + token budget guard for GeminiClient.
+
+Layered architecture:
+  CachingGeminiClient
+    └── ResponseCache  (prompt-hash × model-version → response, with TTL)
+    └── TokenBudget    (per-request cap + per-day rolling circuit-breaker)
+    └── GeminiClient   (the actual Vertex AI call)
+
+Cache entries are stored in-memory by default.  In production, swap
+ResponseCache for a Firestore-backed implementation with the same interface.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from dataclasses import dataclass
+
+from fantasy_coach.commentary.client import GeminiClient, GeminiResponse
+
+logger = logging.getLogger(__name__)
+
+# Default round-level TTL: 7 days.  Predictions don't change between rounds.
+DEFAULT_TTL: float = 7 * 24 * 3600.0
+
+
+class BudgetExceededError(RuntimeError):
+    """Raised when a request would breach the configured token budget."""
+
+
+# ---------------------------------------------------------------------------
+# Cache entry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _CacheEntry:
+    response: GeminiResponse
+    expires_at: float  # monotonic clock
+
+
+# ---------------------------------------------------------------------------
+# ResponseCache
+# ---------------------------------------------------------------------------
+
+
+class ResponseCache:
+    """In-memory response cache keyed by (prompt_hash, model_version) with TTL.
+
+    The cache key is SHA-256( ``model_version + ":" + combined_prompt`` ) so
+    any change to the prompt or model invalidates the entry automatically.
+
+    Swap the backend by subclassing and overriding ``_raw_get`` / ``_raw_set``.
+    """
+
+    def __init__(self, default_ttl: float = DEFAULT_TTL) -> None:
+        self._default_ttl = default_ttl
+        self._store: dict[str, _CacheEntry] = {}
+        self._hits = 0
+        self._misses = 0
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get(self, prompt: str, model_version: str) -> GeminiResponse | None:
+        """Return a cached response or ``None`` on a miss / expired entry."""
+        key = _cache_key(prompt, model_version)
+        entry = self._store.get(key)
+        if entry is None or time.monotonic() > entry.expires_at:
+            if entry is not None:
+                del self._store[key]
+            self._misses += 1
+            logger.debug("gemini_cache status=miss key_prefix=%.8s", key)
+            return None
+        self._hits += 1
+        logger.info(
+            "gemini_cache status=hit hit_rate=%.2f hits=%d misses=%d",
+            self.hit_rate,
+            self._hits,
+            self._misses,
+        )
+        return entry.response
+
+    def set(
+        self,
+        prompt: str,
+        model_version: str,
+        response: GeminiResponse,
+        *,
+        ttl: float | None = None,
+    ) -> None:
+        """Store a response in the cache."""
+        key = _cache_key(prompt, model_version)
+        expires_at = time.monotonic() + (ttl if ttl is not None else self._default_ttl)
+        self._store[key] = _CacheEntry(response=response, expires_at=expires_at)
+
+    def invalidate(self, prompt: str, model_version: str) -> None:
+        key = _cache_key(prompt, model_version)
+        self._store.pop(key, None)
+
+    # ------------------------------------------------------------------
+    # Metrics
+    # ------------------------------------------------------------------
+
+    @property
+    def hit_rate(self) -> float:
+        total = self._hits + self._misses
+        return self._hits / total if total else 0.0
+
+    @property
+    def hits(self) -> int:
+        return self._hits
+
+    @property
+    def misses(self) -> int:
+        return self._misses
+
+
+# ---------------------------------------------------------------------------
+# TokenBudget
+# ---------------------------------------------------------------------------
+
+
+class TokenBudget:
+    """Per-request cap + per-day rolling circuit-breaker.
+
+    Two independent limits:
+    - ``per_request_max``: hard cap on ``max_output_tokens`` per call.
+    - ``daily_limit``: rolling 24 h total-token ceiling (input + output).
+    """
+
+    def __init__(
+        self,
+        *,
+        per_request_max: int = 512,
+        daily_limit: int = 100_000,
+    ) -> None:
+        self._per_request_max = per_request_max
+        self._daily_limit = daily_limit
+        self._used: int = 0
+        self._window_start: float = time.time()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def check_request(self, max_output_tokens: int) -> None:
+        """Raise BudgetExceededError if the request would breach any limit."""
+        if max_output_tokens > self._per_request_max:
+            raise BudgetExceededError(
+                f"max_output_tokens={max_output_tokens} exceeds per-request "
+                f"limit of {self._per_request_max}"
+            )
+        self._reset_if_expired()
+        projected = self._used + max_output_tokens
+        if projected > self._daily_limit:
+            raise BudgetExceededError(
+                f"Daily token budget ({self._daily_limit}) would be exceeded. "
+                f"Already used {self._used} tokens in the current window."
+            )
+
+    def record_usage(self, total_tokens: int) -> None:
+        """Account for tokens consumed by a completed request."""
+        self._reset_if_expired()
+        self._used += total_tokens
+        remaining = max(0, self._daily_limit - self._used)
+        logger.info(
+            "gemini_budget used=%d daily_limit=%d remaining=%d",
+            self._used,
+            self._daily_limit,
+            remaining,
+        )
+        if remaining == 0:
+            logger.warning("gemini_budget daily_limit_reached limit=%d", self._daily_limit)
+
+    @property
+    def used(self) -> int:
+        self._reset_if_expired()
+        return self._used
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _reset_if_expired(self) -> None:
+        if time.time() - self._window_start >= 86_400:
+            self._used = 0
+            self._window_start = time.time()
+
+
+# ---------------------------------------------------------------------------
+# CachingGeminiClient
+# ---------------------------------------------------------------------------
+
+
+class CachingGeminiClient:
+    """GeminiClient wrapper with response caching + token budget enforcement.
+
+    Usage::
+
+        client = CachingGeminiClient(
+            GeminiClient(project="my-project"),
+            cache=ResponseCache(default_ttl=3600),
+            budget=TokenBudget(per_request_max=256, daily_limit=50_000),
+        )
+        response = client.generate("Who will win?", system="You are an NRL expert.")
+        # Second identical call returns instantly from cache:
+        response2 = client.generate("Who will win?", system="You are an NRL expert.")
+    """
+
+    def __init__(
+        self,
+        client: GeminiClient,
+        *,
+        cache: ResponseCache | None = None,
+        budget: TokenBudget | None = None,
+    ) -> None:
+        self._client = client
+        self._cache = cache if cache is not None else ResponseCache()
+        self._budget = budget if budget is not None else TokenBudget()
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        system: str = "",
+        max_output_tokens: int = 512,
+        ttl: float | None = None,
+    ) -> GeminiResponse:
+        """Return a (cached) response, enforcing budget before live calls.
+
+        The cache key combines ``system`` + ``prompt`` so changing either
+        one is a guaranteed cache miss.  ``ttl`` overrides the cache's
+        default TTL for this entry only.
+        """
+        combined = f"{system}\n\n{prompt}"
+        model_version = self._client._model
+
+        cached = self._cache.get(combined, model_version)
+        if cached is not None:
+            return cached
+
+        self._budget.check_request(max_output_tokens)
+
+        response = self._client.generate(
+            prompt,
+            system=system,
+            max_output_tokens=max_output_tokens,
+        )
+        self._budget.record_usage(response.total_tokens)
+        self._cache.set(combined, model_version, response, ttl=ttl)
+        return response
+
+    # Expose underlying metrics for observability.
+    @property
+    def cache(self) -> ResponseCache:
+        return self._cache
+
+    @property
+    def budget(self) -> TokenBudget:
+        return self._budget
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cache_key(prompt: str, model_version: str) -> str:
+    return hashlib.sha256(f"{model_version}:{prompt}".encode()).hexdigest()

--- a/tests/test_gemini_cache.py
+++ b/tests/test_gemini_cache.py
@@ -1,0 +1,278 @@
+"""Tests for ResponseCache, TokenBudget, and CachingGeminiClient."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+
+from fantasy_coach.commentary.cache import (
+    BudgetExceededError,
+    CachingGeminiClient,
+    ResponseCache,
+    TokenBudget,
+    _cache_key,
+)
+from fantasy_coach.commentary.client import GeminiClient, GeminiResponse
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_RESPONSE = GeminiResponse(text="Panthers win by 10.", input_tokens=40, output_tokens=8)
+MODEL = "gemini-2.0-flash-001"
+PROJECT = "test-project"
+
+
+def _make_client(call_count_ref: list[int] | None = None) -> GeminiClient:
+    """Return a GeminiClient whose generate() is monkeypatched to avoid HTTP."""
+    client = GeminiClient.__new__(GeminiClient)
+    client._project = PROJECT
+    client._model = MODEL
+    client._location = "us-central1"
+    client._max_retries = 3
+    client._timeout = 30.0
+    client._endpoint = "https://mock-endpoint"
+
+    _calls = call_count_ref if call_count_ref is not None else []
+
+    def fake_generate(prompt: str, *, system: str = "", max_output_tokens: int = 512) -> GeminiResponse:
+        _calls.append(1)
+        return FAKE_RESPONSE
+
+    client.generate = fake_generate  # type: ignore[method-assign]
+    return client
+
+
+# ---------------------------------------------------------------------------
+# _cache_key
+# ---------------------------------------------------------------------------
+
+
+def test_cache_key_changes_with_model() -> None:
+    assert _cache_key("same prompt", "model-a") != _cache_key("same prompt", "model-b")
+
+
+def test_cache_key_changes_with_prompt() -> None:
+    assert _cache_key("prompt-a", MODEL) != _cache_key("prompt-b", MODEL)
+
+
+def test_cache_key_stable() -> None:
+    assert _cache_key("hello", MODEL) == _cache_key("hello", MODEL)
+
+
+# ---------------------------------------------------------------------------
+# ResponseCache
+# ---------------------------------------------------------------------------
+
+
+def test_cache_miss_on_first_call() -> None:
+    cache = ResponseCache()
+    assert cache.get("some prompt", MODEL) is None
+    assert cache.misses == 1
+    assert cache.hits == 0
+
+
+def test_cache_hit_after_set() -> None:
+    cache = ResponseCache()
+    cache.set("prompt", MODEL, FAKE_RESPONSE)
+    result = cache.get("prompt", MODEL)
+    assert result == FAKE_RESPONSE
+    assert cache.hits == 1
+
+
+def test_cache_expired_entry_is_a_miss() -> None:
+    cache = ResponseCache(default_ttl=0.01)
+    cache.set("prompt", MODEL, FAKE_RESPONSE)
+    time.sleep(0.02)
+    assert cache.get("prompt", MODEL) is None
+    assert cache.misses == 1
+
+
+def test_cache_ttl_override_per_set() -> None:
+    cache = ResponseCache(default_ttl=3600)
+    cache.set("prompt", MODEL, FAKE_RESPONSE, ttl=0.01)
+    time.sleep(0.02)
+    assert cache.get("prompt", MODEL) is None
+
+
+def test_cache_hit_rate_is_zero_with_no_calls() -> None:
+    assert ResponseCache().hit_rate == 0.0
+
+
+def test_cache_hit_rate_after_mixed_calls() -> None:
+    cache = ResponseCache()
+    cache.set("p", MODEL, FAKE_RESPONSE)
+    cache.get("p", MODEL)   # hit
+    cache.get("nope", MODEL)  # miss
+    assert cache.hit_rate == pytest.approx(0.5)
+
+
+def test_cache_hit_logs_hit_rate(caplog: pytest.LogCaptureFixture) -> None:
+    cache = ResponseCache()
+    cache.set("p", MODEL, FAKE_RESPONSE)
+    with caplog.at_level(logging.INFO, logger="fantasy_coach.commentary.cache"):
+        cache.get("p", MODEL)
+    assert "gemini_cache" in caplog.text
+    assert "status=hit" in caplog.text
+
+
+def test_cache_invalidate_removes_entry() -> None:
+    cache = ResponseCache()
+    cache.set("p", MODEL, FAKE_RESPONSE)
+    cache.invalidate("p", MODEL)
+    assert cache.get("p", MODEL) is None
+
+
+# ---------------------------------------------------------------------------
+# TokenBudget
+# ---------------------------------------------------------------------------
+
+
+def test_budget_allows_request_within_limit() -> None:
+    budget = TokenBudget(per_request_max=512, daily_limit=10_000)
+    budget.check_request(256)  # should not raise
+
+
+def test_budget_raises_on_per_request_exceeded() -> None:
+    budget = TokenBudget(per_request_max=256)
+    with pytest.raises(BudgetExceededError, match="per-request"):
+        budget.check_request(512)
+
+
+def test_budget_raises_on_daily_limit_exceeded() -> None:
+    budget = TokenBudget(per_request_max=512, daily_limit=100)
+    budget.record_usage(90)
+    with pytest.raises(BudgetExceededError, match="Daily token budget"):
+        budget.check_request(20)
+
+
+def test_budget_record_usage_accumulates() -> None:
+    budget = TokenBudget(daily_limit=1000)
+    budget.record_usage(300)
+    budget.record_usage(200)
+    assert budget.used == 500
+
+
+def test_budget_logs_usage(caplog: pytest.LogCaptureFixture) -> None:
+    budget = TokenBudget(daily_limit=1000)
+    with caplog.at_level(logging.INFO, logger="fantasy_coach.commentary.cache"):
+        budget.record_usage(100)
+    assert "gemini_budget" in caplog.text
+    assert "used=100" in caplog.text
+
+
+def test_budget_window_resets_after_24h(monkeypatch: pytest.MonkeyPatch) -> None:
+    import fantasy_coach.commentary.cache as _mod
+
+    now = time.time()
+    monkeypatch.setattr(_mod.time, "time", lambda: now)
+
+    budget = TokenBudget(daily_limit=1000)
+    budget.record_usage(900)
+    assert budget.used == 900
+
+    # Advance clock 25 hours.
+    monkeypatch.setattr(_mod.time, "time", lambda: now + 25 * 3600)
+    assert budget.used == 0  # reset on access
+
+
+# ---------------------------------------------------------------------------
+# CachingGeminiClient — cache hit path
+# ---------------------------------------------------------------------------
+
+
+def test_caching_client_cache_miss_calls_underlying() -> None:
+    calls: list[int] = []
+    client = _make_client(calls)
+    caching = CachingGeminiClient(client)
+
+    result = caching.generate("Who wins?")
+
+    assert result == FAKE_RESPONSE
+    assert len(calls) == 1
+
+
+def test_caching_client_cache_hit_skips_underlying() -> None:
+    calls: list[int] = []
+    client = _make_client(calls)
+    caching = CachingGeminiClient(client)
+
+    first = caching.generate("Who wins?")
+    second = caching.generate("Who wins?")
+
+    assert first == second
+    assert len(calls) == 1  # underlying called only once
+
+
+def test_caching_client_different_prompts_are_separate_entries() -> None:
+    calls: list[int] = []
+    client = _make_client(calls)
+    caching = CachingGeminiClient(client)
+
+    caching.generate("Who wins match A?")
+    caching.generate("Who wins match B?")
+
+    assert len(calls) == 2
+
+
+def test_caching_client_system_prompt_is_part_of_cache_key() -> None:
+    calls: list[int] = []
+    client = _make_client(calls)
+    caching = CachingGeminiClient(client)
+
+    caching.generate("Who wins?", system="Be brief.")
+    caching.generate("Who wins?", system="Be verbose.")
+
+    assert len(calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# CachingGeminiClient — budget-exceeded path
+# ---------------------------------------------------------------------------
+
+
+def test_caching_client_raises_on_budget_exceeded() -> None:
+    calls: list[int] = []
+    client = _make_client(calls)
+    budget = TokenBudget(per_request_max=64)
+    caching = CachingGeminiClient(client, budget=budget)
+
+    with pytest.raises(BudgetExceededError, match="per-request"):
+        caching.generate("Test.", max_output_tokens=128)
+
+    assert len(calls) == 0  # no underlying call should be made
+
+
+def test_caching_client_budget_not_checked_on_cache_hit() -> None:
+    calls: list[int] = []
+    client = _make_client(calls)
+    # Tiny daily budget that would be exceeded on a second live call.
+    budget = TokenBudget(per_request_max=512, daily_limit=10)
+    caching = CachingGeminiClient(client, budget=budget)
+
+    # First call: live — records usage.
+    caching.generate("Who wins?", max_output_tokens=10)
+    # Second identical call: cache hit — budget NOT checked, so no error.
+    result = caching.generate("Who wins?", max_output_tokens=10)
+
+    assert result == FAKE_RESPONSE
+    assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# CachingGeminiClient — TTL override
+# ---------------------------------------------------------------------------
+
+
+def test_caching_client_custom_ttl() -> None:
+    calls: list[int] = []
+    client = _make_client(calls)
+    caching = CachingGeminiClient(client, cache=ResponseCache(default_ttl=3600))
+
+    caching.generate("Test.", ttl=0.01)
+    time.sleep(0.02)
+    caching.generate("Test.")  # should be a miss after expiry
+
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary

Closes #66

- **`ResponseCache`**: SHA-256 keyed `(prompt × model_version)` in-memory cache with per-entry TTL override. Hit rate logged at INFO level for observability (target ≥ 80% after round 1).
- **`TokenBudget`**: per-request `max_output_tokens` cap + 24 h rolling total-token circuit-breaker. Raises `BudgetExceededError` before any live API call; logs usage and remaining budget.
- **`CachingGeminiClient`**: wraps `GeminiClient` — checks cache first, enforces budget on misses, stores result with TTL.
- Cache hits bypass budget checks entirely (already-paid responses are free).

## Test plan
- [ ] 24 new tests in `tests/test_gemini_cache.py`
- [ ] Cache miss → live call; cache hit → no underlying call (1 call for 2 identical prompts)
- [ ] Expired TTL treated as a miss; per-entry TTL override works
- [ ] `BudgetExceededError` raised before live call when per-request or daily limit is breached
- [ ] Budget NOT checked on cache hit (even if daily limit exhausted)
- [ ] Cache key isolation: different prompts, same prompt different system, different model versions
- [ ] Hit-rate and budget-usage metrics logged
- [ ] Budget window resets after 24 h
- [ ] Full suite: 151 tests, all passing

https://claude.ai/code/session_015kmGAV8wkUGiv8mpv8UriL