### PR TITLE
feat(docs): document budget alerts + per-SKU dashboard bootstrap (closes #63)

### DIFF
--- a/docs/cost.md
+++ b/docs/cost.md
@@ -3,11 +3,72 @@
 Running costs for the fantasy-coach stack, how we keep them low, and what
 to do when a number moves in the wrong direction.
 
-> This doc is thin today — most of the infrastructure scales to zero and
-> GCP credits cover the rest. Budget alerts, per-SKU dashboards, and a
-> real baseline come with #63 (`projects/fantasy-coach/billing.tf` and
-> Billing Export → BigQuery). Anything not filled in here is a known gap,
-> not forgotten.
+> Most of the infrastructure scales to zero and GCP credits cover the
+> rest today, so real-dollar costs are near-zero. This doc is the
+> early-warning plumbing for when credits run out or usage moves.
+
+## Baseline (April 2026)
+
+The stack is currently billed in three components. All numbers are
+projections — real dollars will come from the BigQuery billing export
+once it's manually enabled (see below).
+
+| Component | Driver | Expected monthly cost at current traffic |
+|-----------|--------|-------------------------------------------|
+| Cloud Run (API) | 0 → low; scale-to-zero; 256Mi × concurrency 80 | < $1 |
+| Firestore | Free tier (1 GiB storage, 50K reads/day) | $0 |
+| Artifact Registry | One image tag per deploy, ~1 GiB total | < $0.10 |
+| Cloud Logging | Default retention; low request volume | $0 (free tier) |
+| Vertex AI (Gemini) | Not yet wired (tracked by #22) | $0 |
+| Egress | SPA bundle from Firebase Hosting; low traffic | $0 (free tier) |
+
+Refresh these numbers by querying the BigQuery billing export dataset
+(`billing_export.gcp_billing_export_v1_<billing-account-id>`) once
+enabled — see the manual bootstrap step below.
+
+## Budget alerts
+
+A single project-wide budget is defined in
+[`lopeztech/platform-infra:projects/fantasy-coach/billing.tf`](https://github.com/lopeztech/platform-infra/blob/master/projects/fantasy-coach/billing.tf)
+via the shared `modules/budget`. Configuration lives in
+`projects/fantasy-coach/environments/prod/terraform.tfvars`:
+
+- **Monthly cap:** `$20` USD (generous alarm threshold given current
+  burn is < $1/mo — tighten later if real spend rises).
+- **Thresholds:** 50 %, 80 %, 100 % of current spend, plus
+  forecasted-100 %.
+- **Recipient:** `admin@lopezcloud.dev` (`notification_email`
+  variable). Routed via a `google_monitoring_notification_channel`
+  email channel, not the default IAM recipients.
+- **Rotation:** bump `monthly_budget_usd` in tfvars + re-apply. The
+  email address comes from the same tfvars, single source of truth.
+
+Slack webhook routing is an explicit follow-up — add a second
+notification channel to the `budget` module when we need it.
+
+## Per-SKU dashboard (manual bootstrap)
+
+Terraform manages the budget, but the per-SKU breakdown dashboard
+needs Billing Export → BigQuery turned on *at the billing-account
+level*. Enabling it requires `roles/billing.admin` on the billing
+account, which is outside `projects/fantasy-coach/`'s Terraform scope.
+One-time manual steps:
+
+1. **Enable the export** — Billing console → Billing export → BigQuery
+   export → pick project `fantasy-coach-lcd` and dataset name
+   `billing_export` (create on first run). Choose *Standard usage
+   cost* at minimum; *Detailed usage cost* if we need per-SKU
+   pricing later.
+2. **Label propagation** — Cloud Run already carries
+   `app=fantasy-coach`, `environment=prod`, `managed_by=terraform`
+   (see `cloudrun.tf`). Both the billing-account-level export and
+   BigQuery preserve these, so a Looker Studio panel can segment on
+   `labels.app` without us adding new tags.
+3. **Dashboard** — clone a Looker Studio billing template, point it at
+   the new dataset, save the public URL here once built.
+
+Until step 3 lands, per-SKU visibility lives in the Billing console's
+Reports view (filter by label `app=fantasy-coach`).
 
 ## Cloud Run right-sizing (April 2026)
 


### PR DESCRIPTION
**Stacked on #89 (#64 Cloud Run right-sizing)** — both touch \`docs/cost.md\`, so this extends #89's baseline rather than racing it. Re-target to \`main\` before merging #89 per the repo convention.

## Summary

- Extends \`docs/cost.md\` with a current-traffic baseline table, budget-alert configuration (where the values live, how to rotate), and the manual Billing Export → BigQuery bootstrap step.
- Paired with [lopeztech/platform-infra#43](https://github.com/lopeztech/platform-infra/pull/43), which actually wires the project-wide budget via the shared \`modules/budget\`. That PR uses \`monthly_budget_usd=$20\` and \`notification_email=admin@lopezcloud.dev\`, both already in \`projects/fantasy-coach/environments/prod/terraform.tfvars\`.

## Why the per-SKU dashboard is manual

Billing Export → BigQuery has to be turned on at the billing-account level (requires \`roles/billing.admin\` on the billing account, which can't be granted to the project's deployer SA). I documented the one-time manual enable in \`docs/cost.md\` under "Per-SKU dashboard (manual bootstrap)"; the Looker Studio template + dashboard URL will be filled in once the export is live.

## Decisions (from my needs-clarification comment on #63)

- Monthly budget: \`$20\` (existing default in tfvars; generous for current burn <$1/mo).
- Alert email: \`admin@lopezcloud.dev\` (existing default in tfvars; matches other projects).
- Per-SKU budgets: one project-wide budget instead (SKU breakdown comes from the Looker Studio dashboard later — alerts per SKU without an incident story aren't worth the noise).
- Labels: keeping existing \`app\`/\`environment\`/\`managed_by\` keys (BQ billing export segments fine on either scheme).

## Test plan

- [ ] Verify the infra PR lands first; \`terraform apply\` creates the budget + email channel.
- [ ] Send a test notification from Cloud Monitoring → Alerting → Notification channels to confirm the email actually arrives.
- [ ] Hand-trigger the budget to fire (e.g. by temporarily dropping \`monthly_budget_usd\` to $0.01) and verify the email path; revert.

## Out of scope (explicit follow-ups)

- Turning Billing Export → BigQuery on (manual, one-time, documented in \`cost.md\`).
- Building the Looker Studio dashboard once the export is live.
- Slack webhook routing via a second notification channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)