### PR TITLE
feat(team-lists): snapshot + diff pipeline for starting-XIII changes (#24)

### DIFF
--- a/src/fantasy_coach/__main__.py
+++ b/src/fantasy_coach/__main__.py
@@ -6,6 +6,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+from typing import Any
 
 from fantasy_coach.backfill import (
     BackfillState,
@@ -266,10 +267,15 @@ def _detect_upcoming_round(year: int) -> int | None:
 
 
 def _run_precompute(args: argparse.Namespace) -> int:
+    import os  # noqa: PLC0415
     from datetime import UTC, datetime  # noqa: PLC0415
 
     from fantasy_coach.config import get_repository  # noqa: PLC0415
     from fantasy_coach.predictions import compute_predictions, get_prediction_store  # noqa: PLC0415
+    from fantasy_coach.storage.team_list import (  # noqa: PLC0415
+        FirestoreTeamListRepository,
+        SQLiteTeamListRepository,
+    )
 
     season = args.season or datetime.now(UTC).year
     round_ = args.round
@@ -282,6 +288,17 @@ def _run_precompute(args: argparse.Namespace) -> int:
 
     repo = get_repository()
     store = get_prediction_store()
+    # Shadow the STORAGE_BACKEND switch on the team-list side so snapshots
+    # land in the same backend as matches. SQLite dev reuses the repo's
+    # connection to keep everything in one file.
+    if os.getenv("STORAGE_BACKEND", "sqlite").lower() == "firestore":
+        team_list_repo: Any = FirestoreTeamListRepository()
+    else:
+        # Access the underlying sqlite3.Connection. SQLiteRepository exposes
+        # it as ``_conn``; tolerate absence for fake repos in tests.
+        conn = getattr(repo, "_conn", None)
+        team_list_repo = SQLiteTeamListRepository(conn) if conn is not None else None
+
     try:
         predictions = compute_predictions(
             season,
@@ -289,6 +306,7 @@ def _run_precompute(args: argparse.Namespace) -> int:
             repo,
             store,
             force=not args.no_force,
+            team_list_repo=team_list_repo,
         )
     finally:
         if hasattr(repo, "close"):

--- a/src/fantasy_coach/features.py
+++ b/src/fantasy_coach/features.py
@@ -85,6 +85,10 @@ class PlayerRow(BaseModel):
     position: str | None
     first_name: str | None
     last_name: str | None
+    # True = named in the starting XIII for this scrape, False = bench/reserve.
+    # Optional because completed matches don't carry this flag — only upcoming
+    # matches do (starting XIII is decided right before kickoff).
+    is_on_field: bool | None = None
 
 
 class TeamRow(BaseModel):
@@ -162,12 +166,14 @@ def _extract_team(raw: dict[str, Any]) -> TeamRow:
 
 
 def _extract_player(raw: dict[str, Any]) -> PlayerRow:
+    is_on_field = raw.get("isOnField")
     return PlayerRow(
         player_id=int(raw["playerId"]),
         jersey_number=_optional_int(raw.get("number")),
         position=raw.get("position"),
         first_name=raw.get("firstName"),
         last_name=raw.get("lastName"),
+        is_on_field=bool(is_on_field) if is_on_field is not None else None,
     )
 
 

--- a/src/fantasy_coach/predictions.py
+++ b/src/fantasy_coach/predictions.py
@@ -307,6 +307,43 @@ def _feature_hash() -> str:
     return hashlib.sha256(",".join(sorted(FEATURE_NAMES)).encode()).hexdigest()[:12]
 
 
+def _record_team_list_snapshots(team_list_repo: Any, row: MatchRow) -> None:
+    """Persist one snapshot per team for this match, if team lists are present.
+
+    Skips teams whose players array is empty or missing the ``isOnField``
+    flag entirely — those scrapes pre-date the team-list drop and carry no
+    signal about the starting XIII. Failures are logged and swallowed so
+    the precompute loop keeps processing other matches.
+    """
+    from datetime import UTC, datetime  # noqa: PLC0415
+
+    from fantasy_coach.team_lists import TeamListSnapshot  # noqa: PLC0415
+
+    now = datetime.now(UTC)
+    for side in (row.home, row.away):
+        players = side.players
+        if not players:
+            continue
+        if not any(p.is_on_field is not None for p in players):
+            continue
+        snapshot = TeamListSnapshot(
+            season=row.season,
+            round=row.round,
+            match_id=row.match_id,
+            team_id=side.team_id,
+            scraped_at=now,
+            players=tuple(players),
+        )
+        try:
+            team_list_repo.record_snapshot(snapshot)
+        except Exception:
+            logger.exception(
+                "Failed to record team-list snapshot for match %s team %s",
+                row.match_id,
+                side.team_id,
+            )
+
+
 def _compute_contributions(
     loaded: Any, x: np.ndarray, *, top_k: int = 5
 ) -> list[FeatureContribution] | None:
@@ -384,12 +421,19 @@ def compute_predictions(
     fetch_round_fn: Any = fetch_round,
     fetch_match_fn: Any = fetch_match_from_url,
     force: bool = False,
+    team_list_repo: Any = None,
 ) -> list[PredictionOut]:
     """Return predictions for season/round; compute and cache them on miss.
 
     ``force=True`` bypasses the cache-hit short-circuit so the precompute
     Job can refresh stored predictions when team lists change between
     scheduled runs. On cache miss ``force`` is a no-op.
+
+    ``team_list_repo`` is optional. When provided (production path via
+    ``_run_precompute``), each scraped match with populated team-list data
+    appends a snapshot per side so downstream model features (#27) can
+    diff named-squad vs kickoff lineup across scrapes. Silently skipped
+    when ``None`` — tests that don't exercise the snapshot path pass None.
 
     Raises ``FileNotFoundError`` if the model artefact does not exist (caller
     should surface this as HTTP 503).
@@ -435,6 +479,8 @@ def compute_predictions(
             row = extract_match_features(raw)
             repo.upsert_match(row)
             round_matches.append(row)
+            if team_list_repo is not None:
+                _record_team_list_snapshots(team_list_repo, row)
         except Exception:
             logger.exception("Failed to extract/store match from %s", url)
 

--- a/src/fantasy_coach/storage/firestore.py
+++ b/src/fantasy_coach/storage/firestore.py
@@ -104,6 +104,7 @@ def _player_to_doc(p: PlayerRow) -> dict[str, Any]:
         "position": p.position,
         "first_name": p.first_name,
         "last_name": p.last_name,
+        "is_on_field": p.is_on_field,
     }
 
 
@@ -152,6 +153,7 @@ def _player_from_doc(d: dict[str, Any]) -> PlayerRow:
         position=d.get("position"),
         first_name=d.get("first_name"),
         last_name=d.get("last_name"),
+        is_on_field=d.get("is_on_field"),
     )
 
 

--- a/src/fantasy_coach/storage/schema.sql
+++ b/src/fantasy_coach/storage/schema.sql
@@ -1,9 +1,10 @@
--- Schema version 2.
+-- Schema version 3.
 --
 -- One row per match in `matches`, children (`match_players`, `match_team_stats`)
 -- keyed by match_id + side ('home' | 'away'). Upserts are done by deleting the
 -- existing match rows and re-inserting, so children stay consistent.
 -- v2 adds referee_id and video_referee_id columns to matches (NRL officials block).
+-- v3 adds is_on_field to match_players + a team_list_snapshots table (#24).
 
 CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER PRIMARY KEY
@@ -41,8 +42,25 @@ CREATE TABLE IF NOT EXISTS match_players (
     position       TEXT,
     first_name     TEXT,
     last_name      TEXT,
+    is_on_field    INTEGER,   -- 1/0/NULL; starting XIII flag from NRL's isOnField
     PRIMARY KEY (match_id, side, player_id)
 );
+
+CREATE TABLE IF NOT EXISTS team_list_snapshots (
+    snapshot_id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    season        INTEGER NOT NULL,
+    round         INTEGER NOT NULL,
+    match_id      INTEGER NOT NULL,
+    team_id       INTEGER NOT NULL,
+    scraped_at    TEXT    NOT NULL,   -- ISO 8601 UTC
+    players_json  TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_list_match_time
+    ON team_list_snapshots (match_id, team_id, scraped_at);
+
+CREATE INDEX IF NOT EXISTS idx_team_list_season_time
+    ON team_list_snapshots (season, scraped_at);
 
 CREATE TABLE IF NOT EXISTS match_team_stats (
     match_id    INTEGER NOT NULL REFERENCES matches(match_id) ON DELETE CASCADE,

--- a/src/fantasy_coach/storage/sqlite.py
+++ b/src/fantasy_coach/storage/sqlite.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from fantasy_coach.features import MatchRow, PlayerRow, TeamRow, TeamStat
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 
 class SQLiteRepository:
@@ -130,6 +130,14 @@ class SQLiteRepository:
                     with contextlib.suppress(Exception):
                         self._conn.execute(f"ALTER TABLE matches ADD COLUMN {col}")
                 self._conn.execute("UPDATE schema_version SET version = 2")
+        if from_version < 3:
+            with self._conn:
+                # v2 → v3: add is_on_field to match_players. The
+                # team_list_snapshots table is created by executescript(schema)
+                # above via CREATE TABLE IF NOT EXISTS, so no work needed here.
+                with contextlib.suppress(Exception):
+                    self._conn.execute("ALTER TABLE match_players ADD COLUMN is_on_field INTEGER")
+                self._conn.execute("UPDATE schema_version SET version = 3")
 
     def _insert_players(self, match_id: int, side: str, players: list[PlayerRow]) -> None:
         if not players:
@@ -138,8 +146,8 @@ class SQLiteRepository:
             """
             INSERT INTO match_players
                 (match_id, side, player_id, jersey_number, position,
-                 first_name, last_name)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+                 first_name, last_name, is_on_field)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
                 (
@@ -150,6 +158,7 @@ class SQLiteRepository:
                     p.position,
                     p.first_name,
                     p.last_name,
+                    None if p.is_on_field is None else int(p.is_on_field),
                 )
                 for p in players
             ],
