### PR TITLE
feat(ui): mobile expand/collapse for contributing factors panel

### DIFF
--- a/web/src/routes/MatchDetail.tsx
+++ b/web/src/routes/MatchDetail.tsx
@@ -106,6 +106,8 @@ export default function MatchDetail() {
   );
 }
 
+const MOBILE_TOP = 3;
+
 function MatchDetailBody({ prediction }: { prediction: Prediction }) {
   const homePct = Math.round(prediction.homeWinProbability * 100);
   const awayPct = 100 - homePct;
@@ -114,6 +116,8 @@ function MatchDetailBody({ prediction }: { prediction: Prediction }) {
   const winnerPct = prediction.predictedWinner === "home" ? homePct : awayPct;
 
   const contributions = prediction.contributions ?? [];
+  const [expanded, setExpanded] = useState(false);
+  const hasExtra = contributions.length > MOBILE_TOP;
 
   return (
     <article className="match-detail">
@@ -144,13 +148,19 @@ function MatchDetailBody({ prediction }: { prediction: Prediction }) {
       </div>
 
       {contributions.length > 0 ? (
-        <section className="contributions" aria-labelledby="why-heading">
+        <section
+          className={`contributions${expanded ? " contributions--expanded" : ""}`}
+          aria-labelledby="why-heading"
+        >
           <h2 id="why-heading">Why this pick</h2>
           <ol className="contribution-list">
-            {contributions.map((c) => {
+            {contributions.map((c, idx) => {
               const label = labelFor(c, prediction.home.name, prediction.away.name);
               return (
-                <li key={c.feature} className={`contribution favours-${label.favours}`}>
+                <li
+                  key={c.feature}
+                  className={`contribution favours-${label.favours}${idx >= MOBILE_TOP ? " contribution--extra" : ""}`}
+                >
                   <span className="contribution-text">{label.text}</span>
                   <span
                     className="contribution-magnitude muted"
@@ -163,6 +173,17 @@ function MatchDetailBody({ prediction }: { prediction: Prediction }) {
               );
             })}
           </ol>
+          {hasExtra && (
+            <button
+              className="contributions-toggle"
+              onClick={() => setExpanded((e) => !e)}
+              aria-expanded={expanded}
+            >
+              {expanded
+                ? "Show fewer"
+                : `Show all ${contributions.length} factors`}
+            </button>
+          )}
           <p className="muted fine-print">
             Contributions are in log-odds units — higher magnitude means the feature pushed the
             probability harder in the direction shown.

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -473,6 +473,41 @@ a:focus-visible {
   margin: 0.5rem 0 0;
 }
 
+/* Mobile-only: collapse contributions beyond the first MOBILE_TOP items. */
+.contributions-toggle {
+  display: none; /* hidden on desktop; shown below 480 px */
+}
+
+@media (max-width: 479px) {
+  .contribution--extra {
+    display: none;
+  }
+
+  .contributions--expanded .contribution--extra {
+    display: flex;
+  }
+
+  .contributions-toggle {
+    display: block;
+    width: 100%;
+    margin-top: 0.5rem;
+    background: transparent;
+    border: 1px solid var(--color-border-subtle);
+    color: var(--color-text-secondary);
+    font-size: 0.85rem;
+    padding: 0.4rem 0.75rem;
+    border-radius: var(--radius-sm);
+    text-align: center;
+    cursor: pointer;
+  }
+
+  .contributions-toggle:hover {
+    border-color: var(--color-primary);
+    color: var(--color-text);
+    background: transparent;
+  }
+}
+
 /* ── Offline banner ────────────────────────────────────────────────────── */
 
 .offline-banner {


### PR DESCRIPTION
## Summary

Closes #111.

The probability bar, contributing factors panel, API `feature_contributions`, and accessibility attributes (`role="img"`, `aria-label`, real `<ol>`) were already shipped in #58. This PR completes the final acceptance criterion:

- **Mobile layout (< 480 px):** top-3 contributing factors visible by default; a "Show all N factors" toggle button appears below. Tapping again collapses to top-3. The button has `aria-expanded` for screen readers.
- **Desktop (≥ 480 px):** all factors shown, toggle button hidden — no behaviour change.

Implementation is CSS-class-driven: items past index 2 get `contribution--extra`; container gets `contributions--expanded` when toggled; a `@media (max-width: 479px)` block in `styles.css` applies the visibility rules.

No new dependencies — hand-rolled as decided in the issue (SPA budget < 100 kB gzipped).

## Test plan
- [x] TypeScript build passes (`npm run build`)
- [x] Ruff check + format pass on Python side (no Python changes)
- [ ] Manual: on a narrow viewport (< 480 px), only 3 factors show; "Show all 5 factors" button appears; tap expands to 5; tap again collapses
- [ ] Manual: on desktop, all factors always visible, no toggle button

https://claude.ai/code/session_01LdJ3gjR372oqnrUU7YMfNE