### PR TITLE
feat(deploy): right-size Cloud Run — 256Mi + explicit concurrency/timeout (closes #64)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,9 @@ jobs:
             --min-instances 0 \
             --max-instances 2 \
             --cpu 1 \
-            --memory 512Mi \
+            --memory 256Mi \
+            --concurrency 80 \
+            --timeout 120 \
             --cpu-throttling \
             --port 8080 \
             --execution-environment gen2 \

--- a/docs/cost.md
+++ b/docs/cost.md
@@ -1,0 +1,35 @@
+# Cost
+
+Running costs for the fantasy-coach stack, how we keep them low, and what
+to do when a number moves in the wrong direction.
+
+> This doc is thin today — most of the infrastructure scales to zero and
+> GCP credits cover the rest. Budget alerts, per-SKU dashboards, and a
+> real baseline come with #63 (`projects/fantasy-coach/billing.tf` and
+> Billing Export → BigQuery). Anything not filled in here is a known gap,
+> not forgotten.
+
+## Cloud Run right-sizing (April 2026)
+
+The prediction API was deployed with gcloud defaults for its first 13
+hours, then tightened once we had enough observability to make informed
+cuts. Nothing was cut below observed p99 + meaningful headroom.
+
+| Flag | Before (gcloud defaults / original deploy) | After (pinned in `deploy.yml` + TF) | Why |
+|------|---------------------------------------------|--------------------------------------|-----|
+| `--memory` | `512Mi` | `256Mi` | p99 container RSS < 20% of 512Mi across 20 revisions. 256Mi is still > 2.5× the working set. |
+| `--concurrency` | Cloud Run default 80 (not pinned) | `80` pinned | Explicit so TF and deploy stay aligned; no behavioural change. |
+| `--timeout` | Cloud Run default `300s` (not pinned) | `120s` pinned | Cold-round scrape does ~8 HTTPS round-trips to nrl.com, so 60s is unsafe until #65 moves scrape off-path. 120s is still a 60% reduction from the default. |
+| `--cpu` | `1` | `1` unchanged | Predict is µs-scale; scraping is I/O-bound. |
+| `--min-instances` | `0` | `0` unchanged | Scale-to-zero stays. |
+| `--max-instances` | `2` | `2` unchanged | Blast-radius cap. |
+
+**Expected impact:** Cloud Run bills per GiB-second while an instance is
+running. Halving memory halves that component's cost for every billable
+second. With scale-to-zero and low traffic the absolute saving is small
+today, but the ratio persists as traffic grows.
+
+The measurements above came from a ~13-hour window dominated by CI
+churn, not real user traffic. Revisit concurrency and memory once we
+have 30 days of real requests — concurrency especially may have room to
+go from 80 → 200 on a mostly-I/O endpoint. Tracked as a follow-up on #64.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -62,7 +62,9 @@ gcloud run deploy "$SERVICE" \
     --min-instances 0 \
     --max-instances 2 \
     --cpu 1 \
-    --memory 512Mi \
+    --memory 256Mi \
+    --concurrency 80 \
+    --timeout 120 \
     --cpu-throttling \
     --port 8080 \
     --execution-environment gen2 \
@@ -72,6 +74,28 @@ gcloud run deploy "$SERVICE" \
 
 `--cpu-throttling` is the flag that achieves "CPU allocated only during
 requests" — without it, the container is billed for CPU even when idle.
+
+## Runtime sizing
+
+Flags above and in `.github/workflows/deploy.yml` must stay in sync with
+the Terraform resource (`google_cloud_run_v2_service.api` in
+platform-infra). Cloud Run stores whatever was last deployed, so the
+workflow is the effective source of truth — TF matches so fresh applies
+don't drift.
+
+| Flag | Value | Rationale |
+|------|-------|-----------|
+| `--memory` | `256Mi` | Observed p99 RSS < 100 MiB; a small logistic joblib loads in a few ms. 256Mi gives ~2.5× headroom while halving the per-instance memory bill. |
+| `--cpu` | `1` | One request at a time fits well under one vCPU; the logistic predict is µs-scale. |
+| `--concurrency` | `80` | Cloud Run's default; pinned explicitly so TF/deploy can't silently drift. Revisit after we have real traffic; 200 may be viable for a mostly-I/O endpoint. |
+| `--timeout` | `120` | Down from the 300s default. First request of a round does a live scrape of nrl.com (~1s/fixture × 8 fixtures + overhead), so we can't safely cut to the AC's 60s yet — drop once #65 lands and scrape is off-path. |
+| `--cpu-throttling` | on | Billable CPU only during requests; cold idle is free. |
+| `--min-instances` | `0` | Scale to zero when idle. |
+| `--max-instances` | `2` | Keeps the blast radius bounded while traffic is low. |
+
+These values were chosen against 13 hours of post-launch metrics, not a
+30-day window. Revisit once we have real traffic (tracked as a follow-up
+on #64).
 
 ## Auth model
 


### PR DESCRIPTION
## Summary

- \`--memory\`: 512Mi → **256Mi** (observed p99 RSS is <20% of 512Mi across 20 revisions; still >2.5× headroom over the working set).
- \`--concurrency\`: **pin 80** (Cloud Run default, explicit so TF/deploy can't drift).
- \`--timeout\`: 300s default → **120s**. *Not* the AC's 60s — cold-round scrape does ~8 sequential fetches to nrl.com, so 60s is unsafe until #65 moves scrape off-path. 120s is still a 60% reduction from the default.
- \`docs/deploy.md\` documents the flags table + rationale; \`docs/cost.md\` (new, minimal) captures the before/after.

## Scope adjustment (from my needs-clarification comment on #64)

The AC asked for 30 days of revision metrics. The service is only ~13 hours old, so that window isn't available. I'm shipping the conservative cuts we can defend against observed data today, and leaving concurrency tuning (80 → 200 on a mostly-I/O endpoint?) to a follow-up once real traffic accumulates. I flagged this as **option A** in the issue thread and the user green-lit it.

## Paired platform-infra PR

Pins the same values on \`google_cloud_run_v2_service.api\` so a fresh \`terraform apply\` can't silently re-widen memory to 512Mi. Without the paired change, the deploy-workflow values stay the effective source of truth but TF drifts visibly.

## Test plan

- [x] YAML parses.
- [ ] Merge triggers the existing \`deploy.yml\` workflow; confirm the new revision is \`fantasy-coach-api-000XX\` with \`memory=256Mi\`, \`containerConcurrency=80\`, \`timeoutSeconds=120\`.
- [ ] Smoke the prediction endpoint via the SPA — cache-miss scrape should still complete well under 120s.
- [ ] Check Cloud Run logs for OOM kills over the next 48h; none expected but worth eyeballing.

## Out of scope (follow-ups)

- Revisit concurrency after 30 days of real traffic (80 → 200 candidate).
- Cut timeout from 120s → 60s once #65 lands and the scrape is precomputed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)