### PR TITLE
feat(predictions): attach top-K feature contributions (#58 backend)

### DIFF
--- a/src/fantasy_coach/predictions.py
+++ b/src/fantasy_coach/predictions.py
@@ -12,7 +12,9 @@ for true cross-restart persistence.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
+import json
 import logging
 import os
 import sqlite3
@@ -51,6 +53,7 @@ CREATE TABLE IF NOT EXISTS predictions (
     model_version    TEXT    NOT NULL,
     feature_hash     TEXT    NOT NULL,
     created_at       TEXT    NOT NULL,
+    contributions    TEXT,
     PRIMARY KEY (season, round, match_id)
 );
 """
@@ -66,6 +69,21 @@ class TeamInfo(BaseModel):
     name: str
 
 
+class FeatureContribution(BaseModel):
+    """One feature's signed push on the model's log-odds for a match.
+
+    ``contribution`` is in log-odds units: positive ⇒ pushes home-win
+    probability up. The UI picks top-K by ``abs(contribution)`` and renders
+    plain-English labels per ``feature``. Only emitted for logistic models
+    today (see ``_compute_contributions``); other model types get
+    ``contributions`` omitted so the UI degrades gracefully.
+    """
+
+    feature: str  # matches a FEATURE_NAMES entry
+    value: float  # raw (pre-scaling) feature value
+    contribution: float  # signed log-odds contribution
+
+
 class PredictionOut(BaseModel):
     matchId: int
     home: TeamInfo
@@ -75,6 +93,8 @@ class PredictionOut(BaseModel):
     homeWinProbability: float
     modelVersion: str  # first 12 hex chars of SHA-256 of the model file
     featureHash: str  # first 12 hex chars of SHA-256 of feature names
+    # Optional so predictions written before #58 shipped still deserialise.
+    contributions: list[FeatureContribution] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -96,6 +116,11 @@ class PredictionStore:
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(_CREATE_TABLE)
+        # Forward-compat for DB files created before #58 shipped — adds the
+        # new column in place; no-op on a fresh DB since CREATE TABLE above
+        # already includes it.
+        with contextlib.suppress(sqlite3.OperationalError):
+            self._conn.execute("ALTER TABLE predictions ADD COLUMN contributions TEXT")
 
     def close(self) -> None:
         self._conn.close()
@@ -111,14 +136,20 @@ class PredictionStore:
         now = datetime.now(UTC).isoformat()
         with self._conn:
             for p in predictions:
+                contribs_json = (
+                    json.dumps([c.model_dump() for c in p.contributions])
+                    if p.contributions is not None
+                    else None
+                )
                 self._conn.execute(
                     """
                     INSERT OR REPLACE INTO predictions
                         (season, round, match_id,
                          home_id, home_name, away_id, away_name,
                          kickoff, predicted_winner, home_win_prob,
-                         model_version, feature_hash, created_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                         model_version, feature_hash, created_at,
+                         contributions)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         season,
@@ -134,11 +165,17 @@ class PredictionStore:
                         p.modelVersion,
                         p.featureHash,
                         now,
+                        contribs_json,
                     ),
                 )
 
 
 def _row_to_out(r: sqlite3.Row) -> PredictionOut:
+    # sqlite3.Row exposes column names via .keys(); plain `in r` iterates values.
+    contribs_raw = r["contributions"] if "contributions" in tuple(r.keys()) else None
+    contribs = (
+        [FeatureContribution(**c) for c in json.loads(contribs_raw)] if contribs_raw else None
+    )
     return PredictionOut(
         matchId=r["match_id"],
         home=TeamInfo(id=r["home_id"], name=r["home_name"]),
@@ -148,6 +185,7 @@ def _row_to_out(r: sqlite3.Row) -> PredictionOut:
         homeWinProbability=r["home_win_prob"],
         modelVersion=r["model_version"],
         featureHash=r["feature_hash"],
+        contributions=contribs,
     )
 
 
@@ -269,6 +307,58 @@ def _feature_hash() -> str:
     return hashlib.sha256(",".join(sorted(FEATURE_NAMES)).encode()).hexdigest()[:12]
 
 
