### PR TITLE
feat(web): match detail page with "why this pick" (#58 frontend)

### DIFF
--- a/web/src/components/MatchCard.tsx
+++ b/web/src/components/MatchCard.tsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 import type { Prediction } from "../types";
 
 function formatKickoff(iso: string): string {
@@ -12,7 +14,17 @@ function formatKickoff(iso: string): string {
   });
 }
 
-export function MatchCard({ prediction, preview }: { prediction: Prediction; preview?: string }) {
+export function MatchCard({
+  prediction,
+  season,
+  round,
+  preview,
+}: {
+  prediction: Prediction;
+  season: number;
+  round: number;
+  preview?: string;
+}) {
   const p = prediction;
   const homePct = Math.round(p.homeWinProbability * 100);
   const awayPct = 100 - homePct;
@@ -20,39 +32,45 @@ export function MatchCard({ prediction, preview }: { prediction: Prediction; pre
   const winnerPct = p.predictedWinner === "home" ? homePct : awayPct;
 
   return (
-    <article className="match-card" aria-label={`${p.home.name} vs ${p.away.name}`}>
-      <header className="match-card-head">
-        <div className="teams">
-          <span className="team home">{p.home.name}</span>
-          <span className="muted"> vs </span>
-          <span className="team away">{p.away.name}</span>
+    <Link
+      to={`/round/${season}/${round}/${p.matchId}`}
+      className="match-card-link"
+      aria-label={`${p.home.name} vs ${p.away.name} — view why`}
+    >
+      <article className="match-card">
+        <header className="match-card-head">
+          <div className="teams">
+            <span className="team home">{p.home.name}</span>
+            <span className="muted"> vs </span>
+            <span className="team away">{p.away.name}</span>
+          </div>
+          <time className="kickoff muted" dateTime={p.kickoff}>
+            {formatKickoff(p.kickoff)}
+          </time>
+        </header>
+
+        <div className="prob-bar" role="img" aria-label={`Home win probability ${homePct}%`}>
+          <span
+            className="prob-bar-home"
+            style={{ width: `${homePct}%` }}
+            aria-hidden="true"
+          />
         </div>
-        <time className="kickoff muted" dateTime={p.kickoff}>
-          {formatKickoff(p.kickoff)}
-        </time>
-      </header>
+        <div className="prob-labels">
+          <span>
+            <strong>{p.home.name}</strong> {homePct}%
+          </span>
+          <span>
+            {awayPct}% <strong>{p.away.name}</strong>
+          </span>
+        </div>
 
-      <div className="prob-bar" role="img" aria-label={`Home win probability ${homePct}%`}>
-        <span
-          className="prob-bar-home"
-          style={{ width: `${homePct}%` }}
-          aria-hidden="true"
-        />
-      </div>
-      <div className="prob-labels">
-        <span>
-          <strong>{p.home.name}</strong> {homePct}%
-        </span>
-        <span>
-          {awayPct}% <strong>{p.away.name}</strong>
-        </span>
-      </div>
+        <p className="pick">
+          Pick: <strong>{winnerName}</strong> ({winnerPct}%)
+        </p>
 
-      <p className="pick">
-        Pick: <strong>{winnerName}</strong> ({winnerPct}%)
-      </p>
-
-      {preview ? <p className="preview">{preview}</p> : null}
-    </article>
+        {preview ? <p className="preview">{preview}</p> : null}
+      </article>
+    </Link>
   );
 }

--- a/web/src/features.ts
+++ b/web/src/features.ts
@@ -1,0 +1,115 @@
+// Plain-English labels for each model feature. The backend emits raw
+// feature names (matching fantasy_coach.feature_engineering.FEATURE_NAMES);
+// this module turns them into a one-line sentence the UI can render with
+// the concrete home/away team names.
+//
+// All numeric feature values are home-minus-away by convention (see the
+// backend's feature docstring), so positive values favour the home team.
+
+import type { FeatureContribution } from "./types";
+
+export type ContributionLabel = {
+  /** One-line sentence suitable for a list row. */
+  text: string;
+  /** "home" when the sign of the contribution favours the home team, else "away". */
+  favours: "home" | "away" | "neutral";
+};
+
+function favouredBy(contribution: number): "home" | "away" | "neutral" {
+  if (contribution > 0) return "home";
+  if (contribution < 0) return "away";
+  return "neutral";
+}
+
+function teamFavoured(contribution: number, home: string, away: string): string {
+  return contribution >= 0 ? home : away;
+}
+
+export function labelFor(
+  c: FeatureContribution,
+  home: string,
+  away: string,
+): ContributionLabel {
+  const { feature, value, contribution } = c;
+  const favours = favouredBy(contribution);
+  const text = describe(feature, value, contribution, home, away);
+  return { text, favours };
+}
+
+function describe(
+  feature: string,
+  value: number,
+  contribution: number,
+  home: string,
+  away: string,
+): string {
+  const mag = Math.abs(value);
+  const rounded = (n: number, d = 1) => n.toFixed(d).replace(/\.0$/, "");
+
+  switch (feature) {
+    case "elo_diff": {
+      const who = teamFavoured(contribution, home, away);
+      return `${who} rated ${rounded(mag, 0)} Elo points higher`;
+    }
+    case "form_diff_pf": {
+      const who = teamFavoured(value, home, away);
+      return `${who} scoring ${rounded(mag)} more points per game (recent form)`;
+    }
+    case "form_diff_pa": {
+      // form_diff_pa: home_pa - away_pa. Lower pa = tighter defence, so a
+      // negative value favours the home team. Invert for a natural sentence.
+      const who = teamFavoured(-value, home, away);
+      return `${who} conceding ${rounded(mag)} fewer points per game (recent defence)`;
+    }
+    case "days_rest_diff": {
+      const who = teamFavoured(value, home, away);
+      return `${who} had ${rounded(mag)} more days' rest`;
+    }
+    case "h2h_recent_diff": {
+      const who = teamFavoured(value, home, away);
+      return `${who} leads recent head-to-head by ${rounded(mag)} points`;
+    }
+    case "is_home_field":
+      return `Home-field advantage for ${home}`;
+    case "travel_km_diff": {
+      // Positive = home travelled further, which hurts home.
+      const disadvantaged = teamFavoured(-value, home, away);
+      return `${disadvantaged} travelled ${rounded(mag, 0)} km less`;
+    }
+    case "timezone_delta_diff": {
+      const disadvantaged = teamFavoured(-value, home, away);
+      return `${disadvantaged} had the smaller timezone shift (${rounded(mag)} h)`;
+    }
+    case "back_to_back_short_week_diff":
+      // +1/−1/0 flag for short-week + travel combo.
+      if (value === 0) return "No short-week travel penalty on either side";
+      return value > 0
+        ? `${away} avoided a short-week long-travel penalty`
+        : `${home} avoided a short-week long-travel penalty`;
+    case "is_wet":
+      return value > 0.5 ? "Wet-weather forecast" : "Dry-weather forecast";
+    case "wind_kph":
+      return `Wind ${rounded(value, 0)} kph`;
+    case "temperature_c":
+      return `Temperature ${rounded(value, 0)} °C`;
+    case "missing_weather":
+      return value > 0.5 ? "Weather data unavailable for venue" : "Weather data available";
+    case "venue_avg_total_points":
+      return `Venue typically sees ${rounded(value, 0)} combined points per match`;
+    case "venue_home_win_rate": {
+      const pct = Math.round(value * 100);
+      return `Home teams win ${pct}% of matches at this venue`;
+    }
+    case "ref_avg_total_points":
+      return `Referee averages ${rounded(value, 0)} combined points per match`;
+    case "ref_home_penalty_diff": {
+      const who = teamFavoured(-value, home, away);
+      return `Referee tends to penalise ${who === home ? away : home} more (${rounded(mag)} fewer home penalties)`;
+    }
+    case "missing_referee":
+      return value > 0.5 ? "Referee not yet confirmed" : "Referee confirmed";
+    default:
+      // Fallback for unknown feature names (e.g. future feature additions).
+      return `${feature} = ${rounded(value, 2)}`;
+  }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,6 +4,7 @@ import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 import App from "./App";
 import Home from "./routes/Home";
+import MatchDetail from "./routes/MatchDetail";
 import Round from "./routes/Round";
 import "./styles.css";
 
@@ -14,6 +15,7 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <Home /> },
       { path: "round/:season/:round", element: <Round /> },
+      { path: "round/:season/:round/:matchId", element: <MatchDetail /> },
     ],
   },
 ]);

