### PR TITLE
feat: referee effects — referee_id extraction, schema v2 migration, rolling ref stats (closes #57)

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -23,6 +23,37 @@ each match using only matches whose `start_time` precedes it — no leakage.
 | `days_rest_diff`  | Days between this match and the team's previous match, home minus away. First-of-season clamped to 14.  | Short-week games (4–5 days) measurably underperform 7-day games in the NRL. |
 | `h2h_recent_diff` | Average score margin in the last 3 head-to-head matchups, from the home team's perspective.             | Stylistic mismatches show up in repeated head-to-heads (e.g. forward packs that consistently beat smaller teams). |
 | `is_home_field`   | Constant `1.0`.                                                                                         | Lets the intercept absorb a stable home-field bias rather than letting it leak into other features. |
+| `travel_km_diff`  | Great-circle km the home team travelled from their last venue minus the same for the away team.         | Long-haul trips (e.g. Perth-to-Brisbane) impose measurable fatigue when combined with a short week. |
+| `timezone_delta_diff` | Absolute timezone-shift hours between the team's last venue and the current venue, home minus away. | Eastward shifts disrupt circadian rhythms more than equivalent westward shifts. |
+| `back_to_back_short_week_diff` | `+1` if home team has `rest < 6 days AND travel > 1 000 km`; `-1` for away; `0` otherwise. | Captures the specific "brutal" scenario; orthogonal to `travel_km_diff` and `days_rest_diff`. |
+| `is_wet`          | `1.0` if weather is wet/rainy (from structured NRL weather block or keyword match); else `0.0`.         | Wet conditions suppress high-scoring, favouring defensively disciplined teams. |
+| `wind_kph`        | Wind speed in km/h; `0.0` when data absent.                                                             | Strong wind suppresses kicking game and scoring. |
+| `temperature_c`   | Temperature in Celsius; `0.0` when data absent.                                                         | Extreme heat/cold affects player endurance and injury rates. |
+| `missing_weather` | `1.0` when the weather block is absent (pre-2026 historical data).                                      | Explicit missing-data flag so the model learns a separate intercept rather than imputing zeros. |
+| `venue_avg_total_points` | Rolling-10 average total points at this venue (history-only, no current match).               | Some grounds (windy, small) consistently produce tighter games regardless of teams. |
+| `venue_home_win_rate` | Rolling-20 home win rate at this venue; defaults to 0.5 before any history.                       | Captures venue-specific home advantage — fortress grounds vs neutral-feeling venues. |
+| `ref_avg_total_points` | Rolling-20 average total points for matches officiated by this referee; shrunk toward league mean for < 10 prior matches. | Some referees blow more penalties/restarts affecting scoring pace. |
+| `ref_home_penalty_diff` | Rolling-20 average (home − away) Penalties Conceded for this referee; `0.0` when unavailable. | Captures whether a referee tends to penalise the home or away team more often. |
+| `missing_referee` | `1.0` when referee ID is absent (upcoming fixtures or pre-2026 data).                                   | Explicit missing-data flag. |
+
+### Ablation notes — referee features (#57)
+
+Walk-forward evaluation on the 2024–2025 baseline DB (424 predictions) after
+adding `ref_avg_total_points`, `ref_home_penalty_diff`, and `missing_referee`:
+
+| Metric   | Before #57 | After #57 | Δ      |
+|----------|------------|-----------|--------|
+| accuracy | 0.5637     | 0.5660    | +0.23pp |
+| log_loss | 0.7636     | 0.7640    | −0.0004 |
+| brier    | 0.2655     | 0.2654    | +0.0001 |
+
+**Result: no meaningful signal** — the change is within noise. The root cause is
+that the 2024–2025 baseline DB was built at schema v1 (before referee IDs were
+extracted), so `referee_id = NULL` for every historical match; all predictions
+fall back to `missing_referee = 1.0` and the league-mean prior for
+`ref_avg_total_points`. The features are structurally correct and will accumulate
+signal as new rounds are ingested with referee data. They remain active in the
+feature vector; revisit with at least one full season of referee-annotated matches.
 
 ### What's deliberately *not* in here
 

--- a/src/fantasy_coach/feature_engineering.py
+++ b/src/fantasy_coach/feature_engineering.py
@@ -54,6 +54,9 @@ FEATURE_NAMES = (
     "missing_weather",
     "venue_avg_total_points",
     "venue_home_win_rate",
+    "ref_avg_total_points",
+    "ref_home_penalty_diff",
+    "missing_referee",
 )
 
 VENUE_TOTAL_WINDOW = 10
@@ -62,6 +65,9 @@ VENUE_WIN_WINDOW = 20
 ROLLING_WINDOW = 5
 H2H_WINDOW = 3
 DEFAULT_DAYS_REST = 14
+
+REF_WINDOW = 20  # rolling window for referee stats
+REF_SHRINKAGE_N = 10  # shrink toward league mean for fewer than N prior matches
 
 
 @dataclass(frozen=True)
@@ -100,6 +106,13 @@ class FeatureBuilder:
         self._venue_home_wins: dict[str, deque[int]] = defaultdict(
             lambda: deque(maxlen=VENUE_WIN_WINDOW)
         )
+        # Referee-level rolling stats (keyed by referee profileId).
+        self._ref_total: dict[int, deque[int]] = defaultdict(lambda: deque(maxlen=REF_WINDOW))
+        self._ref_penalty_diff: dict[int, deque[float]] = defaultdict(
+            lambda: deque(maxlen=REF_WINDOW)
+        )
+        # League-wide rolling totals for shrinkage prior.
+        self._league_total: deque[int] = deque(maxlen=REF_WINDOW * 5)
 
     def feature_row(self, match: MatchRow) -> list[float]:
         h_id, a_id = match.home.team_id, match.away.team_id
@@ -126,6 +139,7 @@ class FeatureBuilder:
         venue_hwr = (
             _avg(self._venue_home_wins[vkey]) if (vkey and self._venue_home_wins[vkey]) else 0.5
         )
+        ref_tp, ref_pd, missing_ref = self._referee_features(match.referee_id)
         return [
             elo_diff,
             form_pf_h - form_pf_a,
@@ -142,7 +156,38 @@ class FeatureBuilder:
             wx.missing,
             venue_avg_tp,
             venue_hwr,
+            ref_tp,
+            ref_pd,
+            missing_ref,
         ]
+
+    def _referee_features(self, referee_id: int | None) -> tuple[float, float, float]:
+        """Return (ref_avg_total_points, ref_home_penalty_diff, missing_referee).
+
+        Both numeric features are shrunk toward the league mean when the referee
+        has fewer than REF_SHRINKAGE_N prior observed matches.
+        """
+        if referee_id is None:
+            league_mean = _avg(self._league_total) if self._league_total else 0.0
+            return league_mean, 0.0, 1.0
+
+        history = self._ref_total[referee_id]
+        n = len(history)
+        league_mean = _avg(self._league_total) if self._league_total else 0.0
+
+        if n == 0:
+            ref_avg_tp = league_mean
+        elif n < REF_SHRINKAGE_N:
+            # Shrink toward league mean: weight = n / REF_SHRINKAGE_N
+            w = n / REF_SHRINKAGE_N
+            ref_avg_tp = w * _avg(history) + (1 - w) * league_mean
+        else:
+            ref_avg_tp = _avg(history)
+
+        penalty_hist = self._ref_penalty_diff[referee_id]
+        ref_pd = _avg(penalty_hist) if penalty_hist else 0.0
+
+        return ref_avg_tp, ref_pd, 0.0
 
     def advance_season_if_needed(self, match: MatchRow) -> None:
         """Apply Elo regression-to-mean when the season changes."""
@@ -174,6 +219,14 @@ class FeatureBuilder:
         if vkey:
             self._venue_total[vkey].append(h_score + a_score)
             self._venue_home_wins[vkey].append(1 if h_score > a_score else 0)
+        # Update referee rolling stats.
+        total_points = h_score + a_score
+        self._league_total.append(total_points)
+        if match.referee_id is not None:
+            self._ref_total[match.referee_id].append(total_points)
+            penalty_diff = _penalty_diff(match)
+            if penalty_diff is not None:
+                self._ref_penalty_diff[match.referee_id].append(penalty_diff)
 
 
 def build_training_frame(
@@ -262,3 +315,15 @@ def _signed_h2h(home_id: int, away_id: int, home_score: int, away_score: int) ->
     if home_id <= away_id:
         return home_score - away_score
     return away_score - home_score
+
+
+def _penalty_diff(match: MatchRow) -> float | None:
+    """Return home_penalties_conceded - away_penalties_conceded, or None if unavailable."""
+    for stat in match.team_stats:
+        if (
+            stat.title == "Penalties Conceded"
+            and stat.home_value is not None
+            and stat.away_value is not None
+        ):
+            return float(stat.home_value) - float(stat.away_value)
+    return None

--- a/src/fantasy_coach/features.py
+++ b/src/fantasy_coach/features.py
@@ -121,6 +121,8 @@ class MatchRow(BaseModel):
     home: TeamRow
     away: TeamRow
     team_stats: list[TeamStat]
+    referee_id: int | None = None
+    video_referee_id: int | None = None
 
 
 def extract_match_features(raw: dict[str, Any]) -> MatchRow:
@@ -129,6 +131,7 @@ def extract_match_features(raw: dict[str, Any]) -> MatchRow:
     _log_unknown_keys("match", raw, _KNOWN_TOP_LEVEL_KEYS)
 
     start_time = _parse_iso_utc(raw["startTime"])
+    referee_id, video_referee_id = _extract_referee_ids(raw.get("officials") or [])
 
     return MatchRow(
         match_id=int(raw["matchId"]),
@@ -142,6 +145,8 @@ def extract_match_features(raw: dict[str, Any]) -> MatchRow:
         home=_extract_team(raw["homeTeam"]),
         away=_extract_team(raw["awayTeam"]),
         team_stats=_extract_team_stats(raw.get("stats") or {}),
+        referee_id=referee_id,
+        video_referee_id=video_referee_id,
     )
 
 
@@ -200,6 +205,26 @@ def _optional_int(raw: Any) -> int | None:
 def _parse_iso_utc(raw: str) -> datetime:
     # `2024-03-03T02:30:00Z` — fromisoformat handles `Z` from Python 3.11+.
     return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+
+
+def _extract_referee_ids(officials: list[dict[str, Any]]) -> tuple[int | None, int | None]:
+    """Return (referee_id, video_referee_id) from the officials array.
+
+    NRL positions: "Referee" = main on-field referee, "Senior Review Official" = video ref.
+    Both default to None when the officials block is absent (upcoming fixtures).
+    """
+    referee_id: int | None = None
+    video_referee_id: int | None = None
+    for official in officials:
+        pid = official.get("profileId")
+        if pid is None:
+            continue
+        position = (official.get("position") or "").strip()
+        if position == "Referee" and referee_id is None:
+            referee_id = int(pid)
+        elif position == "Senior Review Official" and video_referee_id is None:
+            video_referee_id = int(pid)
+    return referee_id, video_referee_id
 
 
 def _log_unknown_keys(scope: str, raw: dict[str, Any], known: set[str]) -> None:

--- a/src/fantasy_coach/storage/firestore.py
+++ b/src/fantasy_coach/storage/firestore.py
@@ -82,6 +82,8 @@ def _to_doc(row: MatchRow) -> dict[str, Any]:
         "home": _team_to_doc(row.home),
         "away": _team_to_doc(row.away),
         "team_stats": [_stat_to_doc(s) for s in row.team_stats],
+        "referee_id": row.referee_id,
+        "video_referee_id": row.video_referee_id,
     }
 
 
@@ -128,6 +130,8 @@ def _from_doc(d: dict[str, Any]) -> MatchRow:
         home=_team_from_doc(d["home"]),
         away=_team_from_doc(d["away"]),
         team_stats=[_stat_from_doc(s) for s in d.get("team_stats", [])],
+        referee_id=d.get("referee_id"),
+        video_referee_id=d.get("video_referee_id"),
     )
 
 

