### PR TITLE
feat: precompute predictions off the hot path (closes #65)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,6 +87,21 @@ jobs:
           # the PredictionStore at Firestore (required once #65 landed; the
           # precompute Job and the API share cache state through Firestore).
 
+      - name: Update precompute Job image
+        env:
+          PROJECT_ID: ${{ secrets.FANTASY_COACH_PROJECT_ID }}
+          JOB: fantasy-coach-precompute
+        # The Job is created + fixed-configured by Terraform in platform-infra;
+        # only the image rotates per deploy. ``|| true`` tolerates first
+        # deployments to projects where platform-infra hasn't applied yet.
+        run: |
+          gcloud run jobs update "${JOB}" \
+            --project "${PROJECT_ID}" \
+            --region "${REGION}" \
+            --image "${IMAGE}" \
+            --quiet || \
+          echo "Job '${JOB}' not found — skipping (platform-infra#65 not applied yet)."
+
       # The external /healthz smoke test has been dropped: `gcloud auth
       # print-identity-token` doesn't work with WIF-federated credentials
       # (they're OAuth2 access tokens, not OIDC ID tokens), and Cloud Run's

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
             --port 8080 \
             --execution-environment gen2 \
             --service-account "fantasy-coach-runtime@${PROJECT_ID}.iam.gserviceaccount.com" \
-            --set-env-vars "FIREBASE_PROJECT_ID=${PROJECT_ID}" \
+            --set-env-vars "FIREBASE_PROJECT_ID=${PROJECT_ID},STORAGE_BACKEND=firestore" \
             --quiet
           # Auth model: Cloud Run IAM allows any caller in — the browser can't
           # mint a Google-signed OAuth2 ID token, so the alternative was an API
@@ -83,11 +83,9 @@ jobs:
           # Firebase ID token. The project ID value isn't sensitive, so plain
           # --set-env-vars is enough — Secret Manager storage lands with #16.
           #
-          # Re-add once platform-infra provisions Firestore (#15):
-          #   --set-env-vars "STORAGE_BACKEND=firestore" \
-          # Until then config.py defaults to a per-revision SQLite DB that the
-          # prediction endpoint can't populate, so /predictions returns 500
-          # until the Firestore migration lands. /healthz is unaffected.
+          # STORAGE_BACKEND=firestore points both the matches Repository and
+          # the PredictionStore at Firestore (required once #65 landed; the
+          # precompute Job and the API share cache state through Firestore).
 
       # The external /healthz smoke test has been dropped: `gcloud auth
       # print-identity-token` doesn't work with WIF-federated credentials

--- a/docs/cost.md
+++ b/docs/cost.md
@@ -95,3 +95,24 @@ The measurements above came from a ~13-hour window dominated by CI
 churn, not real user traffic. Revisit concurrency and memory once we
 have 30 days of real requests — concurrency especially may have room to
 go from 80 → 200 on a mostly-I/O endpoint. Tracked as a follow-up on #64.
+
+## Precompute Job vs on-request scrape (#65)
+
+The `/predictions` endpoint no longer scrapes on demand. A Cloud Run
+Job (`fantasy-coach-precompute`) runs the scrape + feature + predict
+pipeline twice a week — Tue 09:00 and Thu 06:00 AEST — and writes the
+round's predictions to Firestore. The API reads from the cache and
+returns 503 on miss.
+
+| Path | Before (on-request) | After (scheduled Job) |
+|------|---------------------|-----------------------|
+| Cloud Run billable time per round | ~30s per first-of-round request on the API instance (while it scrapes ~8 fixtures sequentially) | ~30s on the Job (one-shot container, CPU not throttled while running) — times 2 runs per round |
+| Tail latency to user | p99 dominated by the scrape on cache miss; first user of every round pays 30s+ | p99 is a Firestore doc-get (<100ms) |
+| Max-billable-CPU per stuck request | 120s timeout (deploy flag) | N/A — API path never scrapes |
+| Blast radius on scrape failure | Request returns 500 | Job fails, API still serves last-known predictions; Cloud Scheduler retries (2 retries, 30–300s backoff) |
+
+Net effect: real-dollar cost is a wash (Job instance time ≈ former
+on-request time, just moved), but p99 latency for users is an order of
+magnitude better and we gain a retry safety net. The scheduled Job also
+picks up team-list changes between Tue and Thu — the `--force` default
+re-scrapes even when a round already has cached predictions.

--- a/src/fantasy_coach/__main__.py
+++ b/src/fantasy_coach/__main__.py
@@ -107,6 +107,43 @@ def main(argv: list[str] | None = None) -> int:
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
     )
 