@@ -182,7 +191,7 @@ class SQLiteRepository:
         match_id = match["match_id"]
         players = self._conn.execute(
             """
-            SELECT side, player_id, jersey_number, position, first_name, last_name
+            SELECT side, player_id, jersey_number, position, first_name, last_name, is_on_field
             FROM match_players
             WHERE match_id = ?
             ORDER BY side, jersey_number, player_id
@@ -241,10 +250,12 @@ class SQLiteRepository:
 
     @staticmethod
     def _row_to_player(p: sqlite3.Row) -> PlayerRow:
+        raw_on_field = p["is_on_field"]
         return PlayerRow(
             player_id=p["player_id"],
             jersey_number=p["jersey_number"],
             position=p["position"],
             first_name=p["first_name"],
             last_name=p["last_name"],
+            is_on_field=None if raw_on_field is None else bool(raw_on_field),
         )

--- a/src/fantasy_coach/storage/team_list.py
+++ b/src/fantasy_coach/storage/team_list.py
@@ -1,0 +1,208 @@
+"""Storage for team-list snapshots.
+
+Parallel to ``Repository`` but narrower — the snapshot collection is
+append-only and queried by ``(match_id, team_id)`` for change detection
+or by ``season`` for training-time analytics. Firestore is the
+production backend; SQLite exists for local dev + test parity.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from typing import Any, Protocol
+
+from fantasy_coach.features import PlayerRow
+from fantasy_coach.team_lists import TeamListSnapshot
+
+_COLLECTION = "team_list_snapshots"
+
+
+class TeamListRepository(Protocol):
+    def record_snapshot(self, snapshot: TeamListSnapshot) -> None: ...
+
+    def list_snapshots(
+        self, match_id: int, team_id: int | None = None
+    ) -> list[TeamListSnapshot]: ...
+
+
+# ---------------------------------------------------------------------------
+# SQLite
+# ---------------------------------------------------------------------------
+
+
+class SQLiteTeamListRepository:
+    """SQLite-backed team-list snapshot store.
+
+    Takes a live ``sqlite3.Connection`` rather than a path so callers can
+    share one file with ``SQLiteRepository`` — the snapshot table lives
+    alongside ``matches`` and is created by the same ``schema.sql``.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        self._conn.row_factory = sqlite3.Row
+
+    def record_snapshot(self, snapshot: TeamListSnapshot) -> None:
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO team_list_snapshots
+                    (season, round, match_id, team_id, scraped_at, players_json)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    snapshot.season,
+                    snapshot.round,
+                    snapshot.match_id,
+                    snapshot.team_id,
+                    snapshot.scraped_at.isoformat(),
+                    json.dumps([_player_to_dict(p) for p in snapshot.players]),
+                ),
+            )
+
+    def list_snapshots(self, match_id: int, team_id: int | None = None) -> list[TeamListSnapshot]:
+        if team_id is None:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM team_list_snapshots
+                WHERE match_id = ?
+                ORDER BY scraped_at ASC, snapshot_id ASC
+                """,
+                (match_id,),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM team_list_snapshots
+                WHERE match_id = ? AND team_id = ?
+                ORDER BY scraped_at ASC, snapshot_id ASC
+                """,
+                (match_id, team_id),
+            ).fetchall()
+        return [_row_to_snapshot(r) for r in rows]
+
+
+def _row_to_snapshot(r: sqlite3.Row) -> TeamListSnapshot:
+    return TeamListSnapshot(
+        season=r["season"],
+        round=r["round"],
+        match_id=r["match_id"],
+        team_id=r["team_id"],
+        scraped_at=datetime.fromisoformat(r["scraped_at"]),
+        players=tuple(_dict_to_player(p) for p in json.loads(r["players_json"])),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Firestore
+# ---------------------------------------------------------------------------
+
+
+class FirestoreTeamListRepository:
+    """Firestore-backed team-list snapshot store.
+
+    Collection ``team_list_snapshots`` with auto-generated doc IDs. Each
+    doc carries ``(season, round, match_id, team_id, scraped_at,
+    players)`` so listing by ``(match_id, team_id)`` or by ``season`` is
+    cheap (both queries are backed by composite indexes declared in
+    ``lopeztech/platform-infra``).
+    """
+
+    def __init__(
+        self,
+        client: Any = None,
+        project: str | None = None,
+        database: str = "(default)",
+    ) -> None:
+        if client is not None:
+            self._db = client
+        else:
+            from google.cloud import firestore  # noqa: PLC0415
+
+            self._db = firestore.Client(project=project, database=database)
+
+    def record_snapshot(self, snapshot: TeamListSnapshot) -> None:
+        self._col.add(
+            {
+                "season": snapshot.season,
+                "round": snapshot.round,
+                "match_id": snapshot.match_id,
+                "team_id": snapshot.team_id,
+                "scraped_at": snapshot.scraped_at.isoformat(),
+                "players": [_player_to_dict(p) for p in snapshot.players],
+            }
+        )
+
+    def list_snapshots(self, match_id: int, team_id: int | None = None) -> list[TeamListSnapshot]:
+        query = self._col.where("match_id", "==", match_id)
+        if team_id is not None:
+            query = query.where("team_id", "==", team_id)
+        docs = query.order_by("scraped_at").stream()
+        return [_firestore_doc_to_snapshot(d.to_dict()) for d in docs]
+
+    @property
+    def _col(self) -> Any:
+        return self._db.collection(_COLLECTION)
+
+
+def _firestore_doc_to_snapshot(d: dict[str, Any]) -> TeamListSnapshot:
+    return TeamListSnapshot(
+        season=d["season"],
+        round=d["round"],
+        match_id=d["match_id"],
+        team_id=d["team_id"],
+        scraped_at=datetime.fromisoformat(d["scraped_at"]),
+        players=tuple(_dict_to_player(p) for p in d.get("players", [])),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared serialisation helpers
+# ---------------------------------------------------------------------------
+
+
+def _player_to_dict(p: PlayerRow) -> dict[str, Any]:
+    return {
+        "player_id": p.player_id,
+        "jersey_number": p.jersey_number,
+        "position": p.position,
+        "first_name": p.first_name,
+        "last_name": p.last_name,
+        "is_on_field": p.is_on_field,
+    }
+
+
+def _dict_to_player(d: dict[str, Any]) -> PlayerRow:
+    return PlayerRow(
+        player_id=d["player_id"],
+        jersey_number=d.get("jersey_number"),
+        position=d.get("position"),
+        first_name=d.get("first_name"),
+        last_name=d.get("last_name"),
+        is_on_field=d.get("is_on_field"),
+    )
+
+
+def get_team_list_repository(
+    *, sqlite_conn: sqlite3.Connection | None = None
+) -> TeamListRepository:
+    """Factory mirroring ``config.get_repository``'s STORAGE_BACKEND switch.
+
+    Pass ``sqlite_conn`` when running against SQLite so the snapshot table
+    lives in the same file as the main matches store. In production
+    (``STORAGE_BACKEND=firestore``) the arg is ignored and a fresh
+    Firestore client is created.
+    """
+    import os  # noqa: PLC0415
+
+    backend = os.getenv("STORAGE_BACKEND", "sqlite").lower()
+    if backend == "firestore":
+        return FirestoreTeamListRepository()
+    if sqlite_conn is None:
+        raise RuntimeError(
+            "SQLite team-list repository requires a shared sqlite3.Connection — "
+            "pass `sqlite_conn=...` or set STORAGE_BACKEND=firestore"
+        )
+    return SQLiteTeamListRepository(sqlite_conn)

--- a/src/fantasy_coach/team_lists.py
+++ b/src/fantasy_coach/team_lists.py
@@ -1,0 +1,83 @@
+"""Team-list snapshots: capture how starting XIIIs change between scrapes.
+
+The NRL match endpoint's ``players`` array is a structured view of each
+team's team list — jersey, position, and an ``isOnField`` flag for every
+player named, which distinguishes the starting XIII from the bench.
+
+The precompute Job scrapes this twice a week (Tue 09:00 AEST after team
+lists drop, Thu 06:00 AEST after late changes). Persisting each scrape as
+a snapshot lets the model upgrade in #27 see which players moved between
+the two — e.g. a halfback in Tuesday's starting XIII who ends up on the
+bench by Thursday kickoff. No LLM / announcement parsing required: the
+structured data is already in the scrape payload.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from fantasy_coach.features import PlayerRow
+
+
+@dataclass(frozen=True)
+class TeamListSnapshot:
+    """One team's team list as observed at a specific scrape time."""
+
+    season: int
+    round: int
+    match_id: int
+    team_id: int
+    scraped_at: datetime  # UTC; naive datetimes are rejected at construction
+    players: tuple[PlayerRow, ...]
+
+    def __post_init__(self) -> None:
+        if self.scraped_at.tzinfo is None:
+            raise ValueError("scraped_at must be timezone-aware (UTC)")
+
+
+@dataclass(frozen=True)
+class TeamListChange:
+    """Starting-XIII adds/drops between two snapshots of the same team list.
+
+    ``dropped`` and ``added`` are the raw ``PlayerRow`` objects from the
+    source snapshot (so callers see jersey/position/name without another
+    lookup). A "drop" here means the player was starting in ``earlier`` but
+    is not starting in ``later``: could have moved to bench, been withdrawn,
+    or replaced. The reverse for "add".
+    """
+
+    dropped: tuple[PlayerRow, ...]
+    added: tuple[PlayerRow, ...]
+
+    @property
+    def has_changes(self) -> bool:
+        return bool(self.dropped or self.added)
+
+
+def compute_team_list_changes(
+    earlier: TeamListSnapshot,
+    later: TeamListSnapshot,
+) -> TeamListChange:
+    """Diff starting-XIII membership between two snapshots of the same team.
+
+    Raises ``ValueError`` when the snapshots are for different ``(match_id,
+    team_id)`` pairs (diffing across teams is almost always a bug). Players
+    whose ``is_on_field`` is ``None`` are ignored — completed matches and
+    pre-team-list-drop scrapes don't carry the flag, so a sensible "starter"
+    set isn't derivable.
+    """
+    if earlier.match_id != later.match_id or earlier.team_id != later.team_id:
+        raise ValueError(
+            f"Snapshots must share (match_id, team_id); got "
+            f"({earlier.match_id}, {earlier.team_id}) vs ({later.match_id}, {later.team_id})"
+        )
+
+    earlier_starters = {p.player_id for p in earlier.players if p.is_on_field}
+    later_starters = {p.player_id for p in later.players if p.is_on_field}
+    dropped_ids = earlier_starters - later_starters
+    added_ids = later_starters - earlier_starters
+    return TeamListChange(
+        dropped=tuple(p for p in earlier.players if p.player_id in dropped_ids),
+        added=tuple(p for p in later.players if p.player_id in added_ids),
+    )

--- a/tests/fixtures/extracted/extracted-2024-finals-week-1-game-1.json
+++ b/tests/fixtures/extracted/extracted-2024-finals-week-1-game-1.json
@@ -18,126 +18,144 @@
         "jersey_number": 1,
         "position": "Fullback",
         "first_name": "Dylan",
-        "last_name": "Edwards"
+        "last_name": "Edwards",
+        "is_on_field": true
       },
       {
         "player_id": 509455,
         "jersey_number": 2,
         "position": "Winger",
         "first_name": "Sunia",
-        "last_name": "Turuva"
+        "last_name": "Turuva",
+        "is_on_field": true
       },
       {
         "player_id": 509467,
         "jersey_number": 3,
         "position": "Centre",
         "first_name": "Izack",
-        "last_name": "Tago"
+        "last_name": "Tago",
+        "is_on_field": true
       },
       {
         "player_id": 100004042,
         "jersey_number": 4,
         "position": "Centre",
         "first_name": "Paul",
-        "last_name": "Alamoti"
+        "last_name": "Alamoti",
+        "is_on_field": true
       },
       {
         "player_id": 505410,
         "jersey_number": 5,
         "position": "Winger",
         "first_name": "Brian",
-        "last_name": "To'o"
+        "last_name": "To'o",
+        "is_on_field": true
       },
       {
         "player_id": 504121,
         "jersey_number": 6,
         "position": "Five-Eighth",
         "first_name": "Jarome",
-        "last_name": "Luai"
+        "last_name": "Luai",
+        "is_on_field": true
       },
       {
         "player_id": 504120,
         "jersey_number": 7,
         "position": "Halfback",
         "first_name": "Nathan",
-        "last_name": "Cleary"
+        "last_name": "Cleary",
+        "is_on_field": false
       },
       {
         "player_id": 501461,
         "jersey_number": 8,
         "position": "Prop",
         "first_name": "Moses",
-        "last_name": "Leota"
+        "last_name": "Leota",
+        "is_on_field": false
       },
       {
         "player_id": 505414,
         "jersey_number": 9,
         "position": "Hooker",
         "first_name": "Mitch",
-        "last_name": "Kenny"
+        "last_name": "Kenny",
+        "is_on_field": true
       },
       {
         "player_id": 502580,
         "jersey_number": 10,
         "position": "Prop",
         "first_name": "James",
-        "last_name": "Fisher-Harris"
+        "last_name": "Fisher-Harris",
+        "is_on_field": true
       },
       {
         "player_id": 504125,
         "jersey_number": 12,
         "position": "2nd Row",
         "first_name": "Liam",
-        "last_name": "Martin"
+        "last_name": "Martin",
+        "is_on_field": true
       },
       {
         "player_id": 500534,
         "jersey_number": 13,
         "position": "Lock",
         "first_name": "Isaah",
-        "last_name": "Yeo"
+        "last_name": "Yeo",
+        "is_on_field": true
       },
       {
         "player_id": 505555,
         "jersey_number": 15,
         "position": "Interchange",
         "first_name": "Lindsay",
-        "last_name": "Smith"
+        "last_name": "Smith",
+        "is_on_field": true
       },
       {
         "player_id": 100007929,
         "jersey_number": 16,
         "position": "Interchange",
         "first_name": "Liam",
-        "last_name": "Henry"
+        "last_name": "Henry",
+        "is_on_field": false
       },
       {
         "player_id": 501271,
         "jersey_number": 17,
         "position": "2nd Row",
         "first_name": "Luke",
-        "last_name": "Garner"
+        "last_name": "Garner",
+        "is_on_field": true
       },
       {
         "player_id": 503322,
         "jersey_number": 18,
         "position": "Interchange",
         "first_name": "Matthew",
-        "last_name": "Eisenhuth"
+        "last_name": "Eisenhuth",
+        "is_on_field": false
       },
       {
         "player_id": 100002660,
         "jersey_number": 19,
         "position": "Interchange",
         "first_name": "Bradley",
-        "last_name": "Schneider"
+        "last_name": "Schneider",
+        "is_on_field": true
       },
       {
         "player_id": 100011678,
         "jersey_number": 20,
         "position": "Replacement",
         "first_name": "Casey",
-        "last_name": "McLean"
+        "last_name": "McLean",
+        "is_on_field": false
       }
     ]
   },