--- a/src/fantasy_coach/storage/schema.sql
+++ b/src/fantasy_coach/storage/schema.sql
@@ -1,30 +1,33 @@
--- Schema version 1.
+-- Schema version 2.
 --
 -- One row per match in `matches`, children (`match_players`, `match_team_stats`)
 -- keyed by match_id + side ('home' | 'away'). Upserts are done by deleting the
 -- existing match rows and re-inserting, so children stay consistent.
+-- v2 adds referee_id and video_referee_id columns to matches (NRL officials block).
 
 CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER PRIMARY KEY
 );
 
 CREATE TABLE IF NOT EXISTS matches (
-    match_id      INTEGER PRIMARY KEY,
-    season        INTEGER NOT NULL,
-    round         INTEGER NOT NULL,
-    start_time    TEXT    NOT NULL,  -- ISO 8601 UTC
-    match_state   TEXT    NOT NULL,
-    venue         TEXT,
-    venue_city    TEXT,
-    weather       TEXT,
-    home_team_id  INTEGER NOT NULL,
-    home_name     TEXT    NOT NULL,
-    home_nick     TEXT    NOT NULL,
-    home_score    INTEGER,
-    away_team_id  INTEGER NOT NULL,
-    away_name     TEXT    NOT NULL,
-    away_nick     TEXT    NOT NULL,
-    away_score    INTEGER
+    match_id         INTEGER PRIMARY KEY,
+    season           INTEGER NOT NULL,
+    round            INTEGER NOT NULL,
+    start_time       TEXT    NOT NULL,  -- ISO 8601 UTC
+    match_state      TEXT    NOT NULL,
+    venue            TEXT,
+    venue_city       TEXT,
+    weather          TEXT,
+    home_team_id     INTEGER NOT NULL,
+    home_name        TEXT    NOT NULL,
+    home_nick        TEXT    NOT NULL,
+    home_score       INTEGER,
+    away_team_id     INTEGER NOT NULL,
+    away_name        TEXT    NOT NULL,
+    away_nick        TEXT    NOT NULL,
+    away_score       INTEGER,
+    referee_id       INTEGER,   -- NRL profileId for position="Referee"
+    video_referee_id INTEGER    -- NRL profileId for position="Senior Review Official"
 );
 
 CREATE INDEX IF NOT EXISTS idx_matches_season_round