+    pc = sub.add_parser(
+        "precompute",
+        help=(
+            "Scrape + compute predictions and write them to the configured store. "
+            "Called by the Cloud Run Job twice a week so the API never scrapes "
+            "on the hot path."
+        ),
+    )
+    pc.add_argument(
+        "--season",
+        type=int,
+        default=None,
+        help="Season to precompute. Omit to autodetect the current year.",
+    )
+    pc.add_argument(
+        "--round",
+        type=int,
+        default=None,
+        help=(
+            "Round to precompute. Omit to autodetect the next upcoming round "
+            "(first round containing a fixture with matchState Upcoming/Pre)."
+        ),
+    )
+    pc.add_argument(
+        "--no-force",
+        action="store_true",
+        help=(
+            "Respect existing cached predictions instead of re-scraping. "
+            "Default is --force so scheduled runs pick up team-list changes."
+        ),
+    )
+    pc.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+
     args = parser.parse_args(argv)
     logging.basicConfig(
         level=args.log_level,
@@ -119,6 +156,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_train_logistic(args)
     if args.command == "evaluate":
         return _run_evaluate(args)
+    if args.command == "precompute":
+        return _run_precompute(args)
     parser.error(f"unknown command {args.command!r}")
     return 2  # unreachable
 
@@ -204,6 +243,60 @@ def _run_evaluate(args: argparse.Namespace) -> int:
             f"acc={m['accuracy']:.3f} log_loss={m['log_loss']:.3f} brier={m['brier']:.3f}"
         )
     print(f"Report written to {args.report}")
+    return 0
+
+
+def _detect_upcoming_round(year: int) -> int | None:
+    """Return the first round in ``year`` with an unstarted fixture, or None.
+
+    Iterates ``fetch_round`` starting at round 1. ``matchState`` values
+    ``Upcoming`` and ``Pre`` both mean "hasn't kicked off yet". Capped at 30
+    rounds to cover regular season + finals; beyond that the season is done.
+    """
+    from fantasy_coach.scraper import fetch_round  # noqa: PLC0415
+
+    for round_ in range(1, 31):
+        payload = fetch_round(year, round_)
+        if payload is None:
+            continue
+        fixtures = payload.get("fixtures") or []
+        if any(f.get("matchState") in ("Upcoming", "Pre") for f in fixtures):
+            return round_
+    return None
+
+
+def _run_precompute(args: argparse.Namespace) -> int:
+    from datetime import UTC, datetime  # noqa: PLC0415
+
+    from fantasy_coach.config import get_repository  # noqa: PLC0415
+    from fantasy_coach.predictions import compute_predictions, get_prediction_store  # noqa: PLC0415
+
+    season = args.season or datetime.now(UTC).year
+    round_ = args.round
+    if round_ is None:
+        round_ = _detect_upcoming_round(season)
+        if round_ is None:
+            print(f"No upcoming round found in season {season} — nothing to precompute.")
+            return 0
+        print(f"Autodetected upcoming round: season={season} round={round_}")
+
+    repo = get_repository()
+    store = get_prediction_store()
+    try:
+        predictions = compute_predictions(
+            season,
+            round_,
+            repo,
+            store,
+            force=not args.no_force,
+        )
+    finally:
+        if hasattr(repo, "close"):
+            repo.close()
+        if hasattr(store, "close"):
+            store.close()
+
+    print(f"Precomputed {len(predictions)} predictions for season={season} round={round_}")
     return 0
 
 

--- a/src/fantasy_coach/app.py
+++ b/src/fantasy_coach/app.py
@@ -5,8 +5,12 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from fantasy_coach import __version__
 from fantasy_coach.auth import FirebaseAuthMiddleware
