### PR TITLE
fix(deploy): revert memory to 512Mi — gen2 execution environment minimum blocks 256Mi

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
             --min-instances 0 \
             --max-instances 2 \
             --cpu 1 \
-            --memory 256Mi \
+            --memory 512Mi \
             --concurrency 80 \
             --timeout 120 \
             --cpu-throttling \

--- a/docs/cost.md
+++ b/docs/cost.md
@@ -78,17 +78,18 @@ cuts. Nothing was cut below observed p99 + meaningful headroom.
 
 | Flag | Before (gcloud defaults / original deploy) | After (pinned in `deploy.yml` + TF) | Why |
 |------|---------------------------------------------|--------------------------------------|-----|
-| `--memory` | `512Mi` | `256Mi` | p99 container RSS < 20% of 512Mi across 20 revisions. 256Mi is still > 2.5× the working set. |
+| `--memory` | `512Mi` | `512Mi` unchanged | p99 container RSS < 20% of 512Mi across 20 revisions — 256Mi would fit, but **gen2 execution environment has a 512Mi minimum enforced by `gcloud run deploy`**. We'd need to drop to gen1 to cut further, and the scrape-heavy workload values gen2's networking + startup CPU boost more than the pennies/month of memory savings. |
 | `--concurrency` | Cloud Run default 80 (not pinned) | `80` pinned | Explicit so TF and deploy stay aligned; no behavioural change. |
 | `--timeout` | Cloud Run default `300s` (not pinned) | `120s` pinned | Cold-round scrape does ~8 HTTPS round-trips to nrl.com, so 60s is unsafe until #65 moves scrape off-path. 120s is still a 60% reduction from the default. |
 | `--cpu` | `1` | `1` unchanged | Predict is µs-scale; scraping is I/O-bound. |
 | `--min-instances` | `0` | `0` unchanged | Scale-to-zero stays. |
 | `--max-instances` | `2` | `2` unchanged | Blast-radius cap. |
 
-**Expected impact:** Cloud Run bills per GiB-second while an instance is
-running. Halving memory halves that component's cost for every billable
-second. With scale-to-zero and low traffic the absolute saving is small
-today, but the ratio persists as traffic grows.
+**Expected impact:** Memory is unchanged; the concurrency + timeout
+pins prevent the flags from silently drifting apart between the deploy
+workflow and Terraform, and the 300s → 120s timeout cut reduces the
+maximum billable CPU time per stuck request by 60 %. Real dollars
+today are pennies — this is drift insurance, not a major cost cut.
 
 The measurements above came from a ~13-hour window dominated by CI
 churn, not real user traffic. Revisit concurrency and memory once we

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -62,7 +62,7 @@ gcloud run deploy "$SERVICE" \
     --min-instances 0 \
     --max-instances 2 \
     --cpu 1 \
-    --memory 256Mi \
+    --memory 512Mi \
     --concurrency 80 \
     --timeout 120 \
     --cpu-throttling \
@@ -85,7 +85,7 @@ don't drift.
 
 | Flag | Value | Rationale |
 |------|-------|-----------|
-| `--memory` | `256Mi` | Observed p99 RSS < 100 MiB; a small logistic joblib loads in a few ms. 256Mi gives ~2.5× headroom while halving the per-instance memory bill. |
+| `--memory` | `512Mi` | Observed p99 RSS < 100 MiB, so 256Mi would fit — but gen2 execution environment has a 512Mi minimum, enforced by `gcloud run deploy`. Kept at 512Mi rather than downgrade to gen1. |
 | `--cpu` | `1` | One request at a time fits well under one vCPU; the logistic predict is µs-scale. |
 | `--concurrency` | `80` | Cloud Run's default; pinned explicitly so TF/deploy can't silently drift. Revisit after we have real traffic; 200 may be viable for a mostly-I/O endpoint. |
 | `--timeout` | `120` | Down from the 300s default. First request of a round does a live scrape of nrl.com (~1s/fixture × 8 fixtures + overhead), so we can't safely cut to the AC's 60s yet — drop once #65 lands and scrape is off-path. |


### PR DESCRIPTION
## What broke

The post-merge deploy from #89 failed with:

\`\`\`
spec.template.spec.containers.resources.limits.memory: Invalid value specified for memory.
Total memory < 512 Mi is not supported with gen2 execution environment.
\`\`\`

The Cloud Run API itself accepts 256Mi (the TF apply + live revision 00025 both hold it), but \`gcloud run deploy\` enforces the gen2 minimum **client-side** and rejects every future revision. Left as-is, every push to \`main\` that touches the deploy paths would fail.

## What I'm changing

- \`.github/workflows/deploy.yml\`: \`--memory 256Mi\` → \`--memory 512Mi\`
- \`docs/deploy.md\`: updated flag table + rationale (explains the gen2 floor)
- \`docs/cost.md\`: before/after table now reflects "memory unchanged; concurrency + timeout pins are the actual wins"

## What I'm keeping from #64

- \`--concurrency 80\` pinned (prevents silent TF/deploy drift)
- \`--timeout 120\` (300s default → 120s; a real 60 % cut to max-billable CPU per stuck request)

## Why not switch to gen1

Gen1 allows 128Mi+ but gives up startup CPU boost + the newer networking stack — both meaningful for a scale-to-zero, scrape-heavy service. Pennies/month of memory aren't worth the regression.

## Paired

platform-infra PR reverts TF to 512Mi to match.

## Test plan

- [ ] Merge triggers deploy.yml; confirm revision goes green.
- [ ] \`gcloud run services describe\` shows \`memory: "512Mi"\`, \`containerConcurrency: 80\`, \`timeoutSeconds: 120\`.
- [ ] SPA + API still serve normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)