### PR TITLE
feat: weather & venue features — is_wet, wind_kph, temperature_c, venue rolling stats (closes #54)

### DIFF
--- a/src/fantasy_coach/feature_engineering.py
+++ b/src/fantasy_coach/feature_engineering.py
@@ -19,6 +19,9 @@ Features (all home-minus-away unless noted):
 - `travel_km_diff`: great-circle km travelled from prev venue to this venue, home − away.
 - `timezone_delta_diff`: absolute timezone-shift hours, home − away.
 - `back_to_back_short_week_diff`: +1/−1/0 flag for (days_rest < 6 AND travel > 1 000 km).
+- `is_wet`, `wind_kph`, `temperature_c`, `missing_weather`: parsed from the weather block.
+- `venue_avg_total_points`: rolling-10 average total points at this venue (history-only).
+- `venue_home_win_rate`: rolling-20 home win rate at this venue (history-only).
 """
 
 from __future__ import annotations
@@ -33,6 +36,7 @@ import numpy as np
 from fantasy_coach.features import MatchRow
 from fantasy_coach.models.elo import Elo
 from fantasy_coach.travel import travel_features
+from fantasy_coach.weather import parse_weather
 
 FEATURE_NAMES = (
     "elo_diff",
@@ -44,7 +48,16 @@ FEATURE_NAMES = (
     "travel_km_diff",
     "timezone_delta_diff",
     "back_to_back_short_week_diff",
+    "is_wet",
+    "wind_kph",
+    "temperature_c",
+    "missing_weather",
+    "venue_avg_total_points",
+    "venue_home_win_rate",
 )
+
+VENUE_TOTAL_WINDOW = 10
+VENUE_WIN_WINDOW = 20
 
 ROLLING_WINDOW = 5
 H2H_WINDOW = 3
@@ -80,6 +93,13 @@ class FeatureBuilder:
         )
         self._h2h: dict[tuple[int, int], deque[int]] = defaultdict(lambda: deque(maxlen=H2H_WINDOW))
         self._current_season: int | None = None
+        # Venue-level rolling stats (keyed by lower-cased venue name).
+        self._venue_total: dict[str, deque[int]] = defaultdict(
+            lambda: deque(maxlen=VENUE_TOTAL_WINDOW)
+        )
+        self._venue_home_wins: dict[str, deque[int]] = defaultdict(
+            lambda: deque(maxlen=VENUE_WIN_WINDOW)
+        )
 
     def feature_row(self, match: MatchRow) -> list[float]:
         h_id, a_id = match.home.team_id, match.away.team_id
@@ -99,6 +119,13 @@ class FeatureBuilder:
             rest_h,
             rest_a,
         )
+        wx = parse_weather(match.weather)
+        vkey = (match.venue or "").lower()
+        venue_avg_tp = _avg(self._venue_total[vkey]) if vkey else 0.0
+        # Neutral prior (0.5) when no history available for this venue.
+        venue_hwr = (
+            _avg(self._venue_home_wins[vkey]) if (vkey and self._venue_home_wins[vkey]) else 0.5
+        )
         return [
             elo_diff,
             form_pf_h - form_pf_a,
@@ -109,6 +136,12 @@ class FeatureBuilder:
             tkm,
             ttz,
             tbb,
+            wx.is_wet,
+            wx.wind_kph,
+            wx.temperature_c,
+            wx.missing,
+            venue_avg_tp,
+            venue_hwr,
         ]
 
     def advance_season_if_needed(self, match: MatchRow) -> None:
@@ -136,6 +169,11 @@ class FeatureBuilder:
         self._last_venue[h_id] = match.venue
         self._last_venue[a_id] = match.venue
         self.elo.update(h_id, a_id, h_score, a_score)
+        # Update venue rolling stats after the match result is known.
+        vkey = (match.venue or "").lower()
+        if vkey:
+            self._venue_total[vkey].append(h_score + a_score)
+            self._venue_home_wins[vkey].append(1 if h_score > a_score else 0)
 
 
 def build_training_frame(

--- a/src/fantasy_coach/weather.py
+++ b/src/fantasy_coach/weather.py
@@ -1,0 +1,92 @@
+"""Weather & venue-condition feature extraction.
+
+Weather data on NRL.com:
+- 2026+: a structured JSON object with keys `description`, `tempInCelsius`,
+  `windSpeedKm`, and `isWet`.
+- 2024–2025: field absent (null) — gracefully degrade to zeros with a
+  `missing_weather` flag so the model can learn a separate intercept.
+
+The `parse_weather` function handles both representations and plain-text
+fall-backs (e.g. "Rain, 15°C") for robustness.
+
+Decision (null strategy): use a dedicated `missing_weather` flag rather than
+imputing from venue/seasonal averages.  Imputation would silently introduce
+synthetic correlations; an explicit flag lets the model learn "no weather info
+available" as a distinct case.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import re
+from typing import NamedTuple
+
+logger = logging.getLogger(__name__)
+
+_WET_KEYWORDS = re.compile(
+    r"\b(rain|wet|shower|storm|thunder|thunderstorm|drizzle|hail|sleet)\b", re.IGNORECASE
+)
+
+
+class WeatherInfo(NamedTuple):
+    """Parsed, null-safe weather values for a single match."""
+
+    is_wet: float  # 1.0 if wet/rainy conditions, else 0.0
+    wind_kph: float  # wind speed (0.0 if unknown)
+    temperature_c: float  # temperature in Celsius (0.0 if unknown)
+    missing: float  # 1.0 if source data was absent
+
+
+_MISSING = WeatherInfo(is_wet=0.0, wind_kph=0.0, temperature_c=0.0, missing=1.0)
+_ZERO = WeatherInfo(is_wet=0.0, wind_kph=0.0, temperature_c=0.0, missing=0.0)
+
+
+def parse_weather(raw: str | dict | None) -> WeatherInfo:
+    """Parse a raw weather value into numeric features.
+
+    Handles:
+    - ``None`` / empty: returns the ``missing`` sentinel (all zeros + flag=1).
+    - ``dict``: structured NRL 2026+ format.
+    - ``str`` that is valid JSON: parsed as dict.
+    - ``str`` plain-text: keyword + numeric regex extraction (best-effort).
+    """
+    if raw is None:
+        return _MISSING
+
+    if isinstance(raw, str):
+        raw = raw.strip()
+        if not raw:
+            return _MISSING
+        # Try to decode as JSON first.
+        if raw.startswith("{"):
+            with contextlib.suppress(json.JSONDecodeError):
+                raw = json.loads(raw)
+
+    if isinstance(raw, dict):
+        return _from_dict(raw)
+
+    # Plain text fall-back.
+    return _from_text(str(raw))
+
+
+def _from_dict(d: dict) -> WeatherInfo:
+    is_wet = float(bool(d.get("isWet") or _WET_KEYWORDS.search(str(d.get("description", "")))))
+    wind_kph = float(d.get("windSpeedKm") or d.get("wind_kph") or 0.0)
+    temperature_c = float(d.get("tempInCelsius") or d.get("temperature_c") or 0.0)
+    return WeatherInfo(is_wet=is_wet, wind_kph=wind_kph, temperature_c=temperature_c, missing=0.0)
+
+
+def _from_text(text: str) -> WeatherInfo:
+    is_wet = 1.0 if _WET_KEYWORDS.search(text) else 0.0
+
+    # Temperature: looks for "22°C" or "22 C" or "22 degrees"
+    temp_match = re.search(r"(-?\d+(?:\.\d+)?)\s*[°º]?\s*[Cc](?:\b|elsius|\s|$)", text)
+    temperature_c = float(temp_match.group(1)) if temp_match else 0.0
+
+    # Wind: looks for "20 km/h", "20 kph", "20kmh", "20 KPH"
+    wind_match = re.search(r"(\d+(?:\.\d+)?)\s*(?:km/?h|kph|kmh)\b", text, re.IGNORECASE)
+    wind_kph = float(wind_match.group(1)) if wind_match else 0.0
+
+    return WeatherInfo(is_wet=is_wet, wind_kph=wind_kph, temperature_c=temperature_c, missing=0.0)

--- a/tests/test_baseline_metrics.py
+++ b/tests/test_baseline_metrics.py
@@ -32,12 +32,12 @@ SEASONS = (2024, 2025)
 
 # Snapshot from a 2024+2025 backfill on 2026-04-21 (213 matches/season,
 # draws dropped → 424 scored predictions).
-# Logistic numbers updated in #55 (travel & scheduling features added to pipeline).
-# Travel features hurt logistic on this sample size — documented in docs/model.md.
+# Logistic updated in #55 (travel) and #54 (weather/venue). Extra features
+# increase variance at this sample size; expected to help tree models with more data.
 EXPECTED = {
     "home": {"n": 424, "accuracy": 0.5731, "log_loss": 0.6835, "brier": 0.2452},
     "elo": {"n": 424, "accuracy": 0.5943, "log_loss": 0.6570, "brier": 0.2325},
-    "logistic": {"n": 424, "accuracy": 0.5637, "log_loss": 0.7226, "brier": 0.2557},
+    "logistic": {"n": 424, "accuracy": 0.5637, "log_loss": 0.7636, "brier": 0.2655},
 }
 
 PREDICTORS: dict[str, type[Predictor]] = {

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,264 @@
+"""Tests for weather parsing and venue rolling stats integration."""
+
+from __future__ import annotations
+
+from datetime import UTC
+
+import pytest
+
+from fantasy_coach.weather import _MISSING, WeatherInfo, parse_weather
+
+# ---------------------------------------------------------------------------
+# parse_weather — null / missing inputs
+# ---------------------------------------------------------------------------
+
+
+def test_parse_none_returns_missing() -> None:
+    result = parse_weather(None)
+    assert result == _MISSING
+    assert result.missing == 1.0
+
+
+def test_parse_empty_string_returns_missing() -> None:
+    assert parse_weather("") == _MISSING
+    assert parse_weather("   ") == _MISSING
+
+
+# ---------------------------------------------------------------------------
+# parse_weather — structured dict (NRL 2026+ format)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_dict_wet_conditions() -> None:
+    raw = {"isWet": True, "tempInCelsius": 18, "windSpeedKm": 25, "description": "Heavy Rain"}
+    result = parse_weather(raw)
+    assert result.is_wet == 1.0
+    assert result.temperature_c == pytest.approx(18.0)
+    assert result.wind_kph == pytest.approx(25.0)
+    assert result.missing == 0.0
+
+
+def test_parse_dict_dry_conditions() -> None:
+    raw = {"isWet": False, "tempInCelsius": 24, "windSpeedKm": 10, "description": "Fine"}
+    result = parse_weather(raw)
+    assert result.is_wet == 0.0
+    assert result.temperature_c == pytest.approx(24.0)
+    assert result.wind_kph == pytest.approx(10.0)
+
+
+def test_parse_dict_wet_via_description_keyword() -> None:
+    # isWet missing but description says "shower"
+    raw = {"tempInCelsius": 15, "windSpeedKm": 0, "description": "Shower expected"}
+    result = parse_weather(raw)
+    assert result.is_wet == 1.0
+
+
+def test_parse_dict_missing_fields_default_to_zero() -> None:
+    result = parse_weather({"description": "Fine"})
+    assert result.wind_kph == 0.0
+    assert result.temperature_c == 0.0
+    assert result.missing == 0.0
+
+
+# ---------------------------------------------------------------------------
+# parse_weather — JSON string (dict serialised as string)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_json_string() -> None:
+    import json
+
+    raw = json.dumps({"isWet": True, "tempInCelsius": 12, "windSpeedKm": 35})
+    result = parse_weather(raw)
+    assert result.is_wet == 1.0
+    assert result.temperature_c == pytest.approx(12.0)
+    assert result.wind_kph == pytest.approx(35.0)
+
+
+# ---------------------------------------------------------------------------
+# parse_weather — plain-text fallback
+# ---------------------------------------------------------------------------
+
+
+def test_parse_text_fine() -> None:
+    result = parse_weather("Fine")
+    assert result.is_wet == 0.0
+    assert result.missing == 0.0
+
+
+def test_parse_text_rain() -> None:
+    result = parse_weather("Rain, 15°C, 20 km/h")
+    assert result.is_wet == 1.0
+    assert result.temperature_c == pytest.approx(15.0)
+    assert result.wind_kph == pytest.approx(20.0)
+
+
+def test_parse_text_storm() -> None:
+    assert parse_weather("Thunderstorm").is_wet == 1.0
+
+
+def test_parse_text_wet_field() -> None:
+    assert parse_weather("Wet conditions").is_wet == 1.0
+
+
+def test_parse_text_no_temp_or_wind() -> None:
+    result = parse_weather("Partly Cloudy")
+    assert result.temperature_c == 0.0
+    assert result.wind_kph == 0.0
+    assert result.is_wet == 0.0
+
+
+def test_parse_text_negative_temperature() -> None:
+    result = parse_weather("Snow, -2°C, 10 km/h")
+    assert result.is_wet == 0.0  # "snow" not in wet keywords
+    assert result.temperature_c == pytest.approx(-2.0)
+
+
+def test_parse_text_celsius_variants() -> None:
+    assert parse_weather("22 C clear").temperature_c == pytest.approx(22.0)
+    assert parse_weather("22°C clear").temperature_c == pytest.approx(22.0)
+
+
+def test_parse_text_wind_variants() -> None:
+    assert parse_weather("15 km/h breeze").wind_kph == pytest.approx(15.0)
+    assert parse_weather("15 kph").wind_kph == pytest.approx(15.0)
+    assert parse_weather("15 kmh").wind_kph == pytest.approx(15.0)
+
+
+# ---------------------------------------------------------------------------
+# WeatherInfo helpers
+# ---------------------------------------------------------------------------
+
+
+def test_weather_info_is_named_tuple() -> None:
+    w = WeatherInfo(is_wet=1.0, wind_kph=20.0, temperature_c=18.0, missing=0.0)
+    assert w.is_wet == 1.0
+    assert w[0] == 1.0  # index access (NamedTuple)
+
+
+# ---------------------------------------------------------------------------
+# Integration: venue stats in FeatureBuilder
+# ---------------------------------------------------------------------------
+
+
+def test_venue_stats_start_at_zero() -> None:
+    from datetime import datetime
+
+    from fantasy_coach.feature_engineering import FeatureBuilder
+    from fantasy_coach.features import MatchRow, TeamRow
+
+    def _team(tid: int, score: int | None = None) -> TeamRow:
+        return TeamRow(
+            team_id=tid,
+            name=f"Team{tid}",
+            nick_name=f"T{tid}",
+            score=score,
+            players=[],
+        )
+
+    match = MatchRow(
+        match_id=1,
+        season=2025,
+        round=1,
+        start_time=datetime(2025, 3, 1, 19, 0, tzinfo=UTC),
+        match_state="FullTime",
+        venue="Suncorp Stadium",
+        venue_city="Brisbane",
+        weather=None,
+        home=_team(1, 20),
+        away=_team(2, 12),
+        team_stats=[],
+    )
+
+    builder = FeatureBuilder()
+    row = builder.feature_row(match)
+
+    # Indices 13 and 14 are venue_avg_total_points and venue_home_win_rate
+    # Before any history, venue_avg_total_points = 0, venue_home_win_rate = 0.5
+    assert row[13] == pytest.approx(0.0)
+    assert row[14] == pytest.approx(0.5)
+
+
+def test_venue_stats_update_after_record() -> None:
+    from datetime import datetime
+
+    from fantasy_coach.feature_engineering import FeatureBuilder
+    from fantasy_coach.features import MatchRow, TeamRow
+
+    def _team(tid: int, score: int | None = None) -> TeamRow:
+        return TeamRow(
+            team_id=tid,
+            name=f"Team{tid}",
+            nick_name=f"T{tid}",
+            score=score,
+            players=[],
+        )
+
+    def _match(mid: int, ts: datetime, hscore: int, ascore: int) -> MatchRow:
+        return MatchRow(
+            match_id=mid,
+            season=2025,
+            round=1,
+            start_time=ts,
+            match_state="FullTime",
+            venue="Suncorp Stadium",
+            venue_city="Brisbane",
+            weather=None,
+            home=_team(1, hscore),
+            away=_team(2, ascore),
+            team_stats=[],
+        )
+
+    builder = FeatureBuilder()
+    t0 = datetime(2025, 3, 1, 19, 0, tzinfo=UTC)
+    t1 = datetime(2025, 3, 8, 19, 0, tzinfo=UTC)
+    t2 = datetime(2025, 3, 15, 19, 0, tzinfo=UTC)
+
+    m1 = _match(1, t0, 30, 10)  # total=40, home win
+    m2 = _match(2, t1, 12, 20)  # total=32, away win
+
+    builder.record(m1)
+    builder.record(m2)
+
+    m3 = _match(3, t2, 20, 18)
+    row = builder.feature_row(m3)
+
+    # After 2 matches: avg total = (40 + 32) / 2 = 36
+    assert row[13] == pytest.approx(36.0)
+    # home_win_rate = 1/2 = 0.5
+    assert row[14] == pytest.approx(0.5)
+
+
+def test_weather_features_wired_into_feature_row() -> None:
+    from datetime import datetime
+
+    from fantasy_coach.feature_engineering import FeatureBuilder
+    from fantasy_coach.features import MatchRow, TeamRow
+
+    def _team(tid: int) -> TeamRow:
+        return TeamRow(team_id=tid, name=f"T{tid}", nick_name=f"T{tid}", score=None, players=[])
+
+    import json
+
+    match = MatchRow(
+        match_id=9,
+        season=2025,
+        round=5,
+        start_time=datetime(2025, 5, 1, tzinfo=UTC),
+        match_state="Upcoming",
+        venue="Suncorp Stadium",
+        venue_city="Brisbane",
+        weather=json.dumps({"isWet": True, "tempInCelsius": 16, "windSpeedKm": 30}),
+        home=_team(1),
+        away=_team(2),
+        team_stats=[],
+    )
+
+    builder = FeatureBuilder()
+    row = builder.feature_row(match)
+
+    # Indices: 9=is_wet, 10=wind_kph, 11=temperature_c, 12=missing_weather
+    assert row[9] == pytest.approx(1.0)  # is_wet
+    assert row[10] == pytest.approx(30.0)  # wind_kph
+    assert row[11] == pytest.approx(16.0)  # temperature_c
+    assert row[12] == pytest.approx(0.0)  # missing_weather


### PR DESCRIPTION
## Summary

- Adds `src/fantasy_coach/weather.py`: null-safe `WeatherInfo` parser handling NRL 2026+ JSON dict, JSON strings, plain-text (regex extraction), and `None` — returns explicit `missing_weather=1.0` flag rather than imputing
- Extends `FeatureBuilder` with two venue-level rolling features: `venue_avg_total_points` (window=10) and `venue_home_win_rate` (window=20, neutral prior 0.5 with no history)
- Feature vector grows from 9 → 15 features; `FEATURE_NAMES` and `TrainingFrame` updated accordingly
- `test_baseline_metrics.py` updated to pin new logistic metrics (`accuracy=0.5637, log_loss=0.7636, brier=0.2655`) — extra features increase variance at this sample size; expected to help tree models with more data

## Test plan

- [ ] `uv run pytest` — 194 tests pass
- [ ] `uv run ruff format --check . && uv run ruff check .` — clean
- [ ] `test_weather.py` — 19 tests covering None/empty, dict, JSON string, plain-text variants, FeatureBuilder integration
- [ ] `test_baseline_metrics.py` — pinned walk-forward metrics pass at 1e-3 tolerance

https://claude.ai/code/session_015kmGAV8wkUGiv8mpv8UriL