### PR TITLE
feat: travel & scheduling features — travel_km_diff, timezone_delta_diff, back_to_back (closes #55)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ build/
 .env.*
 !.env.example
 data/
+!data/venues.csv
 
 # Snapshotted DB fixture is committed deliberately — see
 # tests/test_baseline_metrics.py for the regeneration recipe.

--- a/data/venues.csv
+++ b/data/venues.csv
@@ -1,0 +1,28 @@
+name,city,lat,lon,timezone_offset
+Accor Stadium,Sydney,-33.8473,151.0636,10
+Allianz Stadium,Sydney,-33.8920,151.2238,10
+Bankwest Stadium,Sydney,-33.8136,151.0034,10
+CommBank Stadium,Sydney,-33.8136,151.0034,10
+McDonald Jones Stadium,Newcastle,-32.9262,151.7757,10
+Suncorp Stadium,Brisbane,-27.4641,153.0100,10
+Kayo Stadium,Redcliffe,-27.2390,153.0955,10
+Cbus Super Stadium,Gold Coast,-27.9975,153.3624,10
+PointsBet Stadium,Cronulla,-34.0455,151.1515,10
+Netstrata Jubilee Stadium,Sydney,-33.9750,151.0630,10
+Campbelltown Sports Stadium,Sydney,-34.0721,150.8115,10
+WIN Stadium,Wollongong,-34.4218,150.8936,10
+Leichhardt Oval,Sydney,-33.8790,151.1504,10
+BlueBet Stadium,Penrith,-33.7506,150.6894,10
+Apex Oval,Dubbo,-32.2393,148.6019,10
+GIO Stadium,Canberra,-35.2452,149.0877,10
+AAMI Park,Melbourne,-37.8230,144.9844,11
+ENGIE Stadium,Melbourne,-37.9183,145.0022,11
+Go Media Stadium,Auckland,-36.9001,174.7779,13
+Mt Smart Stadium,Auckland,-36.9001,174.7779,13
+4 Pines Park,Sydney,-33.7960,151.2858,10
+Industree Group Stadium,Sydney,-33.7172,151.0976,10
+Scully Park,Tamworth,-31.0909,150.9320,10
+Marley Brown Oval,Gympie,-26.1910,152.6730,10
+Queensland Country Bank Stadium,Townsville,-19.2619,146.7726,10
+Northern Australia Carnival Venue,Cairns,-16.9186,145.7781,10
+Optus Stadium,Perth,-31.9505,115.8605,8

--- a/src/fantasy_coach/commentary/client.py
+++ b/src/fantasy_coach/commentary/client.py
@@ -132,7 +132,9 @@ class GeminiClient:
                         request=resp.request,
                         response=resp,
                     )
-                    logger.warning("gemini_retry attempt=%d status=%d", attempt + 1, resp.status_code)
+                    logger.warning(
+                        "gemini_retry attempt=%d status=%d", attempt + 1, resp.status_code
+                    )
                     continue
                 resp.raise_for_status()
                 return self._parse(resp.json())

--- a/src/fantasy_coach/feature_engineering.py
+++ b/src/fantasy_coach/feature_engineering.py
@@ -11,17 +11,14 @@ outcome into the rolling state. `build_training_frame` is the
 fit-time wrapper that drives the builder over a list of completed matches.
 
 Features (all home-minus-away unless noted):
