### PR TITLE
feat(deploy): allow unauth ingress + pin Firebase middleware via env var

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
             --region "${REGION}" \
             --image "${IMAGE}" \
             --platform managed \
-            --no-allow-unauthenticated \
+            --allow-unauthenticated \
             --min-instances 0 \
             --max-instances 2 \
             --cpu 1 \
@@ -71,12 +71,21 @@ jobs:
             --port 8080 \
             --execution-environment gen2 \
             --service-account "fantasy-coach-runtime@${PROJECT_ID}.iam.gserviceaccount.com" \
+            --set-env-vars "FIREBASE_PROJECT_ID=${PROJECT_ID}" \
             --quiet
-          # Re-add once platform-infra provisions the matching infra:
-          #   --set-secrets "FIREBASE_PROJECT_ID=firebase-project-id:latest" \   # needs #16 (Secret Manager)
-          #   --set-env-vars "STORAGE_BACKEND=firestore" \                       # needs #15 (Firestore DB)
-          # Until then, auth.py falls back to GOOGLE_CLOUD_PROJECT (auto-set by
-          # Cloud Run) and config.py defaults STORAGE_BACKEND to sqlite.
+          # Auth model: Cloud Run IAM allows any caller in — the browser can't
+          # mint a Google-signed OAuth2 ID token, so the alternative was an API
+          # Gateway shim. Security comes instead from FirebaseAuthMiddleware
+          # (src/fantasy_coach/auth.py), which the FIREBASE_PROJECT_ID env var
+          # above activates: every non-/healthz request must carry a valid
+          # Firebase ID token. The project ID value isn't sensitive, so plain
+          # --set-env-vars is enough — Secret Manager storage lands with #16.
+          #
+          # Re-add once platform-infra provisions Firestore (#15):
+          #   --set-env-vars "STORAGE_BACKEND=firestore" \
+          # Until then config.py defaults to a per-revision SQLite DB that the
+          # prediction endpoint can't populate, so /predictions returns 500
+          # until the Firestore migration lands. /healthz is unaffected.
 
       # The external /healthz smoke test has been dropped: `gcloud auth
       # print-identity-token` doesn't work with WIF-federated credentials

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -58,7 +58,7 @@ gcloud run deploy "$SERVICE" \
     --region "$REGION" \
     --image "$IMAGE" \
     --platform managed \
-    --no-allow-unauthenticated \
+    --allow-unauthenticated \
     --min-instances 0 \
     --max-instances 2 \
     --cpu 1 \
@@ -66,23 +66,46 @@ gcloud run deploy "$SERVICE" \
     --cpu-throttling \
     --port 8080 \
     --execution-environment gen2 \
-    --service-account "fantasy-coach-runtime@$PROJECT_ID.iam.gserviceaccount.com"
+    --service-account "fantasy-coach-runtime@$PROJECT_ID.iam.gserviceaccount.com" \
+    --set-env-vars "FIREBASE_PROJECT_ID=$PROJECT_ID"
 ```
 
 `--cpu-throttling` is the flag that achieves "CPU allocated only during
 requests" — without it, the container is billed for CPU even when idle.
 
+## Auth model
+
+The service is `--allow-unauthenticated` at the Cloud Run IAM layer
+because browser clients can't mint Google-signed OAuth2 ID tokens. Real
+auth lives in `FirebaseAuthMiddleware` (`src/fantasy_coach/auth.py`):
+
+- `/healthz` is open (for Cloud Run's own liveness probes + uptime checks).
+- Every other path must carry `Authorization: Bearer <firebase-id-token>`;
+  the middleware rejects missing / expired / wrong-project tokens with 401.
+
+`FIREBASE_PROJECT_ID` activates the middleware. Plain `--set-env-vars`
+(not Secret Manager) is deliberate: the project ID isn't sensitive, and
+Secret Manager wiring is deferred to #16 when the rest of the secrets
+land together.
+
 ## Smoke test
 
-The Cloud Run URL is in the deploy output (`gcloud run services describe
-$SERVICE --region $REGION --format 'value(status.url)'`). With auth still
-required (it is — see #17), use an identity token:
+Cloud Run blocks external GETs on `/healthz` because Google's Frontend
+reserves that path for its own health routing. The container's own
+liveness probes still hit it at 200 OK (visible in Cloud Run logs). For
+an external smoke test, use `/predictions` with a Firebase ID token
+instead — that reaches FastAPI and returns a real response. The
+`gcloud run services describe` still surfaces the current URL:
 
 ```bash
 URL=$(gcloud run services describe $SERVICE --region $REGION --format 'value(status.url)')
-curl -H "Authorization: Bearer $(gcloud auth print-identity-token)" "$URL/healthz"
-# → {"status":"ok","version":"0.1.0"}
+curl "$URL/predictions?season=2026&round=1"
+# → {"detail":"Missing or malformed bearer token"}  (401 from FirebaseAuthMiddleware)
 ```
+
+The 401 without an `Authorization` header *is* the green signal — it
+proves the middleware is active. To actually fetch predictions, let the
+SPA sign in and let the browser send its Firebase ID token.
 
 ## Service account least-privilege
 


### PR DESCRIPTION
## Summary
Unblocks browser → Cloud Run from the SPA at \`fantasy.lopezcloud.dev\`. Two tightly-paired changes:

1. Flip \`--no-allow-unauthenticated\` → \`--allow-unauthenticated\` on the Cloud Run deploy. Browsers can't mint Google-signed OAuth2 ID tokens, so the old flag made the SPA architecturally impossible without a proxy shim.
2. Set \`FIREBASE_PROJECT_ID\` via \`--set-env-vars\` so \`FirebaseAuthMiddleware\` actually activates. Without it the middleware would skip itself, leaving the open ingress genuinely open.

## Auth model after this lands
- \`/healthz\` — open (bypass list in \`auth.py\`; Cloud Run liveness probes need it)
- everything else — requires \`Authorization: Bearer <firebase-id-token>\`; middleware 401s on missing / expired / wrong-project tokens
- Cloud Run IAM no longer gates. Firebase middleware is the sole line of defence.

Dropped the project-ID into plain env (not Secret Manager) because it isn't sensitive. The full SM wiring lands with #16 alongside the other secrets.

## Verification after merge
- \`curl <url>/predictions?season=2026&round=1\` → **401** \`{"detail":"Missing or malformed bearer token"}\` (the 401 *is* the green signal)
- SPA at \`fantasy.lopezcloud.dev\`, signed in, fetches predictions with the Firebase ID token attached by \`apiFetch\`
- \`/predictions\` still returns **500** until Firestore (#15 infra) lands + a model is trained — that's expected and documented

## Test plan
- [ ] CI green
- [ ] Post-merge deploy succeeds
- [ ] \`/predictions\` unauth'd returns 401 (not 500, not 200)
- [ ] Signed-in SPA reaches \`/predictions\` (returns 500 until data wiring lands, but via the app — visible in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)