@@ -152,126 +170,144 @@
         "jersey_number": 1,
         "position": "Fullback",
         "first_name": "James",
-        "last_name": "Tedesco"
+        "last_name": "Tedesco",
+        "is_on_field": true
       },
       {
         "player_id": 500002,
         "jersey_number": 2,
         "position": "Winger",
         "first_name": "Daniel",
-        "last_name": "Tupou"
+        "last_name": "Tupou",
+        "is_on_field": true
       },
       {
         "player_id": 509438,
         "jersey_number": 3,
         "position": "Centre",
         "first_name": "Joseph-Aukuso",
-        "last_name": "Sua'ali'i"
+        "last_name": "Sua'ali'i",
+        "is_on_field": true
       },
       {
         "player_id": 502571,
         "jersey_number": 4,
         "position": "Centre",
         "first_name": "Joseph",
-        "last_name": "Manu"
+        "last_name": "Manu",
+        "is_on_field": true
       },
       {
         "player_id": 100008071,
         "jersey_number": 5,
         "position": "Winger",
         "first_name": "Dominic",
-        "last_name": "Young"
+        "last_name": "Young",
+        "is_on_field": true
       },
       {
         "player_id": 500093,
         "jersey_number": 6,
         "position": "Five-Eighth",
         "first_name": "Luke",
-        "last_name": "Keary"
+        "last_name": "Keary",
+        "is_on_field": true
       },
       {
         "player_id": 509579,
         "jersey_number": 7,
         "position": "Halfback",
         "first_name": "Sandon",
-        "last_name": "Smith"
+        "last_name": "Smith",
+        "is_on_field": true
       },
       {
         "player_id": 505560,
         "jersey_number": 8,
         "position": "Interchange",
         "first_name": "Spencer",
-        "last_name": "Leniu"
+        "last_name": "Leniu",
+        "is_on_field": true
       },
       {
         "player_id": 503327,
         "jersey_number": 9,
         "position": "Hooker",
         "first_name": "Connor",
-        "last_name": "Watson"
+        "last_name": "Watson",
+        "is_on_field": true
       },
       {
         "player_id": 501781,
         "jersey_number": 10,
         "position": "Prop",
         "first_name": "Lindsay",
-        "last_name": "Collins"
+        "last_name": "Collins",
+        "is_on_field": false
       },
       {
         "player_id": 503240,
         "jersey_number": 11,
         "position": "2nd Row",
         "first_name": "Angus",
-        "last_name": "Crichton"
+        "last_name": "Crichton",
+        "is_on_field": true
       },
       {
         "player_id": 505361,
         "jersey_number": 12,
         "position": "2nd Row",
         "first_name": "Sitili",
-        "last_name": "Tupouniua"
+        "last_name": "Tupouniua",
+        "is_on_field": true
       },
       {
         "player_id": 503639,
         "jersey_number": 13,
         "position": "Prop",
         "first_name": "Nat",
-        "last_name": "Butcher"
+        "last_name": "Butcher",
+        "is_on_field": false
       },
       {
         "player_id": 500889,
         "jersey_number": 14,
         "position": "Interchange",
         "first_name": "Zach",
-        "last_name": "Dockar-Clay"
+        "last_name": "Dockar-Clay",
+        "is_on_field": false
       },
       {
         "player_id": 100006390,
         "jersey_number": 15,
         "position": "Interchange",
         "first_name": "Naufahu",
-        "last_name": "Whyte"
+        "last_name": "Whyte",
+        "is_on_field": true
       },
       {
         "player_id": 100004373,
         "jersey_number": 16,
         "position": "Interchange",
         "first_name": "Siua",
-        "last_name": "Wong"
+        "last_name": "Wong",
+        "is_on_field": false
       },
       {
         "player_id": 508065,
         "jersey_number": 17,
         "position": "Lock",
         "first_name": "Terrell",
-        "last_name": "May"
+        "last_name": "May",
+        "is_on_field": true
       },
       {
         "player_id": 500003,
         "jersey_number": 18,
         "position": "Replacement",
         "first_name": "Michael",
-        "last_name": "Jennings"
+        "last_name": "Jennings",
+        "is_on_field": false
       }
     ]
   },