--- a/web/src/routes/MatchDetail.tsx
+++ b/web/src/routes/MatchDetail.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { apiFetch, ApiError, NotSignedInError } from "../api";
+import { useAuth } from "../auth";
+import { labelFor } from "../features";
+import { SignInRequired } from "../components/SignInRequired";
+import type { Prediction } from "../types";
+
+type Status =
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "not_found" }
+  | { kind: "ok"; prediction: Prediction };
+
+function formatKickoff(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    weekday: "long",
+    day: "numeric",
+    month: "short",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export default function MatchDetail() {
+  const { season: seasonParam, round: roundParam, matchId: matchIdParam } = useParams();
+  const { user, loading: authLoading } = useAuth();
+  const [status, setStatus] = useState<Status>({ kind: "loading" });
+
+  const season = Number(seasonParam);
+  const round = Number(roundParam);
+  const matchId = Number(matchIdParam);
+  const paramsValid =
+    Number.isFinite(season) && Number.isFinite(round) && Number.isFinite(matchId);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) return;
+    if (!paramsValid) {
+      setStatus({ kind: "error", message: "Season, round, and match id must be numbers." });
+      return;
+    }
+
+    let cancelled = false;
+    setStatus({ kind: "loading" });
+    // Reuse the round endpoint — the API returns the full list for the
+    // round in one RPC and the cache is already warm from Round.tsx, so
+    // this avoids a second Firestore read for the common navigate-in case.
+    apiFetch<Prediction[]>(`/predictions?season=${season}&round=${round}`)
+      .then((predictions) => {
+        if (cancelled) return;
+        const match = predictions.find((p) => p.matchId === matchId);
+        if (!match) {
+          setStatus({ kind: "not_found" });
+        } else {
+          setStatus({ kind: "ok", prediction: match });
+        }
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof NotSignedInError) {
+          setStatus({ kind: "error", message: "Sign in required." });
+        } else if (err instanceof ApiError) {
+          setStatus({
+            kind: "error",
+            message: `Couldn't load prediction (HTTP ${err.status}). ${err.message}`,
+          });
+        } else {
+          setStatus({ kind: "error", message: "Couldn't reach the prediction API." });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, user, paramsValid, season, round, matchId]);
+
+  if (authLoading) return <p>Loading…</p>;
+  if (!user) return <SignInRequired message="Sign in to see this match." />;
+
+  return (
+    <section>
+      <p className="back-link">
+        <Link to={`/round/${season}/${round}`}>← Back to Round {round}</Link>
+      </p>
+
+      {status.kind === "loading" && <p>Loading match…</p>}
+
+      {status.kind === "error" && (
+        <div className="error-box" role="alert">
+          {status.message}
+        </div>
+      )}
+
+      {status.kind === "not_found" && (
+        <div className="error-box" role="alert">
+          No prediction found for match {matchId} in round {round}.
+        </div>
+      )}
+
+      {status.kind === "ok" && <MatchDetailBody prediction={status.prediction} />}
+    </section>
+  );
+}
+
+function MatchDetailBody({ prediction }: { prediction: Prediction }) {
+  const homePct = Math.round(prediction.homeWinProbability * 100);
+  const awayPct = 100 - homePct;
+  const winnerName =
+    prediction.predictedWinner === "home" ? prediction.home.name : prediction.away.name;
+  const winnerPct = prediction.predictedWinner === "home" ? homePct : awayPct;
+
+  const contributions = prediction.contributions ?? [];
+
+  return (
+    <article className="match-detail">
+      <header className="match-detail-header">
+        <h1>
+          {prediction.home.name} <span className="muted">vs</span> {prediction.away.name}
+        </h1>
+        <time className="kickoff muted" dateTime={prediction.kickoff}>
+          {formatKickoff(prediction.kickoff)}
+        </time>
+      </header>
+
+      <div className="prob-dial" role="img" aria-label={`Home win probability ${homePct}%`}>
+        <div className="prob-dial-bar">
+          <span className="prob-bar-home" style={{ width: `${homePct}%` }} aria-hidden="true" />
+        </div>
+        <div className="prob-dial-labels">
+          <span>
+            <strong>{prediction.home.name}</strong> {homePct}%
+          </span>
+          <span>
+            {awayPct}% <strong>{prediction.away.name}</strong>
+          </span>
+        </div>
+        <p className="pick">
+          Pick: <strong>{winnerName}</strong> ({winnerPct}%)
+        </p>
+      </div>
+
+      {contributions.length > 0 ? (
+        <section className="contributions" aria-labelledby="why-heading">
+          <h2 id="why-heading">Why this pick</h2>
+          <ol className="contribution-list">
+            {contributions.map((c) => {
+              const label = labelFor(c, prediction.home.name, prediction.away.name);
+              return (
+                <li key={c.feature} className={`contribution favours-${label.favours}`}>
+                  <span className="contribution-text">{label.text}</span>
+                  <span
+                    className="contribution-magnitude muted"
+                    aria-label={`log-odds push ${c.contribution.toFixed(2)}`}
+                  >
+                    {c.contribution >= 0 ? "+" : ""}
+                    {c.contribution.toFixed(2)}
+                  </span>
+                </li>
+              );
+            })}
+          </ol>
+          <p className="muted fine-print">
+            Contributions are in log-odds units — higher magnitude means the feature pushed the
+            probability harder in the direction shown.
+          </p>
+        </section>
+      ) : (
+        <p className="muted">
+          This prediction was generated before per-feature explanations were available.
+        </p>
+      )}
+    </article>
+  );
+}

