### PR TITLE
feat(cli): copy-matches-to-firestore — bootstrap Firestore history (closes #123)

### DIFF
--- a/src/fantasy_coach/__main__.py
+++ b/src/fantasy_coach/__main__.py
@@ -145,6 +145,50 @@ def main(argv: list[str] | None = None) -> int:
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
     )
 
+    cp = sub.add_parser(
+        "copy-matches-to-firestore",
+        help=(
+            "Copy completed matches from a local SQLite DB to Firestore. "
+            "One-off bootstrap so the precompute Job's FeatureBuilder sees "
+            "the same history the model was trained against — otherwise every "
+            "historical feature (Elo, form, h2h, venue, referee, key-absence) "
+            "defaults to zero at inference."
+        ),
+    )
+    cp.add_argument("--db", type=Path, default=Path("data/nrl.db"))
+    cp.add_argument(
+        "--season",
+        type=int,
+        action="append",
+        default=None,
+        help="Season to copy. May be repeated. Omit to copy every season in the DB.",
+    )
+    cp.add_argument(
+        "--project",
+        type=str,
+        default=None,
+        help=(
+            "GCP project hosting Firestore. Defaults to GOOGLE_CLOUD_PROJECT / "
+            "FIREBASE_PROJECT_ID / ADC project."
+        ),
+    )
+    cp.add_argument(
+        "--database",
+        type=str,
+        default="(default)",
+        help='Firestore database name (Python client default: "(default)")',
+    )
+    cp.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Count matches per season but do not write.",
+    )
+    cp.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+
     args = parser.parse_args(argv)
     logging.basicConfig(
         level=args.log_level,
@@ -159,6 +203,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_evaluate(args)
     if args.command == "precompute":
         return _run_precompute(args)
+    if args.command == "copy-matches-to-firestore":
+        return _run_copy_matches_to_firestore(args)
     parser.error(f"unknown command {args.command!r}")
     return 2  # unreachable
 
@@ -315,6 +361,54 @@ def _run_precompute(args: argparse.Namespace) -> int:
             store.close()
 
     print(f"Precomputed {len(predictions)} predictions for season={season} round={round_}")
+    return 0
+
+
+def _run_copy_matches_to_firestore(args: argparse.Namespace) -> int:
+    """Copy completed matches from SQLite → Firestore one by one.
+
+    Written for the #123 one-off bootstrap — Firestore's ``matches`` collection
+    was empty in prod, which meant every rolling / historical feature defaulted
+    to zero at inference. Idempotent: ``FirestoreRepository.upsert_match`` uses
+    the match id as the doc id, so re-running this command just overwrites.
+    """
+    from fantasy_coach.storage.firestore import FirestoreRepository  # noqa: PLC0415
+
+    if not args.db.exists():
+        print(f"error: SQLite DB not found at {args.db}", file=sys.stderr)
+        return 2
+
+    src = SQLiteRepository(args.db)
+    try:
+        if args.season:
+            seasons = sorted(set(args.season))
+        else:
+            rows = src._conn.execute(  # noqa: SLF001
+                "SELECT DISTINCT season FROM matches ORDER BY season"
+            ).fetchall()
+            seasons = [r[0] for r in rows]
+
+        if not seasons:
+            print(f"No seasons present in {args.db}", file=sys.stderr)
+            return 1
+
+        dst: FirestoreRepository | None = None
+        if not args.dry_run:
+            dst = FirestoreRepository(project=args.project, database=args.database)
+
+        grand_total = 0
+        for season in seasons:
+            matches = src.list_matches(season)
+            print(f"Season {season}: {len(matches)} matches{' (dry-run)' if args.dry_run else ''}")
+            if not args.dry_run and dst is not None:
+                for row in matches:
+                    dst.upsert_match(row)
+            grand_total += len(matches)
+
+        verb = "Would copy" if args.dry_run else "Copied"
+        print(f"{verb} {grand_total} matches across {len(seasons)} season(s)")
+    finally:
+        src.close()
     return 0
 
 

--- a/tests/test_copy_matches_cli.py
+++ b/tests/test_copy_matches_cli.py
@@ -1,0 +1,111 @@
+"""Tests for the ``copy-matches-to-firestore`` CLI subcommand (#123).
+
+One-off bootstrap that fills a prod Firestore with history from a local
+SQLite backfill. Real Firestore writes are mocked; we just verify the
+CLI wiring + per-season counting.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fantasy_coach.__main__ import main
+from fantasy_coach.features import MatchRow, TeamRow
+from fantasy_coach.storage.sqlite import SQLiteRepository
+
+
+@pytest.fixture
+def seeded_db(tmp_path: Path) -> Path:
+    """Pre-seed a SQLite DB with a handful of matches across two seasons."""
+    path = tmp_path / "nrl.db"
+    repo = SQLiteRepository(path)
+    try:
+        for i, (season, round_) in enumerate([(2024, 1), (2024, 2), (2025, 1)]):
+            repo.upsert_match(
+                MatchRow(
+                    match_id=1000 + i,
+                    season=season,
+                    round=round_,
+                    start_time=datetime(season, 3, round_, 19, 30, tzinfo=UTC),
+                    match_state="FullTime",
+                    venue="Eden Park",
+                    venue_city="Auckland",
+                    weather=None,
+                    home=TeamRow(
+                        team_id=10, name="Tigers", nick_name="Tigers", score=20, players=[]
+                    ),
+                    away=TeamRow(
+                        team_id=20, name="Raiders", nick_name="Raiders", score=14, players=[]
+                    ),
+                    team_stats=[],
+                )
+            )
+    finally:
+        repo.close()
+    return path
+
+
+def test_copy_all_seasons_writes_every_match(seeded_db: Path) -> None:
+    fake_repo = MagicMock()
+    with patch(
+        "fantasy_coach.storage.firestore.FirestoreRepository",
+        return_value=fake_repo,
+    ) as factory:
+        code = main(["copy-matches-to-firestore", "--db", str(seeded_db), "--log-level", "WARNING"])
+
+    assert code == 0
+    factory.assert_called_once()  # single Firestore client
+    assert fake_repo.upsert_match.call_count == 3
+    # All three matches should reach Firestore in season order.
+    match_ids = [c.args[0].match_id for c in fake_repo.upsert_match.call_args_list]
+    assert sorted(match_ids) == [1000, 1001, 1002]
+
+
+def test_copy_filtered_by_season(seeded_db: Path) -> None:
+    fake_repo = MagicMock()
+    with patch(
+        "fantasy_coach.storage.firestore.FirestoreRepository",
+        return_value=fake_repo,
+    ):
+        code = main(
+            [
+                "copy-matches-to-firestore",
+                "--db",
+                str(seeded_db),
+                "--season",
+                "2024",
+                "--log-level",
+                "WARNING",
+            ]
+        )
+
+    assert code == 0
+    # Only the two 2024 matches should be copied.
+    assert fake_repo.upsert_match.call_count == 2
+
+
+def test_copy_dry_run_does_not_instantiate_firestore(seeded_db: Path) -> None:
+    with patch("fantasy_coach.storage.firestore.FirestoreRepository") as factory:
+        code = main(
+            [
+                "copy-matches-to-firestore",
+                "--db",
+                str(seeded_db),
+                "--dry-run",
+                "--log-level",
+                "WARNING",
+            ]
+        )
+
+    assert code == 0
+    factory.assert_not_called()
+
+
+def test_copy_missing_db_is_an_error(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.db"
+    code = main(["copy-matches-to-firestore", "--db", str(missing), "--log-level", "WARNING"])
+    assert code == 2


### PR DESCRIPTION
## Summary
Adds `python -m fantasy_coach copy-matches-to-firestore` — a one-off CLI that upserts every `MatchRow` from a local SQLite DB into Firestore via the existing `FirestoreRepository`. Idempotent, supports `--season`, `--project`, `--database`, and `--dry-run` flags.

## Why
See the PR issue description for the full root cause. Short version: the production precompute Job's `FeatureBuilder` was reading from `FirestoreRepository`, which only contained upcoming-round fixtures the precompute Job had scraped itself. No 2024/2025 history had ever been written to Firestore, so `list_matches(s)` returned `[]` for every prior season. Consequence: nearly every historical feature in the model collapsed to its default value at inference, leaving the model running on weather + current-scrape team-list only.

A user noticed this because the `/predictions` `contributions` array was showing "Referee averages 0 combined points per match" as a top reason — that zero is the default-when-empty `league_total`, not a measurement.

## Operator steps post-merge

```bash
# From a laptop with ADC credentials for fantasy-coach-lcd.
gcloud auth application-default login
uv run python -m fantasy_coach copy-matches-to-firestore \
    --db data/nrl.db \
    --project fantasy-coach-lcd
# ~426 matches across 2024 + 2025.

gcloud run jobs execute fantasy-coach-precompute \
    --region australia-southeast1 \
    --project fantasy-coach-lcd \
    --wait
# Next precompute run now sees real Elo / form / h2h / venue / referee / absence history.
```

Verify after: `elo_diff` in the returned `contributions` should be non-zero and vary per team pairing (Storm vs Tigers should favour Storm heavily, not be 0).

## Follow-up
- #124 — UI filter/relabel for any residual `missing_*` contributions so "0 combined points" labels never leak through even when data is genuinely absent for a specific match.

## Test plan
- [x] `uv run pytest tests/test_copy_matches_cli.py` — 4 new tests (full copy, season filter, dry-run skips Firestore instantiation, missing DB → exit 2).
- [x] Full suite (355 tests) + ruff + format: green.
- [ ] Post-merge: run the operator command above against prod, then re-trigger the Job; confirm `/predictions` contributions contain real Elo / venue / ref numbers instead of zeros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)