--- a/src/fantasy_coach/storage/sqlite.py
+++ b/src/fantasy_coach/storage/sqlite.py
@@ -7,6 +7,7 @@ stay consistent when a match transitions Upcoming → Live → FullTime.
 
 from __future__ import annotations
 
+import contextlib
 import sqlite3
 from datetime import datetime
 from importlib import resources
@@ -14,7 +15,7 @@ from pathlib import Path
 
 from fantasy_coach.features import MatchRow, PlayerRow, TeamRow, TeamStat
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 
 class SQLiteRepository:
@@ -43,8 +44,9 @@ class SQLiteRepository:
                     match_id, season, round, start_time, match_state,
                     venue, venue_city, weather,
                     home_team_id, home_name, home_nick, home_score,
-                    away_team_id, away_name, away_nick, away_score
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    away_team_id, away_name, away_nick, away_score,
+                    referee_id, video_referee_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     row.match_id,
@@ -63,6 +65,8 @@ class SQLiteRepository:
                     row.away.name,
                     row.away.nick_name,
                     row.away.score,
+                    row.referee_id,
+                    row.video_referee_id,
                 ),
             )
             self._insert_players(row.match_id, "home", row.home.players)
@@ -110,11 +114,22 @@ class SQLiteRepository:
                     "INSERT INTO schema_version (version) VALUES (?)",
                     (SCHEMA_VERSION,),
                 )
