### PR TITLE
feat(web): user tip entry & you-vs-model scoreboard (closes #62)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,32 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // User tips: each user owns their own tips subcollection.
+    // - Read: only the owning user.
+    // - Create/Update: only before kickoff (enforced via the kickoff field).
+    // - Delete: never (audit trail).
+    match /users/{uid}/tips/{matchId} {
+      allow read: if request.auth != null && request.auth.uid == uid;
+
+      allow create: if request.auth != null
+                    && request.auth.uid == uid
+                    && request.resource.data.keys().hasAll(["tip", "kickoff", "season", "round"])
+                    && request.resource.data.tip in ["home", "away"]
+                    && request.time < request.resource.data.kickoff;
+
+      allow update: if request.auth != null
+                    && request.auth.uid == uid
+                    && request.resource.data.tip in ["home", "away"]
+                    && request.time < resource.data.kickoff;
+
+      allow delete: if false;
+    }
+
+    // Deny all other reads/writes by default.
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/src/fantasy_coach/app.py
+++ b/src/fantasy_coach/app.py
@@ -5,12 +5,14 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from fantasy_coach import __version__
 from fantasy_coach.auth import FirebaseAuthMiddleware
+from fantasy_coach.config import get_repository
 from fantasy_coach.predictions import (
     FirestorePredictionStore,
     PredictionOut,
     PredictionStore,
     get_prediction_store,
 )
+from fantasy_coach.storage.repository import Repository
 
 ALLOWED_ORIGINS_ENV = "FANTASY_COACH_ALLOWED_ORIGINS"
 DEFAULT_ALLOWED_ORIGINS = (
@@ -49,8 +51,9 @@ app.add_middleware(
     max_age=600,
 )
 
-# Module-level prediction store — created lazily on first use.
+# Module-level prediction store and match repo — both created lazily.
 _store: PredictionStore | FirestorePredictionStore | None = None
+_repo: Repository | None = None
 
 
 def _get_store() -> PredictionStore | FirestorePredictionStore:
@@ -58,6 +61,36 @@ def _get_store() -> PredictionStore | FirestorePredictionStore:
     if _store is None:
         _store = get_prediction_store()
     return _store
+
+
+def _get_repo() -> Repository:
+    global _repo
+    if _repo is None:
+        _repo = get_repository()
+    return _repo
+
+
+def _annotate_results(
+    predictions: list[PredictionOut], season: int, round_: int
+) -> list[PredictionOut]:
+    """Attach actualWinner from the match repo (FullTime matches only)."""
+    try:
+        matches = {m.match_id: m for m in _get_repo().list_matches(season, round_)}
+    except Exception:
+        return predictions  # repo unavailable — return predictions as-is
+    result = []
+    for p in predictions:
+        m = matches.get(p.matchId)
+        if (
+            m
+            and m.match_state == "FullTime"
+            and m.home.score is not None
+            and m.away.score is not None
+        ):
+            winner = "home" if m.home.score > m.away.score else "away"
+            p = p.model_copy(update={"actualWinner": winner})
+        result.append(p)
+    return result
 
 
 @app.get("/healthz")
@@ -91,4 +124,4 @@ def get_predictions(
                 "`gcloud run jobs execute fantasy-coach-precompute`."
             ),
         )
-    return cached
+    return _annotate_results(cached, season, round)

--- a/src/fantasy_coach/predictions.py
+++ b/src/fantasy_coach/predictions.py
@@ -95,6 +95,8 @@ class PredictionOut(BaseModel):
     featureHash: str  # first 12 hex chars of SHA-256 of feature names
     # Optional so predictions written before #58 shipped still deserialise.
     contributions: list[FeatureContribution] | None = None
+    # Populated at serve-time when match_state == "FullTime" (not cached).
+    actualWinner: str | None = None  # "home" | "away"
 
 
 # ---------------------------------------------------------------------------

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,9 @@ export default function App() {
             Fantasy Coach
           </Link>
           <div className="header-controls">
+            <Link to="/scoreboard" className="nav-link">
+              Scoreboard
+            </Link>
             <ThemeToggle />
             <AuthButton />
           </div>

--- a/web/src/components/MatchCard.tsx
+++ b/web/src/components/MatchCard.tsx
@@ -1,5 +1,7 @@
 import { Link } from "react-router-dom";
 
+import { TipEntry } from "./TipEntry";
+import type { TipChoice } from "../tips";
 import type { Prediction } from "../types";
 
 function formatKickoff(iso: string): string {
@@ -19,17 +21,24 @@ export function MatchCard({
   season,
   round,
   preview,
+  tip,
+  savingTip,
+  onTip,
 }: {
   prediction: Prediction;
   season: number;
   round: number;
   preview?: string;
+  tip?: TipChoice | null;
+  savingTip?: boolean;
+  onTip?: (choice: TipChoice) => void;
 }) {
   const p = prediction;
   const homePct = Math.round(p.homeWinProbability * 100);
   const awayPct = 100 - homePct;
   const winnerName = p.predictedWinner === "home" ? p.home.name : p.away.name;
   const winnerPct = p.predictedWinner === "home" ? homePct : awayPct;
+  const isKickedOff = new Date(p.kickoff) <= new Date();
 
   return (
     <Link
@@ -70,6 +79,23 @@ export function MatchCard({
         </p>
 
         {preview ? <p className="preview">{preview}</p> : null}
+
+        {onTip != null && (
+          <div
+            onClick={(e) => e.preventDefault()}
+            onKeyDown={(e) => e.preventDefault()}
+            role="none"
+          >
+            <TipEntry
+              homeTeam={p.home.name}
+              awayTeam={p.away.name}
+              value={tip ?? null}
+              locked={isKickedOff}
+              saving={savingTip ?? false}
+              onTip={onTip}
+            />
+          </div>
+        )}
       </article>
     </Link>
   );

--- a/web/src/components/TipEntry.tsx
+++ b/web/src/components/TipEntry.tsx
@@ -1,0 +1,40 @@
+import type { TipChoice } from "../tips";
+
+type Props = {
+  homeTeam: string;
+  awayTeam: string;
+  value: TipChoice | null;
+  locked: boolean;
+  saving: boolean;
+  onTip: (choice: TipChoice) => void;
+};
+
+export function TipEntry({ homeTeam, awayTeam, value, locked, saving, onTip }: Props) {
+  return (
+    <div className="tip-entry" aria-label="Your tip">
+      <span className="tip-label">Your tip</span>
+      <div className="tip-buttons" role="group" aria-label={`Tip for ${homeTeam} vs ${awayTeam}`}>
+        {(["home", "away"] as const).map((side) => {
+          const name = side === "home" ? homeTeam : awayTeam;
+          const selected = value === side;
+          return (
+            <button
+              key={side}
+              type="button"
+              className={`tip-btn${selected ? " tip-btn--selected" : ""}`}
+              aria-pressed={selected}
+              disabled={locked || saving}
+              onClick={(e) => {
+                e.preventDefault();
+                onTip(side);
+              }}
+            >
+              {name}
+            </button>
+          );
+        })}
+      </div>
+      {locked && <span className="tip-locked">Locked</span>}
+    </div>
+  );
+}

--- a/web/src/firebase.ts
+++ b/web/src/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp, type FirebaseApp } from "firebase/app";
 import { getAuth, type Auth } from "firebase/auth";
+import { getFirestore, type Firestore } from "firebase/firestore";
 
 type FirebaseConfig = {
   apiKey: string;
@@ -23,14 +24,30 @@ function readConfig(): FirebaseConfig | null {
 
 let app: FirebaseApp | null = null;
 let auth: Auth | null = null;
+let firestore: Firestore | null = null;
 
-export function getFirebaseAuth(): Auth | null {
-  if (auth) return auth;
+function _ensureApp(): FirebaseApp | null {
+  if (app) return app;
   const cfg = readConfig();
   if (!cfg) return null;
   app = initializeApp(cfg);
-  auth = getAuth(app);
+  return app;
+}
+
+export function getFirebaseAuth(): Auth | null {
+  if (auth) return auth;
+  const a = _ensureApp();
+  if (!a) return null;
+  auth = getAuth(a);
   return auth;
+}
+
+export function getFirebaseFirestore(): Firestore | null {
+  if (firestore) return firestore;
+  const a = _ensureApp();
+  if (!a) return null;
+  firestore = getFirestore(a);
+  return firestore;
 }
 
 export function isFirebaseConfigured(): boolean {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,6 +6,7 @@ import App from "./App";
 import Home from "./routes/Home";
 import MatchDetail from "./routes/MatchDetail";
 import Round from "./routes/Round";
+import Scoreboard from "./routes/Scoreboard";
 import "./styles.css";
 
 const router = createBrowserRouter([
@@ -16,6 +17,7 @@ const router = createBrowserRouter([
       { index: true, element: <Home /> },
       { path: "round/:season/:round", element: <Round /> },
       { path: "round/:season/:round/:matchId", element: <MatchDetail /> },
+      { path: "scoreboard", element: <Scoreboard /> },
     ],
   },
 ]);

--- a/web/src/routes/Round.tsx
+++ b/web/src/routes/Round.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import { apiFetch, ApiError, NotSignedInError } from "../api";
@@ -6,6 +6,7 @@ import { useAuth } from "../auth";
 import { MatchCard } from "../components/MatchCard";
 import { RoundSelector } from "../components/RoundSelector";
 import { SignInRequired } from "../components/SignInRequired";
+import { getTipsByRound, saveTip, type TipChoice } from "../tips";
 import type { Prediction } from "../types";
 
 type Status =
@@ -17,6 +18,8 @@ export default function Round() {
   const { season: seasonParam, round: roundParam } = useParams();
   const { user, loading: authLoading } = useAuth();
   const [status, setStatus] = useState<Status>({ kind: "loading" });
+  const [tips, setTips] = useState<Map<number, TipChoice>>(new Map());
+  const [savingTip, setSavingTip] = useState<number | null>(null);
 
   const season = Number(seasonParam);
   const round = Number(roundParam);
@@ -32,9 +35,16 @@ export default function Round() {
 
     let cancelled = false;
     setStatus({ kind: "loading" });
-    apiFetch<Prediction[]>(`/predictions?season=${season}&round=${round}`)
-      .then((predictions) => {
-        if (!cancelled) setStatus({ kind: "ok", predictions });
+
+    Promise.all([
+      apiFetch<Prediction[]>(`/predictions?season=${season}&round=${round}`),
+      getTipsByRound(user.uid, season, round).catch(() => new Map<number, TipChoice>()),
+    ])
+      .then(([predictions, loadedTips]) => {
+        if (!cancelled) {
+          setStatus({ kind: "ok", predictions });
+          setTips(loadedTips);
+        }
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -54,6 +64,22 @@ export default function Round() {
       cancelled = true;
     };
   }, [authLoading, user, paramsValid, season, round]);
+
+  const handleTip = useCallback(
+    async (matchId: number, kickoff: string, choice: TipChoice) => {
+      if (!user) return;
+      setSavingTip(matchId);
+      try {
+        await saveTip(user.uid, matchId, choice, kickoff, season, round);
+        setTips((prev) => new Map(prev).set(matchId, choice));
+      } catch {
+        // silently fail — tip just won't persist
+      } finally {
+        setSavingTip(null);
+      }
+    },
+    [user, season, round],
+  );
 
   if (authLoading) return <p>Loading…</p>;
   if (!user) return <SignInRequired message="Sign in to see predictions for this round." />;
@@ -82,7 +108,15 @@ export default function Round() {
       {status.kind === "ok" && status.predictions.length > 0 && (
         <div className="match-grid">
           {status.predictions.map((p) => (
-            <MatchCard key={p.matchId} prediction={p} season={season} round={round} />
+            <MatchCard
+              key={p.matchId}
+              prediction={p}
+              season={season}
+              round={round}
+              tip={tips.get(p.matchId) ?? null}
+              savingTip={savingTip === p.matchId}
+              onTip={(choice) => void handleTip(p.matchId, p.kickoff, choice)}
+            />
           ))}
         </div>
       )}

--- a/web/src/routes/Scoreboard.tsx
+++ b/web/src/routes/Scoreboard.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useState } from "react";
+
+import { apiFetch, ApiError } from "../api";
+import { useAuth } from "../auth";
+import { SignInRequired } from "../components/SignInRequired";
+import { getAllTips, type TipChoice } from "../tips";
+import type { Prediction } from "../types";
+
+type TipRecord = {
+  matchId: number;
+  season: number;
+  round: number;
+  tip: TipChoice;
+};
+
+type MatchResult = {
+  matchId: number;
+  home: string;
+  away: string;
+  kickoff: string;
+  tip: TipChoice;
+  predictedWinner: "home" | "away";
+  homeWinProbability: number;
+  actualWinner: "home" | "away" | null;
+};
+
+type RoundGroup = {
+  season: number;
+  round: number;
+  matches: MatchResult[];
+};
+
+type Status =
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "ok"; rounds: RoundGroup[] };
+
+function logLoss(prob: number, actual: "home" | "away"): number {
+  const p = actual === "home" ? prob : 1 - prob;
+  return -Math.log(Math.max(p, 1e-9));
+}
+
+function formatPct(n: number): string {
+  return `${Math.round(n * 100)}%`;
+}
+
+export default function Scoreboard() {
+  const { user, loading: authLoading } = useAuth();
+  const [status, setStatus] = useState<Status>({ kind: "loading" });
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) return;
+
+    let cancelled = false;
+    setStatus({ kind: "loading" });
+
+    getAllTips(user.uid)
+      .then(async (tipRecords: TipRecord[]) => {
+        if (cancelled) return;
+        if (tipRecords.length === 0) {
+          setStatus({ kind: "ok", rounds: [] });
+          return;
+        }
+
+        // Group by season+round, fetch predictions for each distinct round
+        const roundKeys = [
+          ...new Set(tipRecords.map((t) => `${t.season}:${t.round}`)),
+        ];
+        const predsByRound = new Map<string, Prediction[]>();
+        await Promise.all(
+          roundKeys.map(async (key) => {
+            const [season, round] = key.split(":").map(Number);
+            try {
+              const preds = await apiFetch<Prediction[]>(
+                `/predictions?season=${season}&round=${round}`,
+              );
+              predsByRound.set(key, preds);
+            } catch {
+              predsByRound.set(key, []);
+            }
+          }),
+        );
+
+        if (cancelled) return;
+
+        // Build round groups
+        const grouped = new Map<string, RoundGroup>();
+        for (const tip of tipRecords) {
+          const key = `${tip.season}:${tip.round}`;
+          const preds = predsByRound.get(key) ?? [];
+          const pred = preds.find((p) => p.matchId === tip.matchId);
+          if (!pred) continue;
+          if (!grouped.has(key)) {
+            grouped.set(key, { season: tip.season, round: tip.round, matches: [] });
+          }
+          grouped.get(key)!.matches.push({
+            matchId: tip.matchId,
+            home: pred.home.name,
+            away: pred.away.name,
+            kickoff: pred.kickoff,
+            tip: tip.tip,
+            predictedWinner: pred.predictedWinner,
+            homeWinProbability: pred.homeWinProbability,
+            actualWinner: pred.actualWinner ?? null,
+          });
+        }
+
+        const rounds = [...grouped.values()].sort(
+          (a, b) => b.season - a.season || b.round - a.round,
+        );
+        setStatus({ kind: "ok", rounds });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const msg = err instanceof ApiError ? err.message : "Couldn't load scoreboard.";
+        setStatus({ kind: "error", message: msg });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, user]);
+
+  if (authLoading) return <p>Loading…</p>;
+  if (!user) return <SignInRequired message="Sign in to see your scoreboard." />;
+
+  if (status.kind === "loading") return <p role="status">Loading scoreboard…</p>;
+  if (status.kind === "error") {
+    return (
+      <div className="error-box" role="alert">
+        {status.message}
+      </div>
+    );
+  }
+
+  if (status.rounds.length === 0) {
+    return (
+      <div className="sign-in-required">
+        <p>No tips yet. Head to a round and start tipping!</p>
+      </div>
+    );
+  }
+
+  // Overall stats across all scored matches
+  const allScored = status.rounds
+    .flatMap((r) => r.matches)
+    .filter((m) => m.actualWinner !== null);
+
+  const userCorrect = allScored.filter((m) => m.tip === m.actualWinner).length;
+  const modelCorrect = allScored.filter((m) => m.predictedWinner === m.actualWinner).length;
+  const modelLoss =
+    allScored.length > 0
+      ? allScored.reduce(
+          (sum, m) => sum + logLoss(m.homeWinProbability, m.actualWinner!),
+          0,
+        ) / allScored.length
+      : null;
+
+  return (
+    <section className="scoreboard">
+      <h1>You vs the Model</h1>
+
+      {allScored.length > 0 && (
+        <div className="scoreboard-summary">
+          <div className="scoreboard-stat">
+            <span className="scoreboard-stat-label">Your accuracy</span>
+            <span className="scoreboard-stat-value">
+              {formatPct(userCorrect / allScored.length)}{" "}
+              <span className="muted">
+                ({userCorrect}/{allScored.length})
+              </span>
+            </span>
+          </div>
+          <div className="scoreboard-stat">
+            <span className="scoreboard-stat-label">Model accuracy</span>
+            <span className="scoreboard-stat-value">
+              {formatPct(modelCorrect / allScored.length)}{" "}
+              <span className="muted">
+                ({modelCorrect}/{allScored.length})
+              </span>
+            </span>
+          </div>
+          {modelLoss !== null && (
+            <div className="scoreboard-stat">
+              <span className="scoreboard-stat-label">Model log loss</span>
+              <span className="scoreboard-stat-value">{modelLoss.toFixed(3)}</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {status.rounds.map((rg) => {
+        const scored = rg.matches.filter((m) => m.actualWinner !== null);
+        return (
+          <details key={`${rg.season}-${rg.round}`} className="scoreboard-round" open>
+            <summary className="scoreboard-round-header">
+              Round {rg.round}, {rg.season}
+              {scored.length > 0 && (
+                <span className="muted scoreboard-round-score">
+                  {" "}
+                  — you {scored.filter((m) => m.tip === m.actualWinner).length}/
+                  {scored.length}, model {scored.filter((m) => m.predictedWinner === m.actualWinner).length}/
+                  {scored.length}
+                </span>
+              )}
+            </summary>
+            <ul className="scoreboard-list">
+              {rg.matches.map((m) => {
+                const pending = m.actualWinner === null;
+                const userRight = !pending && m.tip === m.actualWinner;
+                const modelRight = !pending && m.predictedWinner === m.actualWinner;
+                const tipName = m.tip === "home" ? m.home : m.away;
+                const predName = m.predictedWinner === "home" ? m.home : m.away;
+                return (
+                  <li
+                    key={m.matchId}
+                    className={`scoreboard-match${pending ? " scoreboard-match--pending" : userRight ? " scoreboard-match--correct" : " scoreboard-match--wrong"}`}
+                  >
+                    <span className="scoreboard-teams">
+                      {m.home} vs {m.away}
+                    </span>
+                    <span className="scoreboard-tip">
+                      Your tip: <strong>{tipName}</strong>
+                      {!pending && (
+                        <span className={`tip-result ${userRight ? "tip-result--correct" : "tip-result--wrong"}`}>
+                          {userRight ? "✓" : "✗"}
+                        </span>
+                      )}
+                    </span>
+                    <span className="scoreboard-model">
+                      Model: <strong>{predName}</strong>
+                      {!pending && (
+                        <span className={`tip-result ${modelRight ? "tip-result--correct" : "tip-result--wrong"}`}>
+                          {modelRight ? "✓" : "✗"}
+                        </span>
+                      )}
+                    </span>
+                    {pending && <span className="scoreboard-pending muted">Pending</span>}
+                  </li>
+                );
+              })}
+            </ul>
+          </details>
+        );
+      })}
+    </section>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -523,3 +523,190 @@ a:focus-visible {
 .install-prompt-dismiss:hover {
   background: rgba(250, 250, 250, 0.1);
 }
+
+/* ── Nav link ──────────────────────────────────────────────────────────── */
+
+.nav-link {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.nav-link:hover {
+  color: var(--color-text);
+}
+
+/* ── Tip entry ─────────────────────────────────────────────────────────── */
+
+.tip-entry {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.tip-label {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.tip-buttons {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.tip-btn {
+  flex: 1;
+  min-height: 44px;
+  font-size: 0.85rem;
+  padding: 0.4rem 0.5rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tip-btn:hover:not(:disabled) {
+  border-color: var(--color-primary);
+  color: var(--color-text);
+  background: var(--color-surface);
+}
+
+.tip-btn--selected {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: var(--color-bg);
+  font-weight: 600;
+}
+
+.tip-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.tip-locked {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+/* ── Scoreboard ────────────────────────────────────────────────────────── */
+
+.scoreboard h1 {
+  margin-top: 0;
+}
+
+.scoreboard-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  padding: 1rem 1.25rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  margin-bottom: 1.5rem;
+}
+
+.scoreboard-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.scoreboard-stat-label {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.scoreboard-stat-value {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.scoreboard-round {
+  margin-bottom: 1rem;
+}
+
+.scoreboard-round-header {
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.5rem 0;
+  user-select: none;
+}
+
+.scoreboard-round-score {
+  font-weight: 400;
+  font-size: 0.9rem;
+}
+
+.scoreboard-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.scoreboard-match {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 0.5rem 1rem;
+  padding: 0.6rem 0.9rem;
+  border: 1px solid var(--color-border);
+  border-left: 4px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  font-size: 0.9rem;
+}
+
+.scoreboard-match--correct {
+  border-left-color: #27ae60;
+}
+
+.scoreboard-match--wrong {
+  border-left-color: var(--color-error);
+}
+
+.scoreboard-match--pending {
+  border-left-color: var(--color-border-subtle);
+}
+
+.scoreboard-teams {
+  grid-column: 1 / -1;
+  font-weight: 600;
+}
+
+.scoreboard-tip,
+.scoreboard-model {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.scoreboard-pending {
+  font-size: 0.8rem;
+  font-style: italic;
+}
+
+.tip-result {
+  margin-left: 0.35rem;
+  font-weight: 700;
+}
+
+.tip-result--correct {
+  color: #27ae60;
+}
+
+.tip-result--wrong {
+  color: var(--color-error);
+}

--- a/web/src/tips.ts
+++ b/web/src/tips.ts
@@ -1,0 +1,84 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  serverTimestamp,
+  setDoc,
+  Timestamp,
+  where,
+} from "firebase/firestore";
+
+import { getFirebaseFirestore } from "./firebase";
+
+export type TipChoice = "home" | "away";
+
+export type TipDoc = {
+  tip: TipChoice;
+  kickoff: Timestamp;
+  season: number;
+  round: number;
+  updatedAt: Timestamp;
+};
+
+/** Collection path: users/{uid}/tips/{matchId} */
+function tipsCollection(uid: string) {
+  const db = getFirebaseFirestore();
+  if (!db) throw new Error("Firestore not configured");
+  return collection(db, "users", uid, "tips");
+}
+
+export async function saveTip(
+  uid: string,
+  matchId: number,
+  tip: TipChoice,
+  kickoffIso: string,
+  season: number,
+  round: number,
+): Promise<void> {
+  const db = getFirebaseFirestore();
+  if (!db) throw new Error("Firestore not configured");
+  const ref = doc(db, "users", uid, "tips", String(matchId));
+  await setDoc(ref, {
+    tip,
+    kickoff: Timestamp.fromDate(new Date(kickoffIso)),
+    season,
+    round,
+    updatedAt: serverTimestamp(),
+  } satisfies Omit<TipDoc, "updatedAt"> & { updatedAt: ReturnType<typeof serverTimestamp> });
+}
+
+export async function getTip(uid: string, matchId: number): Promise<TipChoice | null> {
+  const db = getFirebaseFirestore();
+  if (!db) return null;
+  const ref = doc(db, "users", uid, "tips", String(matchId));
+  const snap = await getDoc(ref);
+  return snap.exists() ? (snap.data() as TipDoc).tip : null;
+}
+
+export async function getTipsByRound(
+  uid: string,
+  season: number,
+  round: number,
+): Promise<Map<number, TipChoice>> {
+  const col = tipsCollection(uid);
+  const q = query(col, where("season", "==", season), where("round", "==", round));
+  const snap = await getDocs(q);
+  const result = new Map<number, TipChoice>();
+  snap.forEach((d) => {
+    result.set(Number(d.id), (d.data() as TipDoc).tip);
+  });
+  return result;
+}
+
+export async function getAllTips(uid: string): Promise<
+  Array<{ matchId: number; season: number; round: number; tip: TipChoice }>
+> {
+  const col = tipsCollection(uid);
+  const snap = await getDocs(col);
+  return snap.docs.map((d) => ({
+    matchId: Number(d.id),
+    ...(d.data() as Pick<TipDoc, "season" | "round" | "tip">),
+  }));
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -22,4 +22,5 @@ export type Prediction = {
   modelVersion: string;
   featureHash: string;
   contributions?: FeatureContribution[] | null;
+  actualWinner?: "home" | "away" | null;
 };


### PR DESCRIPTION
## Summary

- **TipEntry component**: home/away toggle buttons with ≥44 px tap targets, `aria-pressed` state, locked + `disabled` after kickoff passes
- **MatchCard**: accepts `tip` + `onTip` props; TipEntry is rendered inside a non-link `div` so clicking a button doesn't navigate to the detail page
- **Round route**: loads tips in parallel with predictions via `getTipsByRound()`; saves optimistically with `saveTip()`, catches errors silently (offline / unconfigured Firestore degrades gracefully)
- **Scoreboard page** (`/scoreboard`): all tipped matches grouped by round showing pending / correct ✓ / wrong ✗ state; rolling accuracy and model log loss computed once `actualWinner` is available
- **Nav link** to `/scoreboard` added to the app header
- **`actualWinner`** added to `PredictionOut`; served at request time from the match repo (FullTime matches only — not written to the prediction cache)
- **`firestore.rules`**: users can only read/write their own `users/{uid}/tips/{matchId}`; creates + updates blocked after kickoff; deletes never allowed

## Firestore structure

```
users/{uid}/tips/{matchId}
  tip:       "home" | "away"
  kickoff:   Timestamp        ← used for server-side lock rule
  season:    number
  round:     number
  updatedAt: serverTimestamp()
```

## Test plan

- [ ] Sign in and navigate to a round; tip buttons appear on each match card
- [ ] Select a tip — button highlights; reload the page and tip persists
- [ ] After kickoff, buttons are disabled and "Locked" label appears
- [ ] `/scoreboard` shows all rounds you've tipped with pending state for upcoming matches
- [ ] Once results land (`actualWinner` populated by backend), correct/wrong badges and accuracy stats appear
- [ ] Try accessing `users/other-uid/tips/...` — denied by Firestore rules

https://claude.ai/code/session_01KoLWJaMsiNPZirUr774xsx