-- `elo_diff`: home Elo + home_advantage − away Elo, computed against the rolling
-  Elo book that is updated *after* each match is emitted.
-- `form_diff_pf`, `form_diff_pa`: rolling-5 points-for and points-against
-  averages, home minus away. Empty deques (no prior matches) read as 0
-  — equivalent to "no prior info, no edge".
-- `days_rest_diff`: home days since last match minus away days since last
-  match. First-match-of-season teams are clamped to 14 days (≈ pre-season).
-- `h2h_recent_diff`: average home-perspective score margin in the last 3
-  meetings (so a team that's beaten its opponent badly recently scores high).
-- `is_home_field`: always 1 (home perspective). Constant; included so the
-  intercept absorbs it cleanly when fitting.
+- `elo_diff`: home Elo + home_advantage − away Elo.
+- `form_diff_pf`, `form_diff_pa`: rolling-5 points-for and points-against averages.
+- `days_rest_diff`: home days since last match minus away days since last match.
+- `h2h_recent_diff`: average home-perspective score margin in the last 3 meetings.
+- `is_home_field`: always 1 (home perspective).
+- `travel_km_diff`: great-circle km travelled from prev venue to this venue, home − away.
+- `timezone_delta_diff`: absolute timezone-shift hours, home − away.
+- `back_to_back_short_week_diff`: +1/−1/0 flag for (days_rest < 6 AND travel > 1 000 km).
 """
 
 from __future__ import annotations
@@ -35,6 +32,7 @@ import numpy as np
 
 from fantasy_coach.features import MatchRow
 from fantasy_coach.models.elo import Elo
+from fantasy_coach.travel import travel_features
 
 FEATURE_NAMES = (
     "elo_diff",
@@ -43,6 +41,9 @@ FEATURE_NAMES = (
     "days_rest_diff",
     "h2h_recent_diff",
     "is_home_field",
+    "travel_km_diff",
+    "timezone_delta_diff",
+    "back_to_back_short_week_diff",
 )
 
 ROLLING_WINDOW = 5
@@ -72,6 +73,7 @@ class FeatureBuilder:
     def __init__(self, elo: Elo | None = None) -> None:
         self.elo = elo or Elo()
         self._last_played: dict[int, datetime] = {}
+        self._last_venue: dict[int, str | None] = {}
         self._points_for: dict[int, deque[int]] = defaultdict(lambda: deque(maxlen=ROLLING_WINDOW))
         self._points_against: dict[int, deque[int]] = defaultdict(
             lambda: deque(maxlen=ROLLING_WINDOW)
@@ -90,6 +92,13 @@ class FeatureBuilder:
         rest_a = _days_since(self._last_played.get(a_id), match.start_time)
         h2h_avg = _avg(self._h2h[_h2h_key(h_id, a_id)])
         h2h_recent = h2h_avg if h_id <= a_id else -h2h_avg
+        tkm, ttz, tbb = travel_features(
+            self._last_venue.get(h_id),
+            self._last_venue.get(a_id),
+            match.venue,
+            rest_h,
+            rest_a,
+        )
         return [
             elo_diff,
             form_pf_h - form_pf_a,
@@ -97,6 +106,9 @@ class FeatureBuilder:
             rest_h - rest_a,
             h2h_recent,
             1.0,
+            tkm,
+            ttz,
+            tbb,
         ]
 
     def advance_season_if_needed(self, match: MatchRow) -> None:
@@ -121,6 +133,8 @@ class FeatureBuilder:
         self._h2h[_h2h_key(h_id, a_id)].append(_signed_h2h(h_id, a_id, h_score, a_score))
         self._last_played[h_id] = match.start_time
         self._last_played[a_id] = match.start_time
+        self._last_venue[h_id] = match.venue
+        self._last_venue[a_id] = match.venue
         self.elo.update(h_id, a_id, h_score, a_score)
 
 

--- a/src/fantasy_coach/travel.py
+++ b/src/fantasy_coach/travel.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import csv
 import math
-from importlib import resources
 from pathlib import Path
 from typing import NamedTuple
 
@@ -82,9 +81,10 @@ def haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     r = 6_371.0
     d_lat = math.radians(lat2 - lat1)
     d_lon = math.radians(lon2 - lon1)
-    a = math.sin(d_lat / 2) ** 2 + math.cos(math.radians(lat1)) * math.cos(
-        math.radians(lat2)
-    ) * math.sin(d_lon / 2) ** 2
+    a = (
+        math.sin(d_lat / 2) ** 2
+        + math.cos(math.radians(lat1)) * math.cos(math.radians(lat2)) * math.sin(d_lon / 2) ** 2
+    )
     return r * 2 * math.asin(math.sqrt(a))
 
 

--- a/src/fantasy_coach/travel.py
+++ b/src/fantasy_coach/travel.py
@@ -1,0 +1,155 @@
+"""Travel & scheduling features for the NRL prediction model.
+
+Three features, all expressed as home-minus-away differentials:
+
+- ``travel_km_diff``: great-circle kilometres each team travelled from their
+  previous match venue to this one.  Teams with no prior match this season
+  get 0 km (neutral — no advantage modelled for a team starting from home).
+
+- ``timezone_delta_diff``: absolute hours of timezone shift since the previous
+  match.  The Warriors flying Auckland→Brisbane is +3 h; Brisbane→Sydney is 0.
+  Zero for first match of season.
+
+- ``back_to_back_short_week_diff``: +1 / −1 / 0 flag capturing the interaction
+  of short rest (< 6 days) AND long travel (> 1 000 km).  Both conditions must
+  hold for a team to score ±1; partial matches are 0.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+from importlib import resources
+from pathlib import Path
+from typing import NamedTuple
+
+# ---------------------------------------------------------------------------
+# Venue database
+# ---------------------------------------------------------------------------
+
+_VENUES_FILE = Path(__file__).parent.parent.parent / "data" / "venues.csv"
+
+
+class _VenueInfo(NamedTuple):
+    name: str
+    city: str
+    lat: float
+    lon: float
+    tz_offset: int  # hours offset from UTC
+
+
+_VENUE_DB: dict[str, _VenueInfo] | None = None
+
+
+def _load_venues() -> dict[str, _VenueInfo]:
+    global _VENUE_DB
+    if _VENUE_DB is not None:
+        return _VENUE_DB
+
+    path = _VENUES_FILE
+    db: dict[str, _VenueInfo] = {}
+    try:
+        with path.open(newline="") as fh:
+            for row in csv.DictReader(fh):
+                info = _VenueInfo(
+                    name=row["name"],
+                    city=row["city"],
+                    lat=float(row["lat"]),
+                    lon=float(row["lon"]),
+                    tz_offset=int(row["timezone_offset"]),
+                )
+                db[row["name"].lower()] = info
+    except FileNotFoundError:
+        pass  # No venues file — features will degrade to zero.
+    _VENUE_DB = db
+    return db
+
+
+def lookup_venue(venue_name: str | None) -> _VenueInfo | None:
+    """Return venue info for *venue_name* using a case-insensitive lookup."""
+    if not venue_name:
+        return None
+    return _load_venues().get(venue_name.lower())
+
+
+# ---------------------------------------------------------------------------
+# Haversine distance
+# ---------------------------------------------------------------------------
+
+
+def haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Return the great-circle distance in kilometres between two coordinates."""
+    r = 6_371.0
+    d_lat = math.radians(lat2 - lat1)
+    d_lon = math.radians(lon2 - lon1)
+    a = math.sin(d_lat / 2) ** 2 + math.cos(math.radians(lat1)) * math.cos(
+        math.radians(lat2)
+    ) * math.sin(d_lon / 2) ** 2
+    return r * 2 * math.asin(math.sqrt(a))
+
+
+# ---------------------------------------------------------------------------
+# Feature computation
+# ---------------------------------------------------------------------------
+
+
+def travel_features(
+    home_prev_venue: str | None,
+    away_prev_venue: str | None,
+    current_venue: str | None,
+    home_days_rest: float,
+    away_days_rest: float,
+) -> tuple[float, float, float]:
+    """Return ``(travel_km_diff, timezone_delta_diff, bb_short_week_diff)``.
+
+    All three values are expressed as home − away.
+
+    Parameters
+    ----------
+    home_prev_venue:
+        Venue name where the home team last played (None if no prior match).
+    away_prev_venue:
+        Venue name where the away team last played (None if no prior match).
+    current_venue:
+        Venue name of the upcoming match.
+    home_days_rest, away_days_rest:
+        Days since each team last played (from `FeatureBuilder`).
+    """
+    cur_info = lookup_venue(current_venue)
+
+    home_km = _travel_km(home_prev_venue, cur_info)
+    away_km = _travel_km(away_prev_venue, cur_info)
+    travel_km_diff = home_km - away_km
+
+    home_tz = _tz_delta(home_prev_venue, cur_info)
+    away_tz = _tz_delta(away_prev_venue, cur_info)
+    timezone_delta_diff = float(home_tz - away_tz)
+
+    home_bb = _is_brutal(home_days_rest, home_km)
+    away_bb = _is_brutal(away_days_rest, away_km)
+    bb_diff = float(home_bb - away_bb)
+
+    return travel_km_diff, timezone_delta_diff, bb_diff
+
+
+def _travel_km(prev_venue: str | None, cur_info: _VenueInfo | None) -> float:
+    if cur_info is None or prev_venue is None:
+        return 0.0
+    prev_info = lookup_venue(prev_venue)
+    if prev_info is None:
+        return 0.0
+    return haversine_km(prev_info.lat, prev_info.lon, cur_info.lat, cur_info.lon)
+
+
+def _tz_delta(prev_venue: str | None, cur_info: _VenueInfo | None) -> int:
+    if cur_info is None or prev_venue is None:
+        return 0
+    prev_info = lookup_venue(prev_venue)
+    if prev_info is None:
+        return 0
+    return abs(cur_info.tz_offset - prev_info.tz_offset)
+
+
+def _is_brutal(days_rest: float, travel_km: float) -> int:
+    """Return 1 if the team has short rest AND long travel, else 0."""
+    return int(days_rest < 6.0 and travel_km > 1_000.0)

--- a/tests/test_baseline_metrics.py
+++ b/tests/test_baseline_metrics.py
@@ -32,10 +32,12 @@ SEASONS = (2024, 2025)
 
 # Snapshot from a 2024+2025 backfill on 2026-04-21 (213 matches/season,
 # draws dropped → 424 scored predictions).
+# Logistic numbers updated in #55 (travel & scheduling features added to pipeline).
+# Travel features hurt logistic on this sample size — documented in docs/model.md.
 EXPECTED = {
     "home": {"n": 424, "accuracy": 0.5731, "log_loss": 0.6835, "brier": 0.2452},
     "elo": {"n": 424, "accuracy": 0.5943, "log_loss": 0.6570, "brier": 0.2325},
-    "logistic": {"n": 424, "accuracy": 0.5755, "log_loss": 0.6994, "brier": 0.2477},
+    "logistic": {"n": 424, "accuracy": 0.5637, "log_loss": 0.7226, "brier": 0.2557},
 }
 
 PREDICTORS: dict[str, type[Predictor]] = {

--- a/tests/test_gemini_cache.py
+++ b/tests/test_gemini_cache.py
@@ -37,7 +37,9 @@ def _make_client(call_count_ref: list[int] | None = None) -> GeminiClient:
 
     _calls = call_count_ref if call_count_ref is not None else []
 
-    def fake_generate(prompt: str, *, system: str = "", max_output_tokens: int = 512) -> GeminiResponse:
+    def fake_generate(
+        prompt: str, *, system: str = "", max_output_tokens: int = 512
+    ) -> GeminiResponse:
         _calls.append(1)
         return FAKE_RESPONSE
 
@@ -104,7 +106,7 @@ def test_cache_hit_rate_is_zero_with_no_calls() -> None:
 def test_cache_hit_rate_after_mixed_calls() -> None:
     cache = ResponseCache()
     cache.set("p", MODEL, FAKE_RESPONSE)
-    cache.get("p", MODEL)   # hit
+    cache.get("p", MODEL)  # hit
     cache.get("nope", MODEL)  # miss
     assert cache.hit_rate == pytest.approx(0.5)
 

--- a/tests/test_travel.py
+++ b/tests/test_travel.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import math
-
 import pytest
 
 from fantasy_coach.travel import (
@@ -14,7 +12,6 @@ from fantasy_coach.travel import (
     lookup_venue,
     travel_features,
 )
-
 
 # ---------------------------------------------------------------------------
 # Haversine
@@ -158,9 +155,9 @@ def test_travel_features_all_zero_when_no_venues() -> None:
 def test_travel_features_home_minus_away_sign() -> None:
     # Home team has travelled further (Auckland → Brisbane) than away (Sydney → Brisbane).
     km, _, _ = travel_features(
-        "Go Media Stadium",   # Auckland (home came from)
-        "Allianz Stadium",    # Sydney   (away came from)
-        "Suncorp Stadium",    # Brisbane (current match)
+        "Go Media Stadium",  # Auckland (home came from)
+        "Allianz Stadium",  # Sydney   (away came from)
+        "Suncorp Stadium",  # Brisbane (current match)
         7.0,
         7.0,
     )
@@ -183,8 +180,8 @@ def test_travel_features_equal_travel_is_zero() -> None:
 def test_travel_features_bb_flag_asymmetric() -> None:
     # Home team: short rest + long travel → brutal; Away: fine.
     _, _, bb = travel_features(
-        "Go Media Stadium",   # Auckland → Brisbane (> 1 000 km)
-        "Suncorp Stadium",    # Brisbane → Brisbane (0 km)
+        "Go Media Stadium",  # Auckland → Brisbane (> 1 000 km)
+        "Suncorp Stadium",  # Brisbane → Brisbane (0 km)
         "Suncorp Stadium",
         4.0,  # home: short rest
         7.0,  # away: long rest

--- a/tests/test_travel.py
+++ b/tests/test_travel.py
@@ -1,0 +1,192 @@
+"""Tests for travel & scheduling feature computation."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from fantasy_coach.travel import (
+    _is_brutal,
+    _travel_km,
+    _tz_delta,
+    haversine_km,
+    lookup_venue,
+    travel_features,
+)
+
+
+# ---------------------------------------------------------------------------
+# Haversine
+# ---------------------------------------------------------------------------
+
+
+def test_haversine_same_point_is_zero() -> None:
+    assert haversine_km(0.0, 0.0, 0.0, 0.0) == pytest.approx(0.0, abs=0.01)
+
+
+def test_haversine_sydney_to_auckland_approx() -> None:
+    # Sydney ↔ Auckland is ~2 155 km great-circle.
+    km = haversine_km(-33.87, 151.21, -36.90, 174.78)
+    assert 2100 < km < 2200
+
+
+def test_haversine_sydney_to_perth_approx() -> None:
+    # Sydney ↔ Perth is ~3 290 km great-circle.
+    km = haversine_km(-33.87, 151.21, -31.95, 115.86)
+    assert 3200 < km < 3400
+
+
+def test_haversine_is_symmetric() -> None:
+    a = haversine_km(-33.87, 151.21, -27.47, 153.02)
+    b = haversine_km(-27.47, 153.02, -33.87, 151.21)
+    assert a == pytest.approx(b, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# lookup_venue
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_venue_returns_info_for_known_venue() -> None:
+    info = lookup_venue("Suncorp Stadium")
+    assert info is not None
+    assert info.city == "Brisbane"
+    assert info.tz_offset == 10
+
+
+def test_lookup_venue_case_insensitive() -> None:
+    assert lookup_venue("suncorp stadium") is not None
+    assert lookup_venue("SUNCORP STADIUM") is not None
+
+
+def test_lookup_venue_returns_none_for_unknown() -> None:
+    assert lookup_venue("Mystery Ground") is None
+
+
+def test_lookup_venue_returns_none_for_none_input() -> None:
+    assert lookup_venue(None) is None
+
+
+# ---------------------------------------------------------------------------
+# _travel_km
+# ---------------------------------------------------------------------------
+
+
+def test_travel_km_zero_when_no_prev_venue() -> None:
+    cur = lookup_venue("Suncorp Stadium")
+    assert _travel_km(None, cur) == pytest.approx(0.0)
+
+
+def test_travel_km_zero_when_no_cur_venue() -> None:
+    assert _travel_km("Suncorp Stadium", None) == pytest.approx(0.0)
+
+
+def test_travel_km_sydney_to_brisbane() -> None:
+    cur = lookup_venue("Suncorp Stadium")  # Brisbane
+    km = _travel_km("Allianz Stadium", cur)  # Sydney → Brisbane ≈ 735 km
+    assert 650 < km < 800
+
+
+def test_travel_km_sydney_to_auckland() -> None:
+    cur = lookup_venue("Go Media Stadium")  # Auckland
+    km = _travel_km("Allianz Stadium", cur)  # Sydney → Auckland ≈ 2 155 km
+    assert 2000 < km < 2300
+
+
+# ---------------------------------------------------------------------------
+# _tz_delta
+# ---------------------------------------------------------------------------
+
+
+def test_tz_delta_same_timezone_is_zero() -> None:
+    cur = lookup_venue("Suncorp Stadium")  # UTC+10
+    assert _tz_delta("Allianz Stadium", cur) == 0  # also UTC+10
+
+
+def test_tz_delta_sydney_to_perth() -> None:
+    cur = lookup_venue("Optus Stadium")  # UTC+8
+    delta = _tz_delta("Allianz Stadium", cur)  # UTC+10 → +8 = 2 h shift
+    assert delta == 2
+
+
+def test_tz_delta_sydney_to_auckland() -> None:
+    cur = lookup_venue("Go Media Stadium")  # UTC+13
+    delta = _tz_delta("Allianz Stadium", cur)  # UTC+10 → +13 = 3 h shift
+    assert delta == 3
+
+
+# ---------------------------------------------------------------------------
+# _is_brutal
+# ---------------------------------------------------------------------------
+
+
+def test_is_brutal_short_rest_and_long_travel() -> None:
+    assert _is_brutal(4.0, 1500.0) == 1
+
+
+def test_is_brutal_long_rest() -> None:
+    assert _is_brutal(7.0, 1500.0) == 0
+
+
+def test_is_brutal_short_travel() -> None:
+    assert _is_brutal(4.0, 500.0) == 0
+
+
+def test_is_brutal_boundary_rest() -> None:
+    # Exactly 6 days rest is NOT short (condition is < 6).
+    assert _is_brutal(6.0, 2000.0) == 0
+
+
+def test_is_brutal_boundary_travel() -> None:
+    # Exactly 1 000 km is NOT long (condition is > 1 000).
+    assert _is_brutal(3.0, 1000.0) == 0
+
+
+# ---------------------------------------------------------------------------
+# travel_features (integration)
+# ---------------------------------------------------------------------------
+
+
+def test_travel_features_all_zero_when_no_venues() -> None:
+    km, tz, bb = travel_features(None, None, None, 7.0, 7.0)
+    assert km == pytest.approx(0.0)
+    assert tz == pytest.approx(0.0)
+    assert bb == pytest.approx(0.0)
+
+
+def test_travel_features_home_minus_away_sign() -> None:
+    # Home team has travelled further (Auckland → Brisbane) than away (Sydney → Brisbane).
+    km, _, _ = travel_features(
+        "Go Media Stadium",   # Auckland (home came from)
+        "Allianz Stadium",    # Sydney   (away came from)
+        "Suncorp Stadium",    # Brisbane (current match)
+        7.0,
+        7.0,
+    )
+    # Auckland → Brisbane > Sydney → Brisbane, so home_km > away_km → positive diff
+    assert km > 0
+
+
+def test_travel_features_equal_travel_is_zero() -> None:
+    km, tz, _ = travel_features(
+        "Allianz Stadium",
+        "Allianz Stadium",
+        "Suncorp Stadium",
+        7.0,
+        7.0,
+    )
+    assert km == pytest.approx(0.0)
+    assert tz == pytest.approx(0.0)
+
+
+def test_travel_features_bb_flag_asymmetric() -> None:
+    # Home team: short rest + long travel → brutal; Away: fine.
+    _, _, bb = travel_features(
+        "Go Media Stadium",   # Auckland → Brisbane (> 1 000 km)
+        "Suncorp Stadium",    # Brisbane → Brisbane (0 km)
+        "Suncorp Stadium",
+        4.0,  # home: short rest
+        7.0,  # away: long rest
+    )
+    assert bb == pytest.approx(1.0)  # home is suffering, away is not → +1


### PR DESCRIPTION
## Summary

Closes #55

- **`data/venues.csv`**: 27 NRL venues with lat/lon coordinates and UTC timezone offset (one-time static table)
- **`src/fantasy_coach/travel.py`**: `haversine_km()`, `lookup_venue()`, and `travel_features()` — returns `(travel_km_diff, timezone_delta_diff, back_to_back_short_week_diff)` as home−away differentials
- **`feature_engineering.py`**: `FeatureBuilder` now tracks `_last_venue` per team; `feature_row()` calls `travel_features()` to append the three new columns; `FEATURE_NAMES` updated from 6 → 9 features
- **Ablation**: logistic accuracy 0.5755 → 0.5637 on 424-match baseline (features add variance at this sample size; may benefit tree models). Baseline snapshot updated deliberately per the module docstring.

## Feature definitions
| Feature | Description |
|---|---|
| `travel_km_diff` | Great-circle km from prev venue to current, home − away |
| `timezone_delta_diff` | Absolute timezone-shift hours, home − away |
| `back_to_back_short_week_diff` | +1/−1/0: days_rest < 6 AND travel > 1 000 km |

## Test plan
- [ ] 24 tests in `tests/test_travel.py`: haversine, venue lookup (case-insensitive), distance/TZ/brutality helpers, `travel_features()` integration
- [ ] Baseline metrics test updated with new logistic numbers
- [ ] Full suite: 175 tests, all passing

https://claude.ai/code/session_015kmGAV8wkUGiv8mpv8UriL