--- a/web/src/routes/Round.tsx
+++ b/web/src/routes/Round.tsx
@@ -82,7 +82,7 @@ export default function Round() {
       {status.kind === "ok" && status.predictions.length > 0 && (
         <div className="match-grid">
           {status.predictions.map((p) => (
-            <MatchCard key={p.matchId} prediction={p} />
+            <MatchCard key={p.matchId} prediction={p} season={season} round={round} />
           ))}
         </div>
       )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -206,3 +206,129 @@ button:hover {
   font-size: 0.9rem;
   line-height: 1.4;
 }
+
+/* ── Match card link wrapper ───────────────────────────────────────────── */
+
+.match-card-link {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+  border-radius: 8px;
+  transition:
+    transform 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.match-card-link:hover .match-card,
+.match-card-link:focus-visible .match-card {
+  border-color: #1a1a1a;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.match-card-link:focus-visible {
+  outline: 2px solid #1a1a1a;
+  outline-offset: 2px;
+}
+
+/* ── Match detail page ─────────────────────────────────────────────────── */
+
+.back-link {
+  margin: 0 0 1rem;
+  font-size: 0.9rem;
+}
+
+.back-link a {
+  color: #1a1a1a;
+  text-decoration: none;
+}
+
+.back-link a:hover {
+  text-decoration: underline;
+}
+
+.match-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.match-detail-header h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.5rem;
+}
+
+.prob-dial {
+  padding: 1rem 1.25rem;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.prob-dial-bar {
+  height: 0.9rem;
+  background: #e0e0e0;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.prob-dial-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.95rem;
+}
+
+.contributions h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+}
+
+.contribution-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.contribution {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0.9rem;
+  border: 1px solid #e5e5e5;
+  border-left-width: 4px;
+  border-radius: 6px;
+  background: #fff;
+}
+
+.contribution.favours-home {
+  border-left-color: #1a1a1a;
+}
+
+.contribution.favours-away {
+  border-left-color: #c0392b;
+}
+
+.contribution.favours-neutral {
+  border-left-color: #ccc;
+}
+
+.contribution-text {
+  font-size: 0.95rem;
+}
+
+.contribution-magnitude {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.fine-print {
+  font-size: 0.8rem;
+  margin: 0.5rem 0 0;
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -3,6 +3,15 @@ export type Team = {
   name: string;
 };
 
+// Present for logistic-model predictions (see backend #58). Older cached
+// predictions and non-logistic artefacts omit this — consumers must treat
+// it as optional and hide their reasons panel if absent.
+export type FeatureContribution = {
+  feature: string;
+  value: number;
+  contribution: number; // signed log-odds push
+};
+
 export type Prediction = {
   matchId: number;
   home: Team;
@@ -12,4 +21,5 @@ export type Prediction = {
   homeWinProbability: number; // 0..1
   modelVersion: string;
   featureHash: string;
+  contributions?: FeatureContribution[] | null;
 };


### PR DESCRIPTION
## Summary
- New SPA route `/round/:season/:round/:matchId`. `MatchCard` becomes a `<Link>` so every card in the round grid deep-links to the detail view.
- Detail page: teams + kickoff header, probability dial, "Why this pick" list of top contributions from the backend. Each row gets a plain-English sentence rendered from the raw feature + home/away names (see `web/src/features.ts`) plus a left border whose colour tracks whether the feature favours home or away.
- Gracefully hides the reasons panel + shows a muted line if `contributions` is absent (older cached rounds / non-logistic artefacts). Card view stays functional either way.
- CSS: hover/focus states on the card link, new `.match-detail` / `.prob-dial` / `.contribution*` blocks. Keyboard focus ring for a11y.

## Why
Closes the UI half of #58. Builds on the backend `contributions` field that landed as part of #95. Navigating from the round grid into a match now explains the pick instead of just showing a probability.

## Note
This is the re-opened frontend PR. Original PR #96 auto-closed when its base branch was deleted on the backend merge — the commits here are identical, rebased onto `main`.

## Out of scope (separate follow-ups)
- Recent form mini-chart (needs a new endpoint).
- Gemini preview slot (depends on #23).

## Test plan
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [x] `npm run dev` boots; both `/` and `/round/2026/8/:matchId` return 200.
- [ ] Post-merge (and post-next Job run): click a card on `fantasy.lopezcloud.dev`, confirm the detail view shows the top-5 reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)