--- a/tests/fixtures/extracted/extracted-2024-rd1-sea-eagles-v-rabbitohs.json
+++ b/tests/fixtures/extracted/extracted-2024-rd1-sea-eagles-v-rabbitohs.json
@@ -18,126 +18,144 @@
         "jersey_number": 1,
         "position": "Fullback",
         "first_name": "Tom",
-        "last_name": "Trbojevic"
+        "last_name": "Trbojevic",
+        "is_on_field": true
       },
       {
         "player_id": 507670,
         "jersey_number": 2,
         "position": "Winger",
         "first_name": "Jason",
-        "last_name": "Saab"
+        "last_name": "Saab",
+        "is_on_field": false
       },
       {
         "player_id": 509634,
         "jersey_number": 3,
         "position": "Centre",
         "first_name": "Tolutau",
-        "last_name": "Koula"
+        "last_name": "Koula",
+        "is_on_field": true
       },
       {
         "player_id": 503443,
         "jersey_number": 4,
         "position": "Centre",
         "first_name": "Reuben",
-        "last_name": "Garrick"
+        "last_name": "Garrick",
+        "is_on_field": true
       },
       {
         "player_id": 506255,
         "jersey_number": 5,
         "position": "Winger",
         "first_name": "Jaxson",
-        "last_name": "Paulo"
+        "last_name": "Paulo",
+        "is_on_field": true
       },
       {
         "player_id": 500646,
         "jersey_number": 6,
         "position": "Five-Eighth",
         "first_name": "Luke",
-        "last_name": "Brooks"
+        "last_name": "Brooks",
+        "is_on_field": true
       },
       {
         "player_id": 500024,
         "jersey_number": 7,
         "position": "Halfback",
         "first_name": "Daly",
-        "last_name": "Cherry-Evans"
+        "last_name": "Cherry-Evans",
+        "is_on_field": true
       },
       {
         "player_id": 504251,
         "jersey_number": 8,
         "position": "Prop",
         "first_name": "Taniela",
-        "last_name": "Paseka"
+        "last_name": "Paseka",
+        "is_on_field": false
       },
       {
         "player_id": 502063,
         "jersey_number": 9,
         "position": "Hooker",
         "first_name": "Lachlan",
-        "last_name": "Croker"
+        "last_name": "Croker",
+        "is_on_field": true
       },
       {
         "player_id": 500882,
         "jersey_number": 10,
         "position": "Prop",
         "first_name": "Josh",
-        "last_name": "Aloiai"
+        "last_name": "Aloiai",
+        "is_on_field": true
       },
       {
         "player_id": 508033,
         "jersey_number": 11,
         "position": "2nd Row",
         "first_name": "Haumole",
-        "last_name": "Olakau'atu"
+        "last_name": "Olakau'atu",
+        "is_on_field": true
       },
       {
         "player_id": 507850,
         "jersey_number": 12,
         "position": "2nd Row",
         "first_name": "Ben",
-        "last_name": "Trbojevic"
+        "last_name": "Trbojevic",
+        "is_on_field": false
       },
       {
         "player_id": 500751,
         "jersey_number": 13,
         "position": "Lock",
         "first_name": "Jake",
-        "last_name": "Trbojevic"
+        "last_name": "Trbojevic",
+        "is_on_field": true
       },
       {
         "player_id": 502409,
         "jersey_number": 14,
         "position": "Interchange",
         "first_name": "Karl",
-        "last_name": "Lawton"
+        "last_name": "Lawton",
+        "is_on_field": false
       },
       {
         "player_id": 503341,
         "jersey_number": 15,
         "position": "Interchange",
         "first_name": "Corey",
-        "last_name": "Waddell"
+        "last_name": "Waddell",
+        "is_on_field": true
       },
       {
         "player_id": 506153,
         "jersey_number": 16,
         "position": "Interchange",
         "first_name": "Ethan",
-        "last_name": "Bullemor"
+        "last_name": "Bullemor",
+        "is_on_field": false
       },
       {
         "player_id": 500647,
         "jersey_number": 17,
         "position": "Interchange",
         "first_name": "Nathan",
-        "last_name": "Brown"
+        "last_name": "Brown",
+        "is_on_field": true
       },
       {
         "player_id": 509765,
         "jersey_number": 18,
         "position": "Replacement",
         "first_name": "Jake",
-        "last_name": "Arthur"
+        "last_name": "Arthur",
+        "is_on_field": false
       }
     ]
   },