-        elif current["version"] != SCHEMA_VERSION:
+        elif current["version"] < SCHEMA_VERSION:
+            self._apply_migrations(current["version"])
+        elif current["version"] > SCHEMA_VERSION:
             raise RuntimeError(
                 f"SQLite DB at {self._path} is schema v{current['version']}, "
-                f"code expects v{SCHEMA_VERSION}. No migration path yet."
+                f"code expects v{SCHEMA_VERSION}. Downgrade not supported."
             )
+
+    def _apply_migrations(self, from_version: int) -> None:
+        if from_version < 2:
+            with self._conn:
+                # v1 → v2: add referee columns (ALTER TABLE is idempotent-ish via try/except)
+                for col in ("referee_id INTEGER", "video_referee_id INTEGER"):
+                    with contextlib.suppress(Exception):
+                        self._conn.execute(f"ALTER TABLE matches ADD COLUMN {col}")
+                self._conn.execute("UPDATE schema_version SET version = 2")
 
     def _insert_players(self, match_id: int, side: str, players: list[PlayerRow]) -> None:
         if not players:
@@ -220,6 +235,8 @@ class SQLiteRepository:
                 )
                 for s in stats
             ],
+            referee_id=match["referee_id"],
+            video_referee_id=match["video_referee_id"],
         )
 
     @staticmethod

--- a/tests/fixtures/extracted/extracted-2024-finals-week-1-game-1.json
+++ b/tests/fixtures/extracted/extracted-2024-finals-week-1-game-1.json
@@ -500,5 +500,7 @@
       "home_value": 8.0,
       "away_value": 8.0
     }
-  ]
+  ],
+  "referee_id": 500039,
+  "video_referee_id": 500067
 }

--- a/tests/fixtures/extracted/extracted-2024-rd1-sea-eagles-v-rabbitohs.json
+++ b/tests/fixtures/extracted/extracted-2024-rd1-sea-eagles-v-rabbitohs.json
@@ -493,5 +493,7 @@
       "home_value": 8.0,
       "away_value": 8.0
     }
-  ]
+  ],
+  "referee_id": 500039,
+  "video_referee_id": 500004
 }

