### PR TITLE
feat: match preview generation via Gemini — MatchContext + PreviewGenerator (closes #23)

### DIFF
--- a/src/fantasy_coach/commentary/__init__.py
+++ b/src/fantasy_coach/commentary/__init__.py
@@ -7,12 +7,15 @@ from fantasy_coach.commentary.cache import (
     TokenBudget,
 )
 from fantasy_coach.commentary.client import GeminiClient, GeminiResponse
+from fantasy_coach.commentary.preview import MatchContext, PreviewGenerator
 
 __all__ = [
     "BudgetExceededError",
     "CachingGeminiClient",
     "GeminiClient",
     "GeminiResponse",
+    "MatchContext",
+    "PreviewGenerator",
     "ResponseCache",
     "TokenBudget",
 ]

--- a/src/fantasy_coach/commentary/preview.py
+++ b/src/fantasy_coach/commentary/preview.py
@@ -1,0 +1,164 @@
+"""Match preview generation via Gemini.
+
+Builds a structured prompt from prediction + feature context, calls
+CachingGeminiClient, and returns a 2–3 sentence natural-language preview.
+
+Cache key: the prompt incorporates matchId + modelVersion, so the SHA-256
+cache key in ResponseCache implicitly acts as a (matchId, modelVersion) cache.
+
+Budget: 150 output tokens per match ≈ 2–3 sentences.  Eight matches/round ×
+150 tokens ≈ 1 200 tokens output, well under $0.01/round at Flash pricing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+from fantasy_coach.commentary.cache import CachingGeminiClient
+from fantasy_coach.feature_engineering import FEATURE_NAMES
+
+_SYSTEM = (
+    "You are a concise NRL match analyst. "
+    "Write exactly 2–3 sentence match previews using only the facts provided — "
+    "never invent statistics. Active voice. Direct. No filler phrases."
+)
+
+# Tokens per call — enforces <$0.01/round of 8 matches at Gemini Flash pricing.
+_MAX_OUTPUT_TOKENS = 150
+
+# 7-day TTL: predictions for a round don't change once generated.
+_TTL = 7 * 24 * 3600.0
+
+# +1 = higher value favours home, -1 = higher value favours away, 0 = skip.
+_FEATURE_POLARITY: dict[str, int] = {
+    "elo_diff": 1,
+    "form_diff_pf": 1,
+    "form_diff_pa": -1,
+    "days_rest_diff": 1,
+    "h2h_recent_diff": 1,
+    "is_home_field": 0,
+    "travel_km_diff": -1,
+    "timezone_delta_diff": -1,
+    "back_to_back_short_week_diff": -1,
+    "is_wet": 0,
+    "wind_kph": 0,
+    "temperature_c": 0,
+    "missing_weather": 0,
+    "venue_avg_total_points": 0,
+    "venue_home_win_rate": 1,
+}
+
+_FEATURE_LABELS: dict[str, str] = {
+    "elo_diff": "Elo rating advantage",
+    "form_diff_pf": "recent scoring form",
+    "form_diff_pa": "recent defensive form",
+    "days_rest_diff": "rest advantage",
+    "h2h_recent_diff": "head-to-head record",
+    "travel_km_diff": "travel burden",
+    "timezone_delta_diff": "timezone adjustment",
+    "back_to_back_short_week_diff": "back-to-back travel fatigue",
+    "venue_home_win_rate": "venue home-win rate",
+}
+
+
+@dataclass
+class MatchContext:
+    """All facts available to the preview prompt — no fabrication beyond these."""
+
+    match_id: int
+    home_name: str
+    away_name: str
+    predicted_winner: str  # "home" | "away"
+    home_win_prob: float
+    model_version: str
+    venue: str | None = None
+    feature_row: Sequence[float] | None = None
+    feature_names: Sequence[str] = field(default_factory=lambda: list(FEATURE_NAMES))
+
+
+class PreviewGenerator:
+    """Generate a cached 2–3 sentence match preview via Gemini.
+
+    Usage::
+
+        gen = PreviewGenerator(caching_client)
+        text = gen.generate(ctx)
+    """
+
+    def __init__(
+        self,
+        client: CachingGeminiClient,
+        *,
+        max_output_tokens: int = _MAX_OUTPUT_TOKENS,
+        ttl: float | None = _TTL,
+    ) -> None:
+        self._client = client
+        self._max_output_tokens = max_output_tokens
+        self._ttl = ttl
+
+    def generate(self, ctx: MatchContext) -> str:
+        """Return a preview string; result is cached by matchId + modelVersion."""
+        prompt = _build_prompt(ctx)
+        response = self._client.generate(
+            prompt,
+            system=_SYSTEM,
+            max_output_tokens=self._max_output_tokens,
+            ttl=self._ttl,
+        )
+        return response.text.strip()
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction
+# ---------------------------------------------------------------------------
+
+
+def _build_prompt(ctx: MatchContext) -> str:
+    winner_name = ctx.home_name if ctx.predicted_winner == "home" else ctx.away_name
+    confidence = ctx.home_win_prob if ctx.predicted_winner == "home" else 1 - ctx.home_win_prob
+
+    lines: list[str] = [
+        f"[match_id={ctx.match_id} model={ctx.model_version}]",
+        f"Teams: {ctx.home_name} (home) vs {ctx.away_name} (away)",
+    ]
+    if ctx.venue:
+        lines.append(f"Venue: {ctx.venue}")
+
+    lines.append(f"Model pick: {winner_name} ({confidence:.0%} win probability)")
+
+    drivers = _top_drivers(ctx)
+    if drivers:
+        lines.append("Key factors favouring the pick:")
+        for label in drivers:
+            lines.append(f"  - {label}")
+
+    lines.append(
+        f"\nWrite a 2–3 sentence preview explaining why {winner_name} is favoured. "
+        "Use only the facts listed above."
+    )
+    return "\n".join(lines)
+
+
+def _top_drivers(ctx: MatchContext, n: int = 3) -> list[str]:
+    """Return up to n human-readable driver labels ranked by strength."""
+    if not ctx.feature_row:
+        return []
+
+    home_pick = ctx.predicted_winner == "home"
+    scored: list[tuple[float, str]] = []
+
+    for fname, val in zip(ctx.feature_names, ctx.feature_row, strict=False):
+        polarity = _FEATURE_POLARITY.get(fname, 0)
+        if polarity == 0:
+            continue
+        label = _FEATURE_LABELS.get(fname)
+        if label is None:
+            continue
+        # Effective strength: how much does this feature favour the predicted winner?
+        effective = val * polarity * (1.0 if home_pick else -1.0)
+        if effective > 0:
+            scored.append((effective, label))
+
+    scored.sort(reverse=True)
+    return [label for _, label in scored[:n]]

--- a/tests/test_commentary_preview.py
+++ b/tests/test_commentary_preview.py
@@ -1,0 +1,307 @@
+"""Tests for PreviewGenerator and prompt-building helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from fantasy_coach.commentary.cache import CachingGeminiClient, ResponseCache, TokenBudget
+from fantasy_coach.commentary.client import GeminiClient, GeminiResponse
+from fantasy_coach.commentary.preview import (
+    MatchContext,
+    PreviewGenerator,
+    _build_prompt,
+    _top_drivers,
+)
+from fantasy_coach.feature_engineering import FEATURE_NAMES
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _fake_caching_client(text: str = "Broncos to win.") -> CachingGeminiClient:
+    """Return a CachingGeminiClient whose underlying GeminiClient is mocked."""
+    mock_client = MagicMock(spec=GeminiClient)
+    mock_client._model = "gemini-2.0-flash-001"
+    mock_client.generate.return_value = GeminiResponse(text=text, input_tokens=80, output_tokens=20)
+    return CachingGeminiClient(
+        mock_client,
+        cache=ResponseCache(default_ttl=3600),
+        budget=TokenBudget(per_request_max=200, daily_limit=10_000),
+    )
+
+
+def _ctx(
+    *,
+    match_id: int = 1,
+    home: str = "Broncos",
+    away: str = "Storm",
+    winner: str = "home",
+    prob: float = 0.63,
+    version: str = "abc123",
+    venue: str | None = "Suncorp Stadium",
+    feature_row: list[float] | None = None,
+) -> MatchContext:
+    return MatchContext(
+        match_id=match_id,
+        home_name=home,
+        away_name=away,
+        predicted_winner=winner,
+        home_win_prob=prob,
+        model_version=version,
+        venue=venue,
+        feature_row=feature_row,
+    )
+
+
+# ---------------------------------------------------------------------------
+# MatchContext
+# ---------------------------------------------------------------------------
+
+
+def test_match_context_defaults() -> None:
+    ctx = MatchContext(
+        match_id=5,
+        home_name="Raiders",
+        away_name="Panthers",
+        predicted_winner="away",
+        home_win_prob=0.42,
+        model_version="v1",
+    )
+    assert ctx.venue is None
+    assert ctx.feature_row is None
+    assert list(ctx.feature_names) == list(FEATURE_NAMES)
+
+
+def test_match_context_custom_feature_names() -> None:
+    ctx = MatchContext(
+        match_id=1,
+        home_name="A",
+        away_name="B",
+        predicted_winner="home",
+        home_win_prob=0.6,
+        model_version="v1",
+        feature_names=["f1", "f2"],
+    )
+    assert list(ctx.feature_names) == ["f1", "f2"]
+
+
+# ---------------------------------------------------------------------------
+# _build_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_contains_team_names() -> None:
+    ctx = _ctx(home="Broncos", away="Storm")
+    prompt = _build_prompt(ctx)
+    assert "Broncos" in prompt
+    assert "Storm" in prompt
+
+
+def test_prompt_contains_match_id_and_model_version() -> None:
+    ctx = _ctx(match_id=42, version="deadbeef")
+    prompt = _build_prompt(ctx)
+    assert "42" in prompt
+    assert "deadbeef" in prompt
+
+
+def test_prompt_contains_venue_when_set() -> None:
+    ctx = _ctx(venue="Suncorp Stadium")
+    assert "Suncorp Stadium" in _build_prompt(ctx)
+
+
+def test_prompt_omits_venue_when_none() -> None:
+    ctx = _ctx(venue=None)
+    assert "Venue" not in _build_prompt(ctx)
+
+
+def test_prompt_home_winner_confidence() -> None:
+    ctx = _ctx(winner="home", prob=0.63, home="Broncos")
+    prompt = _build_prompt(ctx)
+    assert "Broncos" in prompt
+    assert "63%" in prompt
+
+
+def test_prompt_away_winner_confidence() -> None:
+    ctx = _ctx(winner="away", prob=0.38, away="Storm")
+    prompt = _build_prompt(ctx)
+    assert "Storm" in prompt
+    assert "62%" in prompt  # 1 - 0.38
+
+
+def test_prompt_includes_drivers_when_feature_row_present() -> None:
+    # elo_diff=10 favours home
+    row = [0.0] * len(FEATURE_NAMES)
+    row[0] = 10.0  # elo_diff
+    ctx = _ctx(feature_row=row, winner="home")
+    prompt = _build_prompt(ctx)
+    assert "Elo rating advantage" in prompt
+
+
+def test_prompt_no_drivers_section_without_feature_row() -> None:
+    ctx = _ctx(feature_row=None)
+    assert "Key factors" not in _build_prompt(ctx)
+
+
+# ---------------------------------------------------------------------------
+# _top_drivers
+# ---------------------------------------------------------------------------
+
+
+def _feature_row(**kwargs: float) -> list[float]:
+    """Build a feature row with named overrides; all others zero."""
+    names = list(FEATURE_NAMES)
+    row = [0.0] * len(names)
+    for k, v in kwargs.items():
+        row[names.index(k)] = v
+    return row
+
+
+def test_top_drivers_home_pick_elo() -> None:
+    row = _feature_row(elo_diff=50.0)
+    ctx = _ctx(feature_row=row, winner="home")
+    drivers = _top_drivers(ctx)
+    assert "Elo rating advantage" in drivers
+
+
+def test_top_drivers_away_pick_elo() -> None:
+    # elo_diff negative → home Elo < away Elo → away advantage
+    row = _feature_row(elo_diff=-30.0)
+    ctx = _ctx(feature_row=row, winner="away")
+    drivers = _top_drivers(ctx)
+    assert "Elo rating advantage" in drivers
+
+
+def test_top_drivers_opposing_feature_excluded() -> None:
+    # elo_diff positive favours home; predicted winner is away → should NOT appear
+    row = _feature_row(elo_diff=50.0)
+    ctx = _ctx(feature_row=row, winner="away")
+    drivers = _top_drivers(ctx)
+    assert "Elo rating advantage" not in drivers
+
+
+def test_top_drivers_pa_polarity() -> None:
+    # form_diff_pa polarity=-1: negative value = home concedes less = home advantage
+    row = _feature_row(form_diff_pa=-5.0)
+    ctx = _ctx(feature_row=row, winner="home")
+    drivers = _top_drivers(ctx)
+    assert "recent defensive form" in drivers
+
+
+def test_top_drivers_skips_is_home_field_and_weather_flags() -> None:
+    row = _feature_row(is_home_field=1.0, missing_weather=1.0, is_wet=1.0, wind_kph=30.0)
+    ctx = _ctx(feature_row=row, winner="home")
+    drivers = _top_drivers(ctx)
+    assert not drivers  # all polarity-0 features, nothing to rank
+
+
+def test_top_drivers_returns_at_most_n() -> None:
+    row = _feature_row(elo_diff=50.0, form_diff_pf=10.0, days_rest_diff=3.0, h2h_recent_diff=8.0)
+    ctx = _ctx(feature_row=row, winner="home")
+    assert len(_top_drivers(ctx, n=3)) <= 3
+
+
+def test_top_drivers_ranked_by_magnitude() -> None:
+    row = _feature_row(elo_diff=100.0, form_diff_pf=5.0)
+    ctx = _ctx(feature_row=row, winner="home")
+    drivers = _top_drivers(ctx, n=2)
+    assert drivers[0] == "Elo rating advantage"
+    assert drivers[1] == "recent scoring form"
+
+
+def test_top_drivers_empty_when_no_feature_row() -> None:
+    ctx = _ctx(feature_row=None)
+    assert _top_drivers(ctx) == []
+
+
+# ---------------------------------------------------------------------------
+# PreviewGenerator — happy path + caching
+# ---------------------------------------------------------------------------
+
+
+def test_preview_generator_returns_text() -> None:
+    client = _fake_caching_client("Brisbane Broncos should win comfortably.")
+    gen = PreviewGenerator(client)
+    result = gen.generate(_ctx())
+    assert result == "Brisbane Broncos should win comfortably."
+
+
+def test_preview_generator_strips_whitespace() -> None:
+    client = _fake_caching_client("  Preview text.  \n")
+    gen = PreviewGenerator(client)
+    assert gen.generate(_ctx()) == "Preview text."
+
+
+def test_preview_generator_caches_identical_context() -> None:
+    mock_inner = MagicMock(spec=GeminiClient)
+    mock_inner._model = "gemini-2.0-flash-001"
+    mock_inner.generate.return_value = GeminiResponse(
+        text="Cached.", input_tokens=50, output_tokens=10
+    )
+    caching = CachingGeminiClient(
+        mock_inner,
+        cache=ResponseCache(default_ttl=3600),
+        budget=TokenBudget(per_request_max=200, daily_limit=10_000),
+    )
+    gen = PreviewGenerator(caching)
+    ctx = _ctx(match_id=7, version="v1")
+
+    gen.generate(ctx)
+    gen.generate(ctx)  # second call — should hit cache
+
+    assert mock_inner.generate.call_count == 1  # live call only once
+
+
+def test_preview_generator_different_match_ids_no_cache_collision() -> None:
+    mock_inner = MagicMock(spec=GeminiClient)
+    mock_inner._model = "gemini-2.0-flash-001"
+    mock_inner.generate.return_value = GeminiResponse(
+        text="Text.", input_tokens=50, output_tokens=10
+    )
+    caching = CachingGeminiClient(
+        mock_inner,
+        cache=ResponseCache(default_ttl=3600),
+        budget=TokenBudget(per_request_max=200, daily_limit=10_000),
+    )
+    gen = PreviewGenerator(caching)
+
+    gen.generate(_ctx(match_id=1, version="v1"))
+    gen.generate(_ctx(match_id=2, version="v1"))
+
+    assert mock_inner.generate.call_count == 2
+
+
+def test_preview_generator_different_model_versions_no_cache_collision() -> None:
+    mock_inner = MagicMock(spec=GeminiClient)
+    mock_inner._model = "gemini-2.0-flash-001"
+    mock_inner.generate.return_value = GeminiResponse(
+        text="Text.", input_tokens=50, output_tokens=10
+    )
+    caching = CachingGeminiClient(
+        mock_inner,
+        cache=ResponseCache(default_ttl=3600),
+        budget=TokenBudget(per_request_max=200, daily_limit=10_000),
+    )
+    gen = PreviewGenerator(caching)
+
+    gen.generate(_ctx(match_id=1, version="v1"))
+    gen.generate(_ctx(match_id=1, version="v2"))
+
+    assert mock_inner.generate.call_count == 2
+
+
+def test_preview_generator_custom_token_cap() -> None:
+    mock_inner = MagicMock(spec=GeminiClient)
+    mock_inner._model = "gemini-2.0-flash-001"
+    mock_inner.generate.return_value = GeminiResponse(
+        text="Short.", input_tokens=50, output_tokens=10
+    )
+    caching = CachingGeminiClient(
+        mock_inner,
+        cache=ResponseCache(),
+        budget=TokenBudget(per_request_max=200, daily_limit=10_000),
+    )
+    gen = PreviewGenerator(caching, max_output_tokens=100)
+    gen.generate(_ctx())
+    _, kwargs = mock_inner.generate.call_args
+    assert kwargs["max_output_tokens"] == 100


### PR DESCRIPTION
## Summary

- Adds `src/fantasy_coach/commentary/preview.py`:
  - `MatchContext` dataclass — facts-only carrier (teams, venue, prediction, feature row) with no fabricated fields
  - `PreviewGenerator` — wraps `CachingGeminiClient`, builds structured prompt, returns a trimmed 2–3 sentence preview
  - `_top_drivers()` — ranks feature deltas by polarity-weighted magnitude to identify the top-3 drivers of the predicted winner; skips directionally-ambiguous features (`is_home_field`, weather scalars, etc.)
  - Prompt includes `match_id` + `model_version` header so the SHA-256 cache key in `ResponseCache` acts as a `(matchId, modelVersion)` cache — no separate lookup needed
- Token cap: 150 output tokens/match → ≈ 1,200 tokens/round → well under $0.01/round at Gemini Flash pricing
- TTL: 7 days (round predictions don't change)
- Exports `MatchContext` and `PreviewGenerator` from `commentary/__init__.py`

## Test plan

- [ ] `uv run pytest` — 218 tests pass (24 new in `tests/test_commentary_preview.py`)
- [ ] `uv run ruff format --check . && uv run ruff check .` — clean
- [ ] Tests cover: `MatchContext` defaults, prompt structure, driver ranking/polarity/exclusion, cache hit on identical context, no cache collision across different match IDs / model versions, custom token cap forwarded correctly

https://claude.ai/code/session_015kmGAV8wkUGiv8mpv8UriL