@@ -152,126 +170,144 @@
         "jersey_number": 1,
         "position": "Fullback",
         "first_name": "Latrell",
-        "last_name": "Mitchell"
+        "last_name": "Mitchell",
+        "is_on_field": true
       },
       {
         "player_id": 500108,
         "jersey_number": 2,
         "position": "Winger",
         "first_name": "Alex",
-        "last_name": "Johnston"
+        "last_name": "Johnston",
+        "is_on_field": true
       },
       {
         "player_id": 506548,
         "jersey_number": 3,
         "position": "Centre",
         "first_name": "Isaiah",
-        "last_name": "Tass"
+        "last_name": "Tass",
+        "is_on_field": true
       },
       {
         "player_id": 500599,
         "jersey_number": 4,
         "position": "Centre",
         "first_name": "Richard",
-        "last_name": "Kennar"
+        "last_name": "Kennar",
+        "is_on_field": true
       },
       {
         "player_id": 501245,
         "jersey_number": 5,
         "position": "Winger",
         "first_name": "Jacob",
-        "last_name": "Gagai"
+        "last_name": "Gagai",
+        "is_on_field": true
       },
       {
         "player_id": 500611,
         "jersey_number": 6,
         "position": "Five-Eighth",
         "first_name": "Cody",
-        "last_name": "Walker"
+        "last_name": "Walker",
+        "is_on_field": true
       },
       {
         "player_id": 505564,
         "jersey_number": 7,
         "position": "Halfback",
         "first_name": "Lachlan",
-        "last_name": "Ilias"
+        "last_name": "Ilias",
+        "is_on_field": true
       },
       {
         "player_id": 503450,
         "jersey_number": 8,
         "position": "Prop",
         "first_name": "Tevita",
-        "last_name": "Tatola"
+        "last_name": "Tatola",
+        "is_on_field": true
       },
       {
         "player_id": 501600,
         "jersey_number": 9,
         "position": "Hooker",
         "first_name": "Damien",
-        "last_name": "Cook"
+        "last_name": "Cook",
+        "is_on_field": true
       },
       {
         "player_id": 504265,
         "jersey_number": 10,
         "position": "Prop",
         "first_name": "Sean",
-        "last_name": "Keppie"
+        "last_name": "Keppie",
+        "is_on_field": true
       },
       {
         "player_id": 504174,
         "jersey_number": 11,
         "position": "2nd Row",
         "first_name": "Keaon",
-        "last_name": "Koloamatangi"
+        "last_name": "Koloamatangi",
+        "is_on_field": true
       },
       {
         "player_id": 500149,
         "jersey_number": 12,
         "position": "2nd Row",
         "first_name": "Jai",
-        "last_name": "Arrow"
+        "last_name": "Arrow",
+        "is_on_field": true
       },
       {
         "player_id": 504176,
         "jersey_number": 13,
         "position": "Lock",
         "first_name": "Cameron",
-        "last_name": "Murray"
+        "last_name": "Murray",
+        "is_on_field": true
       },
       {
         "player_id": 501394,
         "jersey_number": 14,
         "position": "Interchange",
         "first_name": "Siliva",
-        "last_name": "Havili"
+        "last_name": "Havili",
+        "is_on_field": false
       },
       {
         "player_id": 500453,
         "jersey_number": 15,
         "position": "Interchange",
         "first_name": "Jacob",
-        "last_name": "Host"
+        "last_name": "Host",
+        "is_on_field": false
       },
       {
         "player_id": 509444,
         "jersey_number": 16,
         "position": "Interchange",
         "first_name": "Davvy",
-        "last_name": "Moale"
+        "last_name": "Moale",
+        "is_on_field": false
       },
       {
         "player_id": 500087,
         "jersey_number": 17,
         "position": "Interchange",
         "first_name": "Thomas",
-        "last_name": "Burgess"
+        "last_name": "Burgess",
+        "is_on_field": false
       },
       {
         "player_id": 504669,
         "jersey_number": 24,
         "position": "Replacement",
         "first_name": "Dean",
-        "last_name": "Hawkins"
+        "last_name": "Hawkins",
+        "is_on_field": false
       }
     ]
   },

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -29,6 +29,7 @@ from fantasy_coach.predictions import (
     _compute_contributions,
     _ensure_model,
     _feature_hash,
+    _record_team_list_snapshots,
     compute_predictions,
     get_prediction_store,
 )