-from fantasy_coach.config import get_repository
-from fantasy_coach.predictions import PredictionOut, PredictionStore, compute_predictions
+from fantasy_coach.predictions import (
+    FirestorePredictionStore,
+    PredictionOut,
+    PredictionStore,
+    get_prediction_store,
+)
 
 ALLOWED_ORIGINS_ENV = "FANTASY_COACH_ALLOWED_ORIGINS"
 DEFAULT_ALLOWED_ORIGINS = (
@@ -46,13 +50,13 @@ app.add_middleware(
 )
 
 # Module-level prediction store — created lazily on first use.
-_store: PredictionStore | None = None
+_store: PredictionStore | FirestorePredictionStore | None = None
 
 
-def _get_store() -> PredictionStore:
+def _get_store() -> PredictionStore | FirestorePredictionStore:
     global _store
     if _store is None:
-        _store = PredictionStore()
+        _store = get_prediction_store()
     return _store
 
 
@@ -67,25 +71,24 @@ def healthz() -> dict[str, str]:
     summary="Get predictions for a season/round",
     description=(
         "Returns predicted winner and home-win probability for every match in "
-        "the requested round. Results are cached on first call; subsequent calls "
-        "return stored predictions without re-scraping."
+        "the requested round. Predictions are precomputed twice a week by a "
+        "Cloud Run Job (Tue 09:00 and Thu 06:00 AEST); this endpoint is a "
+        "cache read only. Returns 503 with a retry hint if the cache is empty."
     ),
 )
 def get_predictions(
     season: int = Query(..., description="NRL season year, e.g. 2026"),
     round: int = Query(..., description="Round number, e.g. 7", alias="round"),
 ) -> list[PredictionOut]:
-    repo = get_repository()
-    try:
-        return compute_predictions(season, round, repo, _get_store())
-    except FileNotFoundError as exc:
+    cached = _get_store().get(season, round)
+    if not cached:
         raise HTTPException(
             status_code=503,
             detail=(
-                f"Model not available ({exc}). "
-                "Train one with: python -m fantasy_coach train-logistic"
+                f"No cached predictions for season {season} round {round}. "
+                "The precompute job runs Tue 09:00 AEST and Thu 06:00 AEST. "
+                "Retry in a few minutes or trigger it manually with "
+                "`gcloud run jobs execute fantasy-coach-precompute`."
             ),
-        ) from exc
-    finally:
-        if hasattr(repo, "close"):
-            repo.close()
+        )
+    return cached

--- a/src/fantasy_coach/predictions.py
+++ b/src/fantasy_coach/predictions.py
@@ -87,7 +87,12 @@ class PredictionStore:
     def __init__(self, path: str | Path | None = None) -> None:
         db_path = Path(path or os.getenv(PREDICTIONS_DB_ENV, DEFAULT_PREDICTIONS_DB))
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(str(db_path))
+        # check_same_thread=False because FastAPI serves the endpoint in a
+        # worker thread (run_in_threadpool) distinct from the one that
+        # instantiated the module-level store. Reads are serialised by the
+        # GIL and writes only come from the precompute Job (different
+        # process), so cross-thread sharing is safe here.
+        self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(_CREATE_TABLE)
 
@@ -146,6 +151,78 @@ def _row_to_out(r: sqlite3.Row) -> PredictionOut:
 
 
 # ---------------------------------------------------------------------------