--- a/tests/fixtures/extracted/extracted-2026-rd8-wests-tigers-v-raiders.json
+++ b/tests/fixtures/extracted/extracted-2026-rd8-wests-tigers-v-raiders.json
@@ -92,5 +92,7 @@
       "home_value": 39.0,
       "away_value": 48.0
     }
-  ]
+  ],
+  "referee_id": null,
+  "video_referee_id": null
 }

--- a/tests/test_baseline_metrics.py
+++ b/tests/test_baseline_metrics.py
@@ -32,12 +32,14 @@ SEASONS = (2024, 2025)
 
 # Snapshot from a 2024+2025 backfill on 2026-04-21 (213 matches/season,
 # draws dropped → 424 scored predictions).
-# Logistic updated in #55 (travel) and #54 (weather/venue). Extra features
-# increase variance at this sample size; expected to help tree models with more data.
+# Logistic updated in #55 (travel), #54 (weather/venue), and #57 (referee). Extra
+# features increase variance at this sample size; expected to help tree models with
+# more data. Referee features show negligible signal on the 2024-2025 baseline (all
+# referee_id values NULL after v1→v2 migration) — see docs/model.md for ablation notes.
 EXPECTED = {
     "home": {"n": 424, "accuracy": 0.5731, "log_loss": 0.6835, "brier": 0.2452},
     "elo": {"n": 424, "accuracy": 0.5943, "log_loss": 0.6570, "brier": 0.2325},
-    "logistic": {"n": 424, "accuracy": 0.5637, "log_loss": 0.7636, "brier": 0.2655},
+    "logistic": {"n": 424, "accuracy": 0.5660, "log_loss": 0.7640, "brier": 0.2654},
 }
 
 PREDICTORS: dict[str, type[Predictor]] = {

--- a/tests/test_referee_features.py
+++ b/tests/test_referee_features.py
@@ -1,0 +1,389 @@
+"""Tests for referee extraction, storage migration, and feature engineering."""
+
+from __future__ import annotations
+
+import tempfile
+from datetime import UTC, datetime
+
+import pytest
+
+from fantasy_coach.feature_engineering import FEATURE_NAMES, REF_SHRINKAGE_N, FeatureBuilder
+from fantasy_coach.features import MatchRow, TeamRow, _extract_referee_ids, extract_match_features
+from fantasy_coach.storage.sqlite import SQLiteRepository
+
+# ---------------------------------------------------------------------------
+# _extract_referee_ids
+# ---------------------------------------------------------------------------
+
+
+def test_extract_referee_ids_from_officials_array() -> None:
+    officials = [
+        {"profileId": 500039, "position": "Referee", "firstName": "Ashley", "lastName": "Klein"},
+        {
+            "profileId": 500068,
+            "position": "Touch Judge",
+            "firstName": "Chris",
+            "lastName": "Sutton",
+        },
+        {
+            "profileId": 500004,
+            "position": "Senior Review Official",
+            "firstName": "Gerard",
+            "lastName": "Sutton",
+        },
+    ]
+    ref_id, vref_id = _extract_referee_ids(officials)
+    assert ref_id == 500039
+    assert vref_id == 500004
+
+
+def test_extract_referee_ids_no_officials() -> None:
+    ref_id, vref_id = _extract_referee_ids([])
+    assert ref_id is None
+    assert vref_id is None
+
+
+def test_extract_referee_ids_only_touch_judges() -> None:
+    officials = [
+        {"profileId": 1, "position": "Touch Judge", "firstName": "A", "lastName": "B"},
+    ]
+    ref_id, vref_id = _extract_referee_ids(officials)
+    assert ref_id is None
+    assert vref_id is None
+
+
+def test_extract_referee_ids_missing_profile_id() -> None:
+    officials = [{"position": "Referee", "firstName": "Unknown", "lastName": "Official"}]
+    ref_id, vref_id = _extract_referee_ids(officials)
+    assert ref_id is None
+
+
+def test_extract_referee_ids_takes_first_referee() -> None:
+    officials = [
+        {"profileId": 111, "position": "Referee"},
+        {"profileId": 222, "position": "Referee"},
+    ]
+    ref_id, _ = _extract_referee_ids(officials)
+    assert ref_id == 111
+
+
+# ---------------------------------------------------------------------------
+# extract_match_features — referee fields
+# ---------------------------------------------------------------------------
+
+
+def test_extract_match_features_captures_referee_ids() -> None:
+    raw = {
+        "matchId": "1",
+        "roundNumber": "1",
+        "startTime": "2024-03-03T02:30:00Z",
+        "matchState": "FullTime",
+        "homeTeam": {"teamId": "1", "name": "Home", "nickName": "H", "score": 20, "players": []},
+        "awayTeam": {"teamId": "2", "name": "Away", "nickName": "A", "score": 10, "players": []},
+        "officials": [
+            {"profileId": 500039, "position": "Referee", "firstName": "X", "lastName": "Y"},
+            {
+                "profileId": 500004,
+                "position": "Senior Review Official",
+                "firstName": "A",
+                "lastName": "B",
+            },
+        ],
+    }
+    row = extract_match_features(raw)
+    assert row.referee_id == 500039
+    assert row.video_referee_id == 500004
+
+
+def test_extract_match_features_no_officials_block() -> None:
+    raw = {
+        "matchId": "2",
+        "roundNumber": "1",
+        "startTime": "2026-05-01T05:00:00Z",
+        "matchState": "Upcoming",
+        "homeTeam": {"teamId": "1", "name": "Home", "nickName": "H", "score": None, "players": []},
+        "awayTeam": {"teamId": "2", "name": "Away", "nickName": "A", "score": None, "players": []},
+    }
+    row = extract_match_features(raw)
+    assert row.referee_id is None
+    assert row.video_referee_id is None
+
+
+# ---------------------------------------------------------------------------
+# SQLite schema migration: v1 → v2
+# ---------------------------------------------------------------------------
+
+
+def _create_v1_db(path: str) -> None:
+    """Create a minimal v1 schema DB (without referee columns)."""
+    import sqlite3
+
+    conn = sqlite3.connect(path)
+    conn.executescript("""
+        CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+        INSERT INTO schema_version VALUES (1);
+        CREATE TABLE matches (
+            match_id INTEGER PRIMARY KEY,
+            season INTEGER NOT NULL,
+            round INTEGER NOT NULL,
+            start_time TEXT NOT NULL,
+            match_state TEXT NOT NULL,
+            venue TEXT, venue_city TEXT, weather TEXT,
+            home_team_id INTEGER NOT NULL, home_name TEXT NOT NULL,
+            home_nick TEXT NOT NULL, home_score INTEGER,
+            away_team_id INTEGER NOT NULL, away_name TEXT NOT NULL,
+            away_nick TEXT NOT NULL, away_score INTEGER
+        );
+        CREATE TABLE IF NOT EXISTS match_players (
+            match_id INTEGER NOT NULL, side TEXT NOT NULL,
+            player_id INTEGER NOT NULL, jersey_number INTEGER,
+            position TEXT, first_name TEXT, last_name TEXT,
+            PRIMARY KEY (match_id, side, player_id)
+        );
+        CREATE TABLE IF NOT EXISTS match_team_stats (
+            match_id INTEGER NOT NULL, ordinal INTEGER NOT NULL,
+            title TEXT NOT NULL, type TEXT NOT NULL,
+            units TEXT, home_value REAL, away_value REAL,
+            PRIMARY KEY (match_id, ordinal)
+        );
+    """)
+    conn.execute(
+        """
+        INSERT INTO matches (match_id, season, round, start_time, match_state,
+            home_team_id, home_name, home_nick, away_team_id, away_name, away_nick)
+        VALUES (42, 2024, 1, '2024-03-03T02:30:00+00:00', 'FullTime', 1, 'H', 'H', 2, 'A', 'A')
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_sqlite_v1_to_v2_migration() -> None:
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = f.name
+
+    _create_v1_db(path)
+    repo = SQLiteRepository(path)
+    match = repo.get_match(42)
+    repo.close()
+
+    assert match is not None
+    assert match.referee_id is None
+    assert match.video_referee_id is None
+
+
+def test_sqlite_upsert_and_retrieve_referee_ids() -> None:
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        path = f.name
+
+    row = MatchRow(
+        match_id=99,
+        season=2025,
+        round=3,
+        start_time=datetime(2025, 4, 1, 19, 0, tzinfo=UTC),
+        match_state="FullTime",
+        venue="Suncorp Stadium",
+        venue_city="Brisbane",
+        weather=None,
+        home=TeamRow(team_id=1, name="Broncos", nick_name="BRI", score=24, players=[]),
+        away=TeamRow(team_id=2, name="Storm", nick_name="MEL", score=18, players=[]),
+        team_stats=[],
+        referee_id=500039,
+        video_referee_id=500004,
+    )
+
+    repo = SQLiteRepository(path)
+    repo.upsert_match(row)
+    loaded = repo.get_match(99)
+    repo.close()
+
+    assert loaded is not None
+    assert loaded.referee_id == 500039
+    assert loaded.video_referee_id == 500004
+
+
+# ---------------------------------------------------------------------------
+# FeatureBuilder — referee feature indices and values
+# ---------------------------------------------------------------------------
+
+_REF_IDX = list(FEATURE_NAMES).index("ref_avg_total_points")
+_PD_IDX = list(FEATURE_NAMES).index("ref_home_penalty_diff")
+_MISS_IDX = list(FEATURE_NAMES).index("missing_referee")
+
+
+def _team(tid: int, score: int | None = None) -> TeamRow:
+    return TeamRow(team_id=tid, name=f"T{tid}", nick_name=f"T{tid}", score=score, players=[])
+
+
+def _match(
+    mid: int,
+    ts: datetime,
+    hscore: int,
+    ascore: int,
+    referee_id: int | None = None,
+) -> MatchRow:
+    from fantasy_coach.features import TeamStat
+
+    stats = []
+    if referee_id is not None:
+        stats = [
+            TeamStat(
+                title="Penalties Conceded",
+                type="Number",
+                units=None,
+                home_value=4.0,
+                away_value=6.0,
+            )
+        ]
+    return MatchRow(
+        match_id=mid,
+        season=2025,
+        round=1,
+        start_time=ts,
+        match_state="FullTime",
+        venue="Suncorp Stadium",
+        venue_city="Brisbane",
+        weather=None,
+        home=_team(1, hscore),
+        away=_team(2, ascore),
+        team_stats=stats,
+        referee_id=referee_id,
+    )
+
+
+def test_missing_referee_flag_when_no_referee_id() -> None:
+    builder = FeatureBuilder()
+    match = MatchRow(
+        match_id=1,
+        season=2025,
+        round=1,
+        start_time=datetime(2025, 3, 1, 19, 0, tzinfo=UTC),
+        match_state="Upcoming",
+        venue="Suncorp",
+        venue_city="Brisbane",
+        weather=None,
+        home=_team(1),
+        away=_team(2),
+        team_stats=[],
+        referee_id=None,
+    )
+    row = builder.feature_row(match)
+    assert row[_MISS_IDX] == pytest.approx(1.0)
+
+
+def test_no_missing_flag_when_referee_known() -> None:
+    builder = FeatureBuilder()
+    t = datetime(2025, 3, 1, 19, 0, tzinfo=UTC)
+    m = _match(1, t, 30, 10, referee_id=500039)
+    row = builder.feature_row(m)
+    assert row[_MISS_IDX] == pytest.approx(0.0)
+
+
+def test_ref_avg_total_points_starts_at_league_mean() -> None:
+    """Before any matches, falls back to league mean (0 when no history at all)."""
+    builder = FeatureBuilder()
+    t = datetime(2025, 3, 1, 19, 0, tzinfo=UTC)
+    row = builder.feature_row(_match(1, t, 0, 0, referee_id=500039))
+    assert row[_REF_IDX] == pytest.approx(0.0)
+
+
+def test_ref_avg_total_points_updates_after_record() -> None:
+    builder = FeatureBuilder()
+    t0 = datetime(2025, 3, 1, 19, 0, tzinfo=UTC)
+    t1 = datetime(2025, 3, 8, 19, 0, tzinfo=UTC)
+
+    m1 = _match(1, t0, 30, 10, referee_id=500039)  # total=40
+    builder.record(m1)
+
+    m2 = _match(2, t1, 20, 20, referee_id=500039)
+    row = builder.feature_row(m2)
+    assert row[_REF_IDX] == pytest.approx(40.0)
+
+
+def test_ref_avg_shrinks_toward_league_mean_with_few_matches() -> None:
+    builder = FeatureBuilder()
+    base = datetime(2025, 3, 1, 19, 0, tzinfo=UTC)
+    import datetime as dt
+
+    # Record 2 matches with referee 500039 (total=40 each)
+    for i in range(2):
+        ts = base + dt.timedelta(weeks=i)
+        m = _match(i + 1, ts, 30, 10, referee_id=500039)
+        builder.record(m)
+
+    # Record 5 matches with a different referee (total=20 each) — these only
+    # contribute to the league mean, not to ref 500039's history.
+    for i in range(5):
+        ts = base + dt.timedelta(weeks=10 + i)
+        m = _match(100 + i, ts, 10, 10, referee_id=999)
+        builder.record(m)
+
+    # League total deque has 7 matches: 2×40 + 5×20 = 180, mean = 180/7 ≈ 25.71
+    # ref 500039 has 2 matches < REF_SHRINKAGE_N=10, so w = 2/10 = 0.2
+    # shrunk = 0.2 * 40 + 0.8 * 25.71 ≈ 8.0 + 20.57 ≈ 28.57
+    ts_next = base + dt.timedelta(weeks=20)
+    m_next = _match(200, ts_next, 0, 0, referee_id=500039)
+    row = builder.feature_row(m_next)
+
+    league_mean = (2 * 40 + 5 * 20) / 7
+    w = 2 / REF_SHRINKAGE_N
+    expected_shrunk = w * 40.0 + (1 - w) * league_mean
+    assert row[_REF_IDX] == pytest.approx(expected_shrunk, abs=0.01)
+
+
+def test_ref_home_penalty_diff_accumulates() -> None:
+    builder = FeatureBuilder()
+    t0 = datetime(2025, 3, 1, 19, 0, tzinfo=UTC)
+    t1 = datetime(2025, 3, 8, 19, 0, tzinfo=UTC)
+
+    # home_penalties=4, away_penalties=6 → diff = -2
+    m1 = _match(1, t0, 20, 18, referee_id=500039)
+    builder.record(m1)
+
+    m2 = _match(2, t1, 20, 18, referee_id=500039)
+    row = builder.feature_row(m2)
+    assert row[_PD_IDX] == pytest.approx(-2.0)  # home_value - away_value = 4 - 6
+
+
+def test_ref_penalty_diff_zero_when_no_stat() -> None:
+    builder = FeatureBuilder()
+    t = datetime(2025, 3, 1, 19, 0, tzinfo=UTC)
+    # no team_stats → no penalty data
+    m = MatchRow(
+        match_id=1,
+        season=2025,
+        round=1,
+        start_time=t,
+        match_state="FullTime",
+        venue="V",
+        venue_city="C",
+        weather=None,
+        home=_team(1, 20),
+        away=_team(2, 18),
+        team_stats=[],
+        referee_id=500039,
+    )
+    builder.record(m)
+    m2 = MatchRow(
+        match_id=2,
+        season=2025,
+        round=2,
+        start_time=t + __import__("datetime").timedelta(weeks=1),
+        match_state="Upcoming",
+        venue="V",
+        venue_city="C",
+        weather=None,
+        home=_team(1),
+        away=_team(2),
+        team_stats=[],
+        referee_id=500039,
+    )
+    row = builder.feature_row(m2)
+    assert row[_PD_IDX] == pytest.approx(0.0)
+
+
+def test_feature_names_has_referee_features() -> None:
+    assert "ref_avg_total_points" in FEATURE_NAMES
+    assert "ref_home_penalty_diff" in FEATURE_NAMES
+    assert "missing_referee" in FEATURE_NAMES
+    assert len(FEATURE_NAMES) == 18


### PR DESCRIPTION
## Summary

- Extracts `referee_id` (position="Referee") and `video_referee_id` (position="Senior Review Official") from the NRL officials array into `MatchRow`
- SQLite schema v1 → v2 migration: `ALTER TABLE matches ADD COLUMN referee_id INTEGER` + `video_referee_id INTEGER` via `contextlib.suppress` (idempotent)
- Firestore `_to_doc` / `_from_doc` updated to round-trip both fields
- Feature snapshot JSONs regenerated to include new fields
- Three new features added to `FeatureBuilder` (indices 15-17):
  - `ref_avg_total_points`: rolling-20 per-referee total points, shrunk toward league mean for < 10 prior matches
  - `ref_home_penalty_diff`: rolling-20 per-referee (home − away) Penalties Conceded
  - `missing_referee`: 1.0 when referee ID absent (upcoming fixtures or pre-v2 data)

## Ablation result

Walk-forward on 2024–2025 baseline (424 predictions):

| Metric   | Before | After  | Δ       |
|----------|--------|--------|---------|
| accuracy | 0.5637 | 0.5660 | +0.23pp |
| log_loss | 0.7636 | 0.7640 | −0.0004 |
| brier    | 0.2655 | 0.2654 | +0.0001 |

**No meaningful signal** — root cause is the baseline DB was built at schema v1 (referee_id = NULL for all historical matches). Features are structurally correct; will accumulate signal once referee-annotated matches are ingested. Full notes in `docs/model.md`.

## Test plan

- [ ] `uv run pytest` — 235 tests pass (17 new in `tests/test_referee_features.py`)
- [ ] `uv run ruff format --check . && uv run ruff check .` — clean
- [ ] `test_referee_features.py` covers: ID extraction, storage migration, upsert/retrieve round-trip, FeatureBuilder shrinkage, penalty diff accumulation, missing flag

https://claude.ai/code/session_015kmGAV8wkUGiv8mpv8UriL