@@ -432,6 +433,88 @@ def test_store_roundtrips_missing_contributions_as_none(store: PredictionStore) 
     store.put(2026, 8, [pred])
     loaded = store.get(2026, 8)
     assert loaded[0].contributions is None
+
+
+# ---------------------------------------------------------------------------
+# _record_team_list_snapshots — wiring guard
+# ---------------------------------------------------------------------------
+
+
+def _make_match_row_with_team_lists(has_is_on_field: bool = True):
+    from datetime import UTC, datetime
+
+    from fantasy_coach.features import MatchRow, PlayerRow, TeamRow
+
+    def _p(pid: int, jersey: int, on_field: bool | None) -> PlayerRow:
+        return PlayerRow(
+            player_id=pid,
+            jersey_number=jersey,
+            position="Fullback",
+            first_name="F",
+            last_name="L",
+            is_on_field=on_field if has_is_on_field else None,
+        )
+
+    return MatchRow(
+        match_id=12345,
+        season=2026,
+        round=8,
+        start_time=datetime(2026, 4, 24, 9, 0, tzinfo=UTC),
+        match_state="Upcoming",
+        venue="Eden Park",
+        venue_city="Auckland",
+        weather=None,
+        home=TeamRow(
+            team_id=10,
+            name="Tigers",
+            nick_name="Tigers",
+            score=None,
+            players=[_p(1, 1, True), _p(2, 14, False)],
+        ),
+        away=TeamRow(
+            team_id=20,
+            name="Raiders",
+            nick_name="Raiders",
+            score=None,
+            players=[_p(3, 1, True), _p(4, 14, False)],
+        ),
+        team_stats=[],
+    )
+
+
+def test_record_team_list_snapshots_writes_one_per_team() -> None:
+    row = _make_match_row_with_team_lists(has_is_on_field=True)
+    repo = MagicMock()
+
+    _record_team_list_snapshots(repo, row)
+
+    assert repo.record_snapshot.call_count == 2
+    snapshots = [c.args[0] for c in repo.record_snapshot.call_args_list]
+    assert {s.team_id for s in snapshots} == {10, 20}
+    assert snapshots[0].season == 2026
+    assert snapshots[0].round == 8
+
+
+def test_record_team_list_snapshots_skips_when_no_is_on_field_flag() -> None:
+    # Pre-drop scrape: players present but is_on_field is all None.
+    row = _make_match_row_with_team_lists(has_is_on_field=False)
+    repo = MagicMock()
+
+    _record_team_list_snapshots(repo, row)
+
+    repo.record_snapshot.assert_not_called()
+
+
+def test_record_team_list_snapshots_swallows_repo_errors() -> None:
+    row = _make_match_row_with_team_lists(has_is_on_field=True)
+    repo = MagicMock()
+    repo.record_snapshot.side_effect = RuntimeError("firestore down")
+
+    # Should not raise — snapshot failures are best-effort per the wiring.
+    _record_team_list_snapshots(repo, row)
+
+    # Both teams attempted (home first, then away) even after the first error.
+    assert repo.record_snapshot.call_count == 2
 
 
 def test_compute_returns_empty_when_no_fixtures(

--- a/tests/test_team_lists.py
+++ b/tests/test_team_lists.py
@@ -1,0 +1,267 @@
+"""Tests for the team-list snapshot data model + storage."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from fantasy_coach.features import PlayerRow
+from fantasy_coach.storage.sqlite import SQLiteRepository
+from fantasy_coach.storage.team_list import (
+    FirestoreTeamListRepository,
+    SQLiteTeamListRepository,
+    _dict_to_player,
+    _player_to_dict,
+)
+from fantasy_coach.team_lists import (
+    TeamListSnapshot,
+    compute_team_list_changes,
+)
+
+
+def _player(
+    player_id: int,
+    *,
+    jersey: int,
+    position: str = "Fullback",
+    is_on_field: bool | None = True,
+) -> PlayerRow:
+    return PlayerRow(
+        player_id=player_id,
+        jersey_number=jersey,
+        position=position,
+        first_name=f"First{player_id}",
+        last_name=f"Last{player_id}",
+        is_on_field=is_on_field,
+    )
+
+
+def _snapshot(
+    *,
+    match_id: int = 1000,
+    team_id: int = 10,
+    scraped_at: datetime | None = None,
+    players: tuple[PlayerRow, ...] = (),
+) -> TeamListSnapshot:
+    return TeamListSnapshot(
+        season=2026,
+        round=8,
+        match_id=match_id,
+        team_id=team_id,
+        scraped_at=scraped_at or datetime(2026, 4, 21, 9, 0, tzinfo=UTC),
+        players=players,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dataclass invariants
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_rejects_naive_datetime() -> None:
+    with pytest.raises(ValueError):
+        TeamListSnapshot(
+            season=2026,
+            round=8,
+            match_id=1,
+            team_id=10,
+            scraped_at=datetime(2026, 4, 21, 9, 0),  # no tz
+            players=(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# compute_team_list_changes
+# ---------------------------------------------------------------------------
+
+
+def test_change_detects_none_when_identical() -> None:
+    players = (_player(1, jersey=1), _player(2, jersey=2))
+    earlier = _snapshot(players=players)
+    later = _snapshot(
+        players=players,
+        scraped_at=earlier.scraped_at + timedelta(days=2),
+    )
+    change = compute_team_list_changes(earlier, later)
+    assert change.dropped == ()
+    assert change.added == ()
+    assert change.has_changes is False
+
+
+def test_change_detects_single_swap() -> None:
+    earlier = _snapshot(
+        players=(_player(1, jersey=7, is_on_field=True), _player(2, jersey=14, is_on_field=False)),
+    )
+    later = _snapshot(
+        players=(_player(1, jersey=14, is_on_field=False), _player(2, jersey=7, is_on_field=True)),
+        scraped_at=earlier.scraped_at + timedelta(days=2),
+    )
+    change = compute_team_list_changes(earlier, later)
+    # Player 1 was starting, now on bench → dropped.
+    # Player 2 was on bench, now starting → added.
+    assert [p.player_id for p in change.dropped] == [1]
+    assert [p.player_id for p in change.added] == [2]
+    assert change.has_changes is True
+
+
+def test_change_ignores_players_with_none_is_on_field() -> None:
+    # A pre-team-list-drop scrape won't carry is_on_field at all.
+    earlier = _snapshot(players=(_player(1, jersey=1, is_on_field=None),))
+    later = _snapshot(
+        players=(_player(1, jersey=1, is_on_field=True),),
+        scraped_at=earlier.scraped_at + timedelta(days=2),
+    )
+    # Starting sets: earlier={} (None filtered), later={1}. → player 1 added.
+    change = compute_team_list_changes(earlier, later)
+    assert [p.player_id for p in change.added] == [1]
+    assert change.dropped == ()
+
+
+def test_change_rejects_mismatched_match_team() -> None:
+    a = _snapshot(match_id=1, team_id=10)
+    b = _snapshot(match_id=2, team_id=10)
+    with pytest.raises(ValueError):
+        compute_team_list_changes(a, b)
+
+
+# ---------------------------------------------------------------------------
+# SQLite storage
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sqlite_conn(tmp_path: Path) -> sqlite3.Connection:
+    # Use the main SQLiteRepository to initialise the schema (creates the
+    # team_list_snapshots table via schema.sql + bumps schema_version).
+    repo = SQLiteRepository(tmp_path / "tl.db")
+    return repo._conn  # noqa: SLF001 — repository owns the connection
+
+
+def test_sqlite_record_and_list(sqlite_conn: sqlite3.Connection) -> None:
+    repo = SQLiteTeamListRepository(sqlite_conn)
+    first = _snapshot(
+        scraped_at=datetime(2026, 4, 21, 9, 0, tzinfo=UTC),
+        players=(_player(1, jersey=1), _player(2, jersey=14, is_on_field=False)),
+    )
+    second = _snapshot(
+        scraped_at=datetime(2026, 4, 23, 6, 0, tzinfo=UTC),
+        players=(_player(1, jersey=1), _player(2, jersey=7, is_on_field=True)),
+    )
+    repo.record_snapshot(first)
+    repo.record_snapshot(second)
+
+    snapshots = repo.list_snapshots(match_id=1000)
+    assert len(snapshots) == 2
+    # Ordered by scraped_at ASC.
+    assert snapshots[0].scraped_at < snapshots[1].scraped_at
+    assert snapshots[0].players[1].is_on_field is False
+    assert snapshots[1].players[1].is_on_field is True
+
+
+def test_sqlite_list_filters_by_team(sqlite_conn: sqlite3.Connection) -> None:
+    repo = SQLiteTeamListRepository(sqlite_conn)
+    home = _snapshot(team_id=10, players=(_player(1, jersey=1),))
+    away = _snapshot(team_id=20, players=(_player(2, jersey=1),))
+    repo.record_snapshot(home)
+    repo.record_snapshot(away)
+
+    home_only = repo.list_snapshots(match_id=1000, team_id=10)
+    assert len(home_only) == 1
+    assert home_only[0].team_id == 10
+
+
+# ---------------------------------------------------------------------------
+# Firestore storage (with a fake client)
+# ---------------------------------------------------------------------------
+
+
+class _FakeFirestoreCollection:
+    def __init__(self) -> None:
+        self._docs: list[dict] = []
+        self._filters: list[tuple[str, str, object]] = []
+        self._order_by: str | None = None
+
+    def add(self, data: dict) -> None:
+        self._docs.append(data)
+
+    def where(self, field: str, op: str, value: object) -> _FakeFirestoreCollection:
+        # Return a child query with this filter added; share the docs list.
+        child = _FakeFirestoreCollection()
+        child._docs = self._docs
+        child._filters = [*self._filters, (field, op, value)]
+        child._order_by = self._order_by
+        return child
+
+    def order_by(self, field: str) -> _FakeFirestoreCollection:
+        child = _FakeFirestoreCollection()
+        child._docs = self._docs
+        child._filters = self._filters
+        child._order_by = field
+        return child
+
+    def stream(self):
+        filtered = [
+            d for d in self._docs if all(_apply_op(d.get(f), op, v) for f, op, v in self._filters)
+        ]
+        if self._order_by is not None:
+            filtered.sort(key=lambda d: d.get(self._order_by))  # type: ignore[arg-type]
+
+        class _Doc:
+            def __init__(self, d: dict) -> None:
+                self._d = d
+
+            def to_dict(self) -> dict:
+                return self._d
+
+        return [_Doc(d) for d in filtered]
+
+
+def _apply_op(left: object, op: str, right: object) -> bool:
+    if op == "==":
+        return left == right
+    raise NotImplementedError(op)
+
+
+class _FakeFirestoreClient:
+    def __init__(self) -> None:
+        self._collection = _FakeFirestoreCollection()
+
+    def collection(self, name: str) -> _FakeFirestoreCollection:
+        assert name == "team_list_snapshots"
+        return self._collection
+
+
+def test_firestore_record_and_list() -> None:
+    repo = FirestoreTeamListRepository(client=_FakeFirestoreClient())
+    a = _snapshot(
+        scraped_at=datetime(2026, 4, 21, 9, 0, tzinfo=UTC),
+        players=(_player(1, jersey=1),),
+    )
+    b = _snapshot(
+        scraped_at=datetime(2026, 4, 23, 6, 0, tzinfo=UTC),
+        players=(_player(1, jersey=1, is_on_field=False),),
+    )
+    repo.record_snapshot(a)
+    repo.record_snapshot(b)
+
+    loaded = repo.list_snapshots(match_id=1000)
+    assert [s.scraped_at for s in loaded] == [a.scraped_at, b.scraped_at]
+    assert loaded[1].players[0].is_on_field is False
+
+
+# ---------------------------------------------------------------------------
+# Shared serialisation helpers
+# ---------------------------------------------------------------------------
+
+
+def test_player_roundtrip_preserves_is_on_field() -> None:
+    original = _player(1, jersey=1, is_on_field=False)
+    assert _dict_to_player(_player_to_dict(original)) == original
+
+
+def test_player_roundtrip_handles_none() -> None:
+    original = _player(1, jersey=1, is_on_field=None)
+    assert _dict_to_player(_player_to_dict(original)) == original


### PR DESCRIPTION
## Summary
Captures one team-list snapshot per team per precompute-Job scrape so downstream model features (#27) can diff named-squad-at-team-list-drop vs starting-XIII-at-kickoff. No LLM / announcement parsing — the NRL match endpoint already returns the structured data we need (`players[]` with `isOnField`).

**Data model** — `fantasy_coach.team_lists`:
- `TeamListSnapshot(season, round, match_id, team_id, scraped_at, players)`; tz-aware `scraped_at` enforced.
- `compute_team_list_changes(earlier, later) -> TeamListChange(dropped, added)` diffing starting-XIII membership by `player_id`.

**Storage** — `fantasy_coach.storage.team_list`:
- `TeamListRepository` Protocol + SQLite + Firestore implementations.
- SQLite schema bumped to v3: new `team_list_snapshots` table + `is_on_field` column on `match_players`, with migration from v2.
- Firestore collection `team_list_snapshots` (auto-ID docs); composite indexes in the paired lopeztech/platform-infra#49.

**Wiring**: `_run_precompute` in `__main__.py` constructs a `TeamListRepository` alongside the main repo; `compute_predictions` records snapshots for home + away on each scraped match whenever `is_on_field` is populated. Failures are logged and swallowed so one bad match can't take the round offline.

**`PlayerRow`** gains `is_on_field: bool | None = None` (NRL's `isOnField`) — wired through extraction + Firestore + SQLite serialisation + regenerated fixture snapshots.

## Scope pivot
See [issue comment](https://github.com/lopeztech/fantasy-coach/issues/24#issuecomment-4293508298): dropped the Gemini / announcement-parsing acceptance criteria because the structured source makes that orthogonal work. Keeps #24 narrow and zero-dependency (no Vertex AI / #22).

## Out of scope (follow-ups)
- Feature engineering on top of snapshots — #27.

## Test plan
- [x] `uv run pytest tests/test_team_lists.py` — 10 passing (dataclass invariants, diff correctness, SQLite + Firestore round-trips).
- [x] `uv run pytest tests/test_predictions.py` — 30 passing (3 new tests guard the `_record_team_list_snapshots` wiring).
- [x] Full sweep (`pytest -q`) green; ruff + format clean.
- [ ] Post-merge + next Job run: `gcloud firestore documents list --collection-group=team_list_snapshots` (or equivalent probe) shows docs being written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)