+# Firestore-backed prediction store (production)
+# ---------------------------------------------------------------------------
+
+
+class FirestorePredictionStore:
+    """Firestore-backed prediction cache.
+
+    Document layout: one doc per ``(season, round)``, ID ``"{season}-{round}"``,
+    inside the ``predictions`` collection. The doc contains the full list of
+    ``PredictionOut`` entries for that round plus a ``createdAt`` timestamp.
+
+    This is the shape the precompute Job writes (twice a week) and the
+    ``/predictions`` endpoint reads (on every request). Using one doc per
+    round keeps both sides to a single Firestore RPC — cheaper than
+    per-match docs, and Firestore's 1 MiB doc limit is ~orders of magnitude
+    more than a round's prediction payload.
+    """
+
+    _COLLECTION = "predictions"
+
+    def __init__(
+        self,
+        client: Any = None,
+        project: str | None = None,
+        database: str = "(default)",
+    ) -> None:
+        if client is not None:
+            self._db = client
+        else:
+            from google.cloud import firestore  # noqa: PLC0415
+
+            self._db = firestore.Client(project=project, database=database)
+
+    def close(self) -> None:  # symmetry with PredictionStore; Firestore has no conn to close
+        return
+
+    def get(self, season: int, round_: int) -> list[PredictionOut]:
+        snap = self._db.collection(self._COLLECTION).document(_doc_id(season, round_)).get()
+        if not snap.exists:
+            return []
+        data = snap.to_dict() or {}
+        return [PredictionOut(**p) for p in data.get("predictions", [])]
+
+    def put(self, season: int, round_: int, predictions: list[PredictionOut]) -> None:
+        self._db.collection(self._COLLECTION).document(_doc_id(season, round_)).set(
+            {
+                "season": season,
+                "round": round_,
+                "predictions": [p.model_dump() for p in predictions],
+                "createdAt": datetime.now(UTC).isoformat(),
+            }
+        )
+
+
+def _doc_id(season: int, round_: int) -> str:
+    return f"{season}-{round_}"
+
+
+def get_prediction_store() -> PredictionStore | FirestorePredictionStore:
+    """Factory: pick the prediction store backend from ``STORAGE_BACKEND``.
+
+    Mirrors ``fantasy_coach.config.get_repository`` so API + Job share one
+    switch. Defaults to SQLite for local dev; Cloud Run deploy sets
+    ``STORAGE_BACKEND=firestore``.
+    """
+    backend = os.getenv("STORAGE_BACKEND", "sqlite").lower()
+    if backend == "firestore":
+        return FirestorePredictionStore()
+    return PredictionStore()
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -182,18 +259,27 @@ def compute_predictions(
     model_path: Path | None = None,
     fetch_round_fn: Any = fetch_round,
     fetch_match_fn: Any = fetch_match_from_url,
+    force: bool = False,
 ) -> list[PredictionOut]:
     """Return predictions for season/round; compute and cache them on miss.
+
+    ``force=True`` bypasses the cache-hit short-circuit so the precompute
+    Job can refresh stored predictions when team lists change between
+    scheduled runs. On cache miss ``force`` is a no-op.
 
     Raises ``FileNotFoundError`` if the model artefact does not exist (caller
     should surface this as HTTP 503).
     """
-    cached = store.get(season, round_)
-    if cached:
-        logger.info(
-            "Cache hit: returning %d stored predictions for %d r%d", len(cached), season, round_
-        )
-        return cached
+    if not force:
+        cached = store.get(season, round_)
+        if cached:
+            logger.info(
+                "Cache hit: returning %d stored predictions for %d r%d",
+                len(cached),
+                season,
+                round_,
+            )
+            return cached
 
     # Resolve and load the model
     path = model_path or Path(os.getenv(MODEL_PATH_ENV, DEFAULT_MODEL_PATH))