+def _compute_contributions(
+    loaded: Any, x: np.ndarray, *, top_k: int = 5
+) -> list[FeatureContribution] | None:
+    """Return top-K signed log-odds contributions for a logistic pipeline.
+
+    Contribution_i = coef_i × (x_i − mean_i) / scale_i, i.e. the per-feature
+    push on the log-odds produced by the ``lr`` step of the pipeline. Sum of
+    contributions + intercept = z = logit(home_win_prob) for an uncalibrated
+    logistic model. Calibrated probabilities apply a monotone transform on
+    top, so the ordering of contributions stays meaningful as "which features
+    pushed hardest" even though the absolute sum no longer equals logit(p).
+
+    Returns ``None`` for non-logistic artefacts (ensemble/xgboost). Callers
+    should ``p.contributions = result`` either way — the UI hides its reasons
+    panel gracefully when the field is absent.
+    """
+    pipeline = getattr(loaded, "pipeline", None)
+    if pipeline is None:
+        return None
+    try:
+        scaler = pipeline.named_steps["scale"]
+        lr = pipeline.named_steps["lr"]
+    except (KeyError, AttributeError):
+        return None
+
+    feature_names = getattr(loaded, "feature_names", None)
+    if not feature_names:
+        return None
+
+    raw = np.asarray(x, dtype=float).reshape(-1)
+    mean = np.asarray(getattr(scaler, "mean_", None))
+    scale = np.asarray(getattr(scaler, "scale_", None))
+    coef = np.asarray(getattr(lr, "coef_", None)).reshape(-1)
+    if mean.shape != raw.shape or scale.shape != raw.shape or coef.shape != raw.shape:
+        return None
+
+    # Guard against a zero-variance column that would have shipped as
+    # scale_=0. sklearn normally replaces those with 1.0 but be defensive.
+    safe_scale = np.where(scale == 0.0, 1.0, scale)
+    contributions = coef * (raw - mean) / safe_scale
+
+    top_idx = np.argsort(-np.abs(contributions))[:top_k]
+    return [
+        FeatureContribution(
+            feature=feature_names[i],
+            value=round(float(raw[i]), 6),
+            contribution=round(float(contributions[i]), 4),
+        )
+        for i in top_idx
+    ]
+
+
 def _build_inference_state(history: list[MatchRow]) -> FeatureBuilder:
     builder = FeatureBuilder()
     for match in sorted(history, key=lambda m: (m.start_time, m.match_id)):