--- a/tests/test_precompute_cli.py
+++ b/tests/test_precompute_cli.py
@@ -1,0 +1,122 @@
+"""Tests for the ``python -m fantasy_coach precompute`` subcommand.
+
+The precompute Job (issue #65) runs this CLI twice a week. These tests
+cover the two entry paths — explicit ``--season/--round`` and autodetect —
+plus the ``--no-force`` opt-out. No real NRL scrapes, no real Firestore.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fantasy_coach.__main__ import _detect_upcoming_round, main
+
+
+def test_detect_upcoming_round_returns_first_round_with_upcoming_fixture() -> None:
+    """Iterates round 1..N and stops at the first round with Upcoming/Pre state."""
+    payloads = {
+        1: {"fixtures": [{"matchState": "FullTime"}, {"matchState": "FullTime"}]},
+        2: {"fixtures": [{"matchState": "FullTime"}]},
+        3: {"fixtures": [{"matchState": "Upcoming"}, {"matchState": "FullTime"}]},
+        4: {"fixtures": [{"matchState": "Upcoming"}]},
+    }
+    calls: list[int] = []
+
+    def _fake_fetch_round(year: int, round_: int, **_kw):
+        calls.append(round_)
+        return payloads.get(round_)
+
+    with patch("fantasy_coach.scraper.fetch_round", side_effect=_fake_fetch_round):
+        result = _detect_upcoming_round(2026)
+
+    assert result == 3
+    # Must have stopped at the first match — no extra round-4 request.
+    assert calls == [1, 2, 3]
+
+
+def test_detect_upcoming_round_accepts_pre_state_too() -> None:
+    """``Pre`` means 'about to kick off' — treat it as upcoming."""
+    payloads = {1: {"fixtures": [{"matchState": "Pre"}]}}
+    with patch(
+        "fantasy_coach.scraper.fetch_round",
+        side_effect=lambda y, r, **kw: payloads.get(r),
+    ):
+        assert _detect_upcoming_round(2026) == 1
+
+
+def test_detect_upcoming_round_returns_none_when_season_is_over() -> None:
+    """Every round fully played → no upcoming round to precompute."""
+    payloads = {r: {"fixtures": [{"matchState": "FullTime"}]} for r in range(1, 31)}
+    with patch(
+        "fantasy_coach.scraper.fetch_round",
+        side_effect=lambda y, r, **kw: payloads.get(r),
+    ):
+        assert _detect_upcoming_round(2026) is None
+
+
+def test_detect_upcoming_round_skips_missing_rounds() -> None:
+    """``fetch_round`` returning None (404) means that round doesn't exist;
+    iteration should keep going, not bail."""
+    payloads = {
+        1: None,
+        2: None,
+        5: {"fixtures": [{"matchState": "Upcoming"}]},
+    }
+    with patch(
+        "fantasy_coach.scraper.fetch_round",
+        side_effect=lambda y, r, **kw: payloads.get(r),
+    ):
+        assert _detect_upcoming_round(2026) == 5
+
+
+@pytest.fixture
+def _mocked_environment(monkeypatch):
+    """Stub out the three IO sinks precompute touches: repo, store, and
+    ``compute_predictions`` itself. Returns the mocks for per-test assertions."""
+    fake_repo = MagicMock()
+    fake_store = MagicMock()
+    fake_compute = MagicMock(return_value=[MagicMock(), MagicMock()])  # 2 predictions
+    monkeypatch.setattr("fantasy_coach.config.get_repository", lambda: fake_repo)
+    monkeypatch.setattr("fantasy_coach.predictions.get_prediction_store", lambda: fake_store)
+    monkeypatch.setattr("fantasy_coach.predictions.compute_predictions", fake_compute)
+    return fake_repo, fake_store, fake_compute
+
+
+def test_precompute_with_explicit_season_and_round(_mocked_environment) -> None:
+    _, _, fake_compute = _mocked_environment
+    rc = main(["precompute", "--season", "2026", "--round", "8"])
+    assert rc == 0
+    fake_compute.assert_called_once()
+    # Positional args: (season, round, repo, store)
+    args, kwargs = fake_compute.call_args
+    assert args[0] == 2026
+    assert args[1] == 8
+    assert kwargs.get("force") is True  # default
+
+
+def test_precompute_no_force_passes_force_false(_mocked_environment) -> None:
+    _, _, fake_compute = _mocked_environment
+    rc = main(["precompute", "--season", "2026", "--round", "8", "--no-force"])
+    assert rc == 0
+    _, kwargs = fake_compute.call_args
+    assert kwargs.get("force") is False
+
+
+def test_precompute_autodetects_round_when_omitted(_mocked_environment) -> None:
+    _, _, fake_compute = _mocked_environment
+    with patch("fantasy_coach.__main__._detect_upcoming_round", return_value=12):
+        rc = main(["precompute", "--season", "2026"])
+    assert rc == 0
+    args, _ = fake_compute.call_args
+    assert args[0] == 2026
+    assert args[1] == 12
+
+
+def test_precompute_noop_when_no_upcoming_round(_mocked_environment) -> None:
+    _, _, fake_compute = _mocked_environment
+    with patch("fantasy_coach.__main__._detect_upcoming_round", return_value=None):
+        rc = main(["precompute", "--season", "2026"])
+    assert rc == 0
+    fake_compute.assert_not_called()

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -18,11 +18,13 @@ from fastapi.testclient import TestClient
 from fantasy_coach.app import app
 from fantasy_coach.features import extract_match_features
 from fantasy_coach.predictions import (
+    FirestorePredictionStore,
     PredictionOut,
     PredictionStore,
     TeamInfo,
     _feature_hash,
     compute_predictions,
+    get_prediction_store,
 )
 from fantasy_coach.storage.sqlite import SQLiteRepository
 
@@ -300,50 +302,207 @@ def _reset_app_store():
     app_module._store = None
 
 
-def _endpoint_patches(tmp_path: Path):
-    """Patch both IO sinks the endpoint touches so tests stay hermetic."""
-    return (
-        patch("fantasy_coach.app.get_repository", return_value=MagicMock()),
-        patch("fantasy_coach.app._get_store", return_value=PredictionStore(path=tmp_path / "p.db")),
+def test_compute_force_bypasses_cache_and_rescrapes(
+    store: PredictionStore, sqlite_repo: SQLiteRepository, tmp_path: Path
+) -> None:
+    """``force=True`` makes the precompute Job re-scrape even when predictions
+    are already cached — so team-list changes between Tue/Thu runs land."""
+    raw_match = _load_fixture(UPCOMING_FIXTURE)
+    # Pre-populate the cache with a stale prediction for the same round.
+    match = extract_match_features(raw_match)
+    stale = PredictionOut(
+        matchId=match.match_id,
+        home=TeamInfo(id=match.home.team_id, name=match.home.name),
+        away=TeamInfo(id=match.away.team_id, name=match.away.name),
+        kickoff=match.start_time.isoformat(),
+        predictedWinner="home",
+        homeWinProbability=0.99,  # clearly a stale / sentinel value
+        modelVersion="stale",
+        featureHash="stale",
     )
+    store.put(2026, 8, [stale])
+
+    mock_round = MagicMock(return_value=_sample_round_payload("/match/url"))
+    mock_match = MagicMock(return_value=raw_match)
+    mock_model = _make_mock_model(0.42)
+    model_path = tmp_path / "model.joblib"
+    model_path.write_bytes(b"fake-model-bytes")
+
+    with patch("fantasy_coach.predictions.load_model", return_value=mock_model):
+        result = compute_predictions(
+            2026,
+            8,
+            sqlite_repo,
+            store,
+            model_path=model_path,
+            fetch_round_fn=mock_round,
+            fetch_match_fn=mock_match,
+            force=True,
+        )
+
+    mock_round.assert_called_once()  # force bypassed the cache and actually scraped
+    assert len(result) == 1
+    # Fresh computation wins over the stale cache entry.
+    assert result[0].homeWinProbability == 0.42
+    assert result[0].modelVersion != "stale"
 
 
-def test_endpoint_returns_503_when_no_model(client: TestClient, tmp_path: Path) -> None:
-    p1, p2 = _endpoint_patches(tmp_path)
-    with (
-        p1,
-        p2,
-        patch(
-            "fantasy_coach.app.compute_predictions",
-            side_effect=FileNotFoundError(tmp_path / "missing.joblib"),
-        ),
-    ):
+def test_endpoint_returns_503_when_cache_empty(client: TestClient, tmp_path: Path) -> None:
+    """The endpoint no longer scrapes; an empty cache is a 503 with retry hint."""
+    empty_store = PredictionStore(path=tmp_path / "p.db")
+    with patch("fantasy_coach.app._get_store", return_value=empty_store):
         response = client.get("/predictions?season=2026&round=8")
     assert response.status_code == 503
+    assert "precompute" in response.json()["detail"].lower()
 
 
-def test_endpoint_returns_predictions(client: TestClient, tmp_path: Path) -> None:
+# ---------------------------------------------------------------------------
+# FirestorePredictionStore — in-memory fake client round-trip
+# ---------------------------------------------------------------------------
+
+
+class _FakeDocRef:
+    def __init__(self, store: dict, key: tuple[str, str]) -> None:
+        self._store = store
+        self._key = key
+
+    def set(self, data: dict) -> None:
+        self._store[self._key] = dict(data)
+
+    def get(self):
+        class _Snap:
+            def __init__(self, data: dict | None) -> None:
+                self._data = data
+
+            @property
+            def exists(self) -> bool:
+                return self._data is not None
+
+            def to_dict(self) -> dict | None:
+                return self._data
+
+        return _Snap(self._store.get(self._key))
+
+
+class _FakeCollection:
+    def __init__(self, store: dict, name: str) -> None:
+        self._store = store
+        self._name = name
+
+    def document(self, doc_id: str) -> _FakeDocRef:
+        return _FakeDocRef(self._store, (self._name, doc_id))
+
+
+class _FakeFirestoreClient:
+    def __init__(self) -> None:
+        self._store: dict = {}
+
+    def collection(self, name: str) -> _FakeCollection:
+        return _FakeCollection(self._store, name)
+
+
+def test_firestore_prediction_store_round_trip() -> None:
+    store = FirestorePredictionStore(client=_FakeFirestoreClient())
+    preds = [
+        PredictionOut(
+            matchId=1,
+            home=TeamInfo(id=10, name="Home"),
+            away=TeamInfo(id=20, name="Away"),
+            kickoff="2026-05-01T08:00:00+00:00",
+            predictedWinner="home",
+            homeWinProbability=0.6,
+            modelVersion="v1",
+            featureHash="fh1",
+        ),
+        PredictionOut(
+            matchId=2,
+            home=TeamInfo(id=30, name="A"),
+            away=TeamInfo(id=40, name="B"),
+            kickoff="2026-05-02T08:00:00+00:00",
+            predictedWinner="away",
+            homeWinProbability=0.3,
+            modelVersion="v1",
+            featureHash="fh1",
+        ),
+    ]
+    store.put(2026, 8, preds)
+    loaded = store.get(2026, 8)
+    assert len(loaded) == 2
+    assert loaded[0].matchId == 1
+    assert loaded[0].homeWinProbability == 0.6
+    assert loaded[1].matchId == 2
+
+
+def test_firestore_prediction_store_get_empty_returns_empty_list() -> None:
+    store = FirestorePredictionStore(client=_FakeFirestoreClient())
+    assert store.get(2026, 8) == []
+
+
+def test_firestore_prediction_store_put_overwrites() -> None:
+    """A second put for the same (season, round) replaces the prior entry
+    — load-bearing for ``--force`` semantics on the Job."""
+    store = FirestorePredictionStore(client=_FakeFirestoreClient())
+    p1 = PredictionOut(
+        matchId=1,
+        home=TeamInfo(id=1, name="A"),
+        away=TeamInfo(id=2, name="B"),
+        kickoff="2026-05-01T08:00:00+00:00",
+        predictedWinner="home",
+        homeWinProbability=0.9,
+        modelVersion="v1",
+        featureHash="fh1",
+    )
+    store.put(2026, 8, [p1])
+    # Second put with same key should replace, not append.
+    p2 = p1.model_copy(update={"homeWinProbability": 0.1, "predictedWinner": "away"})
+    store.put(2026, 8, [p2])
+    loaded = store.get(2026, 8)
+    assert len(loaded) == 1
+    assert loaded[0].homeWinProbability == 0.1
+
+
+def test_get_prediction_store_factory_defaults_to_sqlite(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("STORAGE_BACKEND", raising=False)
+    monkeypatch.setenv("FANTASY_COACH_PREDICTIONS_DB_PATH", str(tmp_path / "p.db"))
+    store = get_prediction_store()
+    assert isinstance(store, PredictionStore)
+
+
+def test_get_prediction_store_factory_picks_firestore(monkeypatch) -> None:
+    """``STORAGE_BACKEND=firestore`` wires the factory to FirestorePredictionStore."""
+    monkeypatch.setenv("STORAGE_BACKEND", "firestore")
+    # Avoid actually constructing the real google.cloud.firestore client.
+    with patch(
+        "fantasy_coach.predictions.FirestorePredictionStore",
+        return_value=MagicMock(spec=FirestorePredictionStore),
+    ) as cls:
+        store = get_prediction_store()
+    cls.assert_called_once()
+    assert store is cls.return_value
+
+
+def test_endpoint_returns_cached_predictions(client: TestClient, tmp_path: Path) -> None:
+    """Cache is populated by the precompute Job; endpoint just reads it."""
     raw = _load_fixture(UPCOMING_FIXTURE)
     match = extract_match_features(raw)
-    expected = [
-        PredictionOut(
-            matchId=match.match_id,
-            home=TeamInfo(id=match.home.team_id, name=match.home.name),
-            away=TeamInfo(id=match.away.team_id, name=match.away.name),
-            kickoff=match.start_time.isoformat(),
-            predictedWinner="home",
-            homeWinProbability=0.65,
-            modelVersion="abc123",
-            featureHash=_feature_hash(),
-        )
-    ]
-    p1, p2 = _endpoint_patches(tmp_path)
-    with p1, p2, patch("fantasy_coach.app.compute_predictions", return_value=expected):
+    cached = PredictionOut(
+        matchId=match.match_id,
+        home=TeamInfo(id=match.home.team_id, name=match.home.name),
+        away=TeamInfo(id=match.away.team_id, name=match.away.name),
+        kickoff=match.start_time.isoformat(),
+        predictedWinner="home",
+        homeWinProbability=0.65,
+        modelVersion="abc123",
+        featureHash=_feature_hash(),
+    )
+    populated_store = PredictionStore(path=tmp_path / "p.db")
+    populated_store.put(2026, 8, [cached])
+
+    with patch("fantasy_coach.app._get_store", return_value=populated_store):
         response = client.get("/predictions?season=2026&round=8")
 
     assert response.status_code == 200
     body = response.json()
-    assert isinstance(body, list)
     assert len(body) == 1
     pred = body[0]
     assert pred["matchId"] == match.match_id


### PR DESCRIPTION
Paired with [lopeztech/platform-infra#45](https://github.com/lopeztech/platform-infra/pull/45) — merge order: platform-infra first (provisions Firestore + Job), then this PR (flips the API to Firestore + image rotation for the Job).

## Summary

- **Precompute CLI**: \`python -m fantasy_coach precompute\` — new subcommand that autodetects the next upcoming round (iterates \`fetch_round\` until it finds \`Upcoming\`/\`Pre\` fixtures) and runs the full scrape + feature + predict pipeline. \`--season X --round Y\` overrides; \`--no-force\` keeps cache-hit semantics for manual runs.
- **\`compute_predictions\` force param**: scheduled runs use \`force=True\` by default so team-list changes between Tue and Thu runs actually land.
- **\`FirestorePredictionStore\`**: mirrors the SQLite \`PredictionStore\` interface. One doc per round, ID \`{season}-{round}\`. Keeps both write (Job) and read (API) sides to a single Firestore RPC per request.
- **\`get_prediction_store()\` factory**: picks SQLite vs Firestore from \`STORAGE_BACKEND\` — one switch for API + Job.
- **\`/predictions\` endpoint**: no longer calls \`compute_predictions\`. Cache miss → 503 with a retry hint explaining when the Job runs next. No cold-path scrape, no 504s against the 120s timeout.
- **Deploy**: \`STORAGE_BACKEND=firestore\` set on the Cloud Run revision; \`gcloud run jobs update\` rotates the Job image alongside the service on each push.
- **Docs**: \`docs/cost.md\` gets a precompute-vs-on-request table (real-dollar cost is a wash, p99 latency order-of-magnitude better, retry safety net).

## Blocker caught during investigation

Issue #15 shipped the \`FirestoreRepository\` code in this repo, but the **Firestore database was never actually provisioned** (API not enabled, no database exists). This PR's paired platform-infra change creates the database + composite indexes + SA grants — so #15 retroactively works for the first time.

## Test plan

- [x] New unit tests: \`FirestorePredictionStore\` round-trip against in-memory fake; \`force=True\` bypasses cache and re-scrapes with fresh probs overwriting stale entries; factory picks backend from \`STORAGE_BACKEND\`; \`/predictions\` endpoint 503s on empty cache with retry hint and 200s on populated cache.
- [x] New CLI tests: \`_detect_upcoming_round\` stops at first \`Upcoming\`/\`Pre\` match, skips missing rounds (404), returns None when season is over; \`precompute\` subcommand passes \`force=True\` by default, respects \`--no-force\`, autodetects when \`--round\` omitted, no-ops when no upcoming round.
- [x] 281 tests pass locally (minus xgboost file which needs libomp — CI covers it).
- [ ] After merge: trigger the Job manually \`gcloud run jobs execute fantasy-coach-precompute\` and verify Firestore \`predictions\` collection is populated. Hit \`/predictions\` and expect 200 with the computed values.

## Out of scope (follow-ups)

- Cut the Cloud Run \`--timeout\` from 120s → 60s now that scrape is off-path (simple deploy.yml tweak).
- Cloud Monitoring alert on \`fantasy-coach-precompute\` execution failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)