@@ -378,6 +468,7 @@ def compute_predictions(
                 homeWinProbability=prob,
                 modelVersion=mv,
                 featureHash=fh,
+                contributions=_compute_contributions(loaded, x),
             )
         )
 

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -14,14 +14,19 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 from fastapi.testclient import TestClient
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 
 from fantasy_coach.app import app
 from fantasy_coach.features import extract_match_features
 from fantasy_coach.predictions import (
+    FeatureContribution,
     FirestorePredictionStore,
     PredictionOut,
     PredictionStore,
     TeamInfo,
+    _compute_contributions,
     _ensure_model,
     _feature_hash,
     compute_predictions,
@@ -323,6 +328,110 @@ def test_compute_dispatches_ensemble_artifact_end_to_end(
     pb = base_b.pipeline.predict_proba(feature_row)[0, 1]
     expected = round(float(weights[0] * pa + weights[1] * pb), 4)
     assert pred.homeWinProbability == expected
+
+
+# ---------------------------------------------------------------------------
+# _compute_contributions — feature-contribution extraction
+# ---------------------------------------------------------------------------
+
+
+def _make_logistic_loaded(n_features: int = 3):
+    """Return a LoadedModel-shaped object with a fitted logistic pipeline."""
+    from fantasy_coach.models.logistic import LoadedModel
+
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((80, n_features))
+    # Make feature 0 dominate so we can assert it sorts to the top.
+    y = (X[:, 0] > 0).astype(int)
+
+    pipeline = Pipeline(
+        steps=[("scale", StandardScaler()), ("lr", LogisticRegression(max_iter=1000))]
+    )
+    pipeline.fit(X, y)
+    return LoadedModel(
+        pipeline=pipeline,
+        feature_names=tuple(f"feat_{i}" for i in range(n_features)),
+    )
+
+
+def test_compute_contributions_picks_top_k_by_abs_value() -> None:
+    loaded = _make_logistic_loaded(n_features=4)
+    x = np.array([[2.5, 0.1, -0.2, 0.05]])  # feat_0 is dominant
+    contribs = _compute_contributions(loaded, x, top_k=2)
+
+    assert contribs is not None
+    assert len(contribs) == 2
+    # Sorted by |contribution| descending; feat_0 must win.
+    assert contribs[0].feature == "feat_0"
+    assert abs(contribs[0].contribution) >= abs(contribs[1].contribution)
+    # Raw (unscaled) value passed through faithfully.
+    assert contribs[0].value == pytest.approx(2.5)
+
+
+def test_compute_contributions_sum_equals_logit_up_to_intercept() -> None:
+    loaded = _make_logistic_loaded(n_features=3)
+    rng = np.random.default_rng(11)
+    x = rng.standard_normal((1, 3))
+    # top_k covers all features so the sum should equal the full log-odds.
+    contribs = _compute_contributions(loaded, x, top_k=3)
+
+    assert contribs is not None
+    intercept = float(loaded.pipeline.named_steps["lr"].intercept_[0])
+    total = sum(c.contribution for c in contribs) + intercept
+
+    raw_prob = float(loaded.pipeline.predict_proba(x)[0, 1])
+    expected_logit = float(np.log(raw_prob / (1.0 - raw_prob)))
+    # Rounded at 4dp, so allow a little slack.
+    assert total == pytest.approx(expected_logit, abs=1e-3)
+
+
+def test_compute_contributions_returns_none_for_non_logistic() -> None:
+    """Mock a model with no ``.pipeline`` attribute — the happy path out."""
+    mock = MagicMock(spec=["feature_names"])
+    contribs = _compute_contributions(mock, np.zeros((1, 3)))
+    assert contribs is None
+
+
+def test_store_roundtrips_contributions(store: PredictionStore) -> None:
+    pred = PredictionOut(
+        matchId=42,
+        home=TeamInfo(id=1, name="A"),
+        away=TeamInfo(id=2, name="B"),
+        kickoff="2026-05-01T08:00:00+00:00",
+        predictedWinner="home",
+        homeWinProbability=0.6,
+        modelVersion="mv",
+        featureHash="fh",
+        contributions=[
+            FeatureContribution(feature="elo_diff", value=42.3, contribution=0.31),
+            FeatureContribution(feature="days_rest_diff", value=3.0, contribution=0.08),
+        ],
+    )
+    store.put(2026, 8, [pred])
+
+    loaded = store.get(2026, 8)
+    assert len(loaded) == 1
+    assert loaded[0].contributions is not None
+    assert len(loaded[0].contributions) == 2
+    assert loaded[0].contributions[0].feature == "elo_diff"
+    assert loaded[0].contributions[0].contribution == pytest.approx(0.31)
+
+
+def test_store_roundtrips_missing_contributions_as_none(store: PredictionStore) -> None:
+    pred = PredictionOut(
+        matchId=43,
+        home=TeamInfo(id=1, name="A"),
+        away=TeamInfo(id=2, name="B"),
+        kickoff="2026-05-01T08:00:00+00:00",
+        predictedWinner="home",
+        homeWinProbability=0.6,
+        modelVersion="mv",
+        featureHash="fh",
+        # contributions omitted
+    )
+    store.put(2026, 8, [pred])
+    loaded = store.get(2026, 8)
+    assert loaded[0].contributions is None
 
 
 def test_compute_returns_empty_when_no_fixtures(


### PR DESCRIPTION
## Summary
- Adds optional `contributions: list[FeatureContribution]` on `PredictionOut`. Each entry is `{feature, value, contribution}`, contribution in log-odds units (positive pushes home-win probability up).
- For logistic pipelines, computes `coef × (x − mean) / scale` per feature and keeps the top 5 by `|contribution|`. Non-logistic artefacts (ensemble/xgboost) return `None` — the future UI hides the panel gracefully.
- SQLite store gets a `contributions TEXT` column (JSON-encoded) with a `contextlib.suppress`-guarded ALTER for forward-compat on existing dev DBs. Firestore picks up the field via `model_dump()` with no schema change.
- 5 new tests: top-K ordering, sum-to-logit sanity check, `None` for non-logistic models, and SQLite round-trip with + without contributions.

## Why
First half of #58 ("why this pick" match detail page). The UI wants plain-English reasons per match; precomputing them in the Job keeps the API as a pure cache read. This is the backend piece — the new route + UI lands in a stacked PR off `main` once this merges.

## Non-goals (separate issues / follow-ups)
- Recent form mini-chart (needs a new endpoint).
- Gemini preview slot (depends on #23).
- XGBoost standalone `pred_contribs` (prod model is logistic; ensemble delegates through bases — deferred until we run a pure-xgboost artefact in prod).

## Test plan
- [x] `uv run pytest tests/test_predictions.py` — 27 passing.
- [x] `uv run ruff check src tests` + `ruff format --check` — clean.
- [ ] Post-merge + next Job run: `gcloud run jobs execute fantasy-coach-precompute` → `/predictions` response includes `contributions` for each match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)