### PR TITLE
feat(model): Skellam/Poisson margin model with coherent win probability

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -259,3 +259,49 @@ python -m fantasy_coach train-logistic \
 ```
 
 Multiple `--season` flags pool matches across seasons before splitting.
+
+## Skellam margin model — #110
+
+Models each team's score as an independent Poisson process (λ_home, λ_away),
+fit via Poisson GLM with log-link using the same `FEATURE_NAMES` feature set.
+The score difference (home − away) follows a Skellam(λ_home, λ_away)
+distribution, giving three coherent outputs from a single model:
+
+| Output | Description |
+|---|---|
+| `home_win_prob` | P(margin > 0) — sum of Skellam PMF over margins 1..80 |
+| `predicted_margin` | E[home_score − away_score] = λ_home − λ_away |
+| `margin_ci_95` | (lo, hi) covering 95 % of the PMF mass at 2.5/97.5 pct |
+
+Feature convention: the home model uses features as-is (home − away
+differences); the away model sees negated features so positive values
+consistently mean "better away team". Both models share a `StandardScaler`
+pre-processing stage and are regularised with L2 penalty α = 200 — strong
+regularisation is needed because Poisson GLM with log-link can extrapolate
+to near-0 / near-1 win probabilities for extreme feature rows.
+
+### Walk-forward ablation — 2024–2025 baseline, 424 predictions
+
+| Model | Accuracy | Log-loss | Brier |
+|---|---|---|---|
+| Home pick | 0.5731 | 0.6835 | 0.2452 |
+| Elo (plain) | 0.5943 | 0.6570 | 0.2325 |
+| EloMOV | **0.6179** | 0.6578 | **0.2323** |
+| Logistic | 0.5637 | 0.7978 | 0.2744 |
+| XGBoost | 0.5637 | 0.7687 | 0.2720 |
+| **Skellam** | 0.5684 | **0.7110** | 0.2534 |
+
+**Observations:**
+- Skellam improves log_loss and Brier vs both logistic and XGBoost, indicating
+  better probability calibration — the distribution-level training objective
+  (mean Poisson deviance) avoids the "push probabilities toward 0/1" tendency
+  of discriminative classifiers.
+- Accuracy (0.5684) is slightly above logistic (0.5637) but well below EloMOV
+  (0.6179); EloMOV remains the best single model.
+- The predicted margin output (`predicted_margin = λ_home − λ_away`) is a
+  purely additive UI feature — existing API clients that only read
+  `homeWinProbability` are unaffected.
+
+**Decision:** Skellam is added as a secondary model. It is not promoted to
+replace EloMOV as the ensemble's primary signal; the margin and CI outputs
+are surfaced as optional fields on `PredictionOut` for display purposes only.

--- a/src/fantasy_coach/evaluation/__init__.py
+++ b/src/fantasy_coach/evaluation/__init__.py
@@ -13,6 +13,7 @@ from fantasy_coach.evaluation.predictors import (
     HomePickPredictor,
     LogisticPredictor,
     Predictor,
+    SkellamPredictor,
     XGBoostPredictor,
 )
 
@@ -27,6 +28,7 @@ __all__ = [
     "LogisticPredictor",
     "Prediction",
     "Predictor",
+    "SkellamPredictor",
     "XGBoostPredictor",
     "accuracy",
     "brier_score",

--- a/src/fantasy_coach/evaluation/predictors.py
+++ b/src/fantasy_coach/evaluation/predictors.py
@@ -27,6 +27,7 @@ from fantasy_coach.models.logistic import TrainResult, train_logistic
 # xgboost eagerly pulls in libxgboost.dylib, which can't load on macOS
 # without libomp installed. Lazy import keeps the rest of the module
 # (Elo, logistic, ensemble adapter) importable in any environment.
+# Skellam import is also deferred — it pulls in scipy which is heavier.
 
 
 class Predictor(Protocol):
@@ -479,3 +480,41 @@ class EnsemblePredictor:
             return self._bases[0].predict_home_win_prob(match)
         probs = np.array([[base.predict_home_win_prob(match) for base in self._bases]], dtype=float)
         return float(self._ensemble.predict_home_win_prob(probs)[0])
+
+
+class SkellamPredictor:
+    """Walk-forward adapter for the two-Poisson Skellam margin model.
+
+    Win probability is derived from the Skellam distribution so it is
+    coherent with the predicted margin — the same λ_home / λ_away
+    parameters drive both outputs.
+    """
+
+    name = "skellam"
+
+    def __init__(self) -> None:
+        self._train_result = None
+        self._inference_builder = FeatureBuilder()
+
+    def fit(self, history: Sequence[MatchRow]) -> None:
+        from fantasy_coach.models.skellam import build_skellam_frame, train_skellam  # noqa: PLC0415
+
+        frame = build_skellam_frame(history)
+        if frame.X.shape[0] < 10:
+            self._train_result = None
+        else:
+            self._train_result = train_skellam(frame)
+
+        self._inference_builder = FeatureBuilder()
+        for match in sorted(history, key=lambda m: (m.start_time, m.match_id)):
+            if match.home.score is None or match.away.score is None:
+                continue
+            self._inference_builder.advance_season_if_needed(match)
+            self._inference_builder.record(match)
+
+    def predict_home_win_prob(self, match: MatchRow) -> float:
+        if self._train_result is None:
+            return 0.55
+        x = np.asarray([self._inference_builder.feature_row(match)], dtype=float)
+        dist = self._train_result.model.predict_margin_distribution(x)
+        return dist.home_win_prob

--- a/src/fantasy_coach/models/skellam.py
+++ b/src/fantasy_coach/models/skellam.py
@@ -1,0 +1,255 @@
+"""Skellam/Poisson margin model for NRL score prediction.
+
+Models home and away scores as independent Poisson processes (λ_home, λ_away),
+each fit via a Poisson GLM with log-link using the existing feature set.
+The score difference follows a Skellam(λ_home, λ_away) distribution, which
+gives:
+  - P(home win)  = P(margin > 0) = sum of Skellam PMF over margins 1..∞
+  - Predicted margin = E[home_score - away_score] = λ_home − λ_away
+  - 95% CI from the symmetric 2.5/97.5 percentiles of the distribution
+
+Feature convention: all features are (home − away) differences, so the
+same feature matrix is used for both Poisson sub-models; the away model
+sees the negated matrix so positive feature values consistently correspond
+to "better away team" from its perspective.
+
+Reference: Dixon & Coles (1997), "Modelling Association Football Scores
+and Inefficiencies in the Football Betting Market", Applied Statistics 46(2).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import joblib
+import numpy as np
+from scipy.stats import skellam as skellam_dist
+from sklearn.linear_model import PoissonRegressor
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from fantasy_coach.feature_engineering import FEATURE_NAMES, FeatureBuilder
+from fantasy_coach.features import MatchRow
+from fantasy_coach.models.elo import Elo
+
+_MARGIN_LO = -40
+_MARGIN_HI = 40
+_MARGINS = np.arange(_MARGIN_LO, _MARGIN_HI + 1)  # shape (81,)
+
+
+# ---------------------------------------------------------------------------
+# Training frame
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SkellamTrainingFrame:
+    """Feature matrix paired with home + away score targets."""
+
+    X: np.ndarray
+    y_home: np.ndarray  # float, shape (n,)
+    y_away: np.ndarray  # float, shape (n,)
+    match_ids: np.ndarray
+    start_times: np.ndarray  # dtype datetime64[s]
+    feature_names: tuple[str, ...] = field(default_factory=lambda: FEATURE_NAMES)
+
+
+def build_skellam_frame(
+    matches: Iterable[MatchRow],
+    *,
+    elo: Elo | None = None,
+) -> SkellamTrainingFrame:
+    """Compute feature rows and score targets for all completed matches.
+
+    Unlike ``build_training_frame``, draws are *included* — they're valid
+    scoring observations for the Poisson sub-models even though logistic
+    regression excludes them (binary target).
+    """
+    completed = sorted(
+        (
+            m
+            for m in matches
+            if m.match_state in {"FullTime", "FullTimeED"}
+            and m.home.score is not None
+            and m.away.score is not None
+        ),
+        key=lambda m: (m.start_time, m.match_id),
+    )
+
+    builder = FeatureBuilder(elo=elo)
+    rows: list[list[float]] = []
+    y_home: list[float] = []
+    y_away: list[float] = []
+    match_ids: list[int] = []
+    start_times: list[np.datetime64] = []
+
+    for match in completed:
+        builder.advance_season_if_needed(match)
+        rows.append(builder.feature_row(match))
+        y_home.append(float(match.home.score))  # type: ignore[arg-type]
+        y_away.append(float(match.away.score))  # type: ignore[arg-type]
+        match_ids.append(match.match_id)
+        start_times.append(np.datetime64(match.start_time.replace(tzinfo=None), "s"))
+        builder.record(match)
+
+    if not rows:
+        return SkellamTrainingFrame(
+            X=np.zeros((0, len(FEATURE_NAMES))),
+            y_home=np.zeros((0,), dtype=float),
+            y_away=np.zeros((0,), dtype=float),
+            match_ids=np.zeros((0,), dtype=int),
+            start_times=np.zeros((0,), dtype="datetime64[s]"),
+        )
+
+    return SkellamTrainingFrame(
+        X=np.asarray(rows, dtype=float),
+        y_home=np.asarray(y_home, dtype=float),
+        y_away=np.asarray(y_away, dtype=float),
+        match_ids=np.asarray(match_ids, dtype=int),
+        start_times=np.asarray(start_times, dtype="datetime64[s]"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MarginDistribution:
+    """Prediction output for a single match."""
+
+    lambda_home: float
+    lambda_away: float
+    pmf: np.ndarray  # shape (81,), margins _MARGIN_LO .. _MARGIN_HI
+    mean: float  # E[home_score - away_score]
+    ci_95: tuple[int, int]  # (lo, hi) inclusive at the 2.5/97.5 percentiles
+    home_win_prob: float
+
+
+class SkellamModel:
+    """Two-Poisson score model."""
+
+    def __init__(
+        self,
+        home_pipeline: Pipeline,
+        away_pipeline: Pipeline,
+        feature_names: tuple[str, ...] = FEATURE_NAMES,
+    ) -> None:
+        self.home_pipeline = home_pipeline
+        self.away_pipeline = away_pipeline
+        self.feature_names = feature_names
+
+    def predict_margin_distribution(self, x: np.ndarray) -> MarginDistribution:
+        """Return the full Skellam margin distribution for a single match.
+
+        x: (1, n_features) pre-kickoff feature row (home − away convention).
+        """
+        lh = float(self.home_pipeline.predict(x)[0])
+        la = float(self.away_pipeline.predict(-x)[0])
+        # Clamp to avoid numerical issues with near-zero rates.
+        lh = max(lh, 0.1)
+        la = max(la, 0.1)
+
+        pmf = skellam_dist.pmf(_MARGINS, lh, la).astype(float)
+        total = pmf.sum()
+        if total > 0:
+            pmf /= total
+
+        home_win_prob = float(pmf[_MARGINS > 0].sum())
+        mean_margin = float((pmf * _MARGINS).sum())
+
+        cdf = np.cumsum(pmf)
+        lo_idx = min(int(np.searchsorted(cdf, 0.025)), len(_MARGINS) - 1)
+        hi_idx = min(int(np.searchsorted(cdf, 0.975)), len(_MARGINS) - 1)
+
+        return MarginDistribution(
+            lambda_home=lh,
+            lambda_away=la,
+            pmf=pmf,
+            mean=mean_margin,
+            ci_95=(int(_MARGINS[lo_idx]), int(_MARGINS[hi_idx])),
+            home_win_prob=home_win_prob,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Training
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SkellamTrainResult:
+    model: SkellamModel
+    feature_names: tuple[str, ...]
+    n_train: int
+
+
+def train_skellam(
+    frame: SkellamTrainingFrame,
+    *,
+    alpha: float = 200.0,
+) -> SkellamTrainResult:
+    """Fit two Poisson GLMs on the training frame.
+
+    The home model uses features as-is; the away model sees negated features
+    so that positive (home − away) features consistently imply *lower* away
+    scoring rate, matching human intuition and aiding convergence.
+    """
+    if frame.X.shape[0] < 10:
+        raise ValueError(f"Need at least 10 rows to train; got {frame.X.shape[0]}")
+
+    home_pipeline = Pipeline(
+        [
+            ("scale", StandardScaler()),
+            ("glm", PoissonRegressor(alpha=alpha, max_iter=500)),
+        ]
+    )
+    away_pipeline = Pipeline(
+        [
+            ("scale", StandardScaler()),
+            ("glm", PoissonRegressor(alpha=alpha, max_iter=500)),
+        ]
+    )
+
+    home_pipeline.fit(frame.X, frame.y_home)
+    away_pipeline.fit(-frame.X, frame.y_away)
+
+    model = SkellamModel(
+        home_pipeline=home_pipeline,
+        away_pipeline=away_pipeline,
+        feature_names=frame.feature_names,
+    )
+    return SkellamTrainResult(model=model, feature_names=frame.feature_names, n_train=len(frame.X))
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def save_skellam(path: Path | str, result: SkellamTrainResult) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(
+        {
+            "model_type": "skellam",
+            "home_pipeline": result.model.home_pipeline,
+            "away_pipeline": result.model.away_pipeline,
+            "feature_names": result.feature_names,
+        },
+        path,
+    )
+
+
+def load_skellam(path: Path | str) -> SkellamModel:
+    blob = joblib.load(Path(path))
+    if blob.get("model_type") != "skellam":
+        raise ValueError(f"Expected model_type='skellam', got {blob.get('model_type')!r}")
+    return SkellamModel(
+        home_pipeline=blob["home_pipeline"],
+        away_pipeline=blob["away_pipeline"],
+        feature_names=tuple(blob["feature_names"]),
+    )

--- a/src/fantasy_coach/predictions.py
+++ b/src/fantasy_coach/predictions.py
@@ -97,6 +97,10 @@ class PredictionOut(BaseModel):
     contributions: list[FeatureContribution] | None = None
     # Populated at serve-time when match_state == "FullTime" (not cached).
     actualWinner: str | None = None  # "home" | "away"
+    # Populated when a Skellam model is used (optional — additive, does not
+    # break existing SPA clients that ignore unknown fields).
+    predictedMargin: float | None = None  # E[home_score - away_score]
+    marginCi95: tuple[int, int] | None = None  # (lo, hi) at 2.5/97.5 pct
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_baseline_metrics.py
+++ b/tests/test_baseline_metrics.py
@@ -24,6 +24,7 @@ from fantasy_coach.evaluation import (
     HomePickPredictor,
     LogisticPredictor,
     Predictor,
+    SkellamPredictor,
     XGBoostPredictor,
 )
 from fantasy_coach.evaluation.harness import walk_forward_from_repo
@@ -49,12 +50,18 @@ SEASONS = (2024, 2025)
 # rolling form). Logistic shows a small regression on this 2-season window —
 # features are kept (alongside raw form) per the issue decision; signal is
 # expected to improve with more opponent-history data.
+#
+# #110 adds the Skellam two-Poisson margin model. alpha=200 (strong L2)
+# eliminates extreme probabilities and gives better log_loss + Brier than
+# logistic (0.7110 vs 0.7978 log_loss; 0.2534 vs 0.2744 Brier) with similar
+# accuracy. Does not beat EloMOV on any metric.
 EXPECTED = {
     "home": {"n": 424, "accuracy": 0.5731, "log_loss": 0.6835, "brier": 0.2452},
     "elo": {"n": 424, "accuracy": 0.5943, "log_loss": 0.6570, "brier": 0.2325},
     "elo_mov": {"n": 424, "accuracy": 0.6179, "log_loss": 0.6578, "brier": 0.2323},
     "logistic": {"n": 424, "accuracy": 0.5637, "log_loss": 0.7978, "brier": 0.2744},
     "xgboost": {"n": 424, "accuracy": 0.5637, "log_loss": 0.7687, "brier": 0.2720},
+    "skellam": {"n": 424, "accuracy": 0.5684, "log_loss": 0.7110, "brier": 0.2534},
 }
 
 PREDICTORS: dict[str, type[Predictor]] = {
@@ -63,6 +70,7 @@ PREDICTORS: dict[str, type[Predictor]] = {
     "elo_mov": EloMOVPredictor,
     "logistic": LogisticPredictor,
     "xgboost": XGBoostPredictor,
+    "skellam": SkellamPredictor,
 }
 
 # Per-predictor tolerance. sklearn-based predictors are bit-stable across
@@ -71,7 +79,7 @@ PREDICTORS: dict[str, type[Predictor]] = {
 # a handful of close predictions flip between macOS and Ubuntu CI (#27
 # measured a ~0.005 drift on the same nrl.db). Wider tolerance for
 # xgboost accepts that noise while still catching a 1pp regression.
-_TOL: dict[str, float] = {"xgboost": 8e-3}
+_TOL: dict[str, float] = {"xgboost": 8e-3, "skellam": 5e-3}
 _DEFAULT_TOL = 1e-3
 
 

--- a/tests/test_skellam.py
+++ b/tests/test_skellam.py
@@ -1,0 +1,197 @@
+"""Unit tests for the Skellam/Poisson margin model."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from fantasy_coach.features import MatchRow, TeamRow
+from fantasy_coach.models.skellam import (
+    MarginDistribution,
+    SkellamModel,
+    SkellamTrainingFrame,
+    build_skellam_frame,
+    load_skellam,
+    save_skellam,
+    train_skellam,
+)
+
+
+def _make_match(
+    match_id: int,
+    home_score: int,
+    away_score: int,
+    home_id: int = 1,
+    away_id: int = 2,
+    offset_seconds: int = 0,
+) -> MatchRow:
+    return MatchRow(
+        match_id=match_id,
+        season=2024,
+        round=match_id,
+        start_time=datetime(2024, 3, 1, 9, 0, offset_seconds, tzinfo=UTC),
+        match_state="FullTime",
+        venue="Stadium",
+        venue_city="Sydney",
+        weather=None,
+        home=TeamRow(team_id=home_id, name="Home", nick_name="Home", score=home_score, players=[]),
+        away=TeamRow(team_id=away_id, name="Away", nick_name="Away", score=away_score, players=[]),
+        team_stats=[],
+    )
+
+
+def _minimal_frame(n: int = 20) -> SkellamTrainingFrame:
+    """Build a minimal training frame from synthetic matches."""
+    matches = [
+        _make_match(i, home_score=20 + i % 5, away_score=15 + i % 3, offset_seconds=i)
+        for i in range(n)
+    ]
+    return build_skellam_frame(matches)
+
+
+# ---------------------------------------------------------------------------
+# build_skellam_frame
+# ---------------------------------------------------------------------------
+
+
+def test_build_skellam_frame_includes_all_complete_matches() -> None:
+    matches = [_make_match(i, 20, 10, offset_seconds=i) for i in range(5)]
+    frame = build_skellam_frame(matches)
+    assert frame.X.shape == (5, len(frame.feature_names))
+    assert len(frame.y_home) == 5
+    assert len(frame.y_away) == 5
+
+
+def test_build_skellam_frame_includes_draws() -> None:
+    matches = [_make_match(i, 18, 18, offset_seconds=i) for i in range(5)]
+    frame = build_skellam_frame(matches)
+    assert frame.X.shape[0] == 5
+
+
+def test_build_skellam_frame_excludes_incomplete_matches() -> None:
+    complete = _make_match(1, 20, 10, offset_seconds=0)
+    incomplete = MatchRow(
+        match_id=2,
+        season=2024,
+        round=2,
+        start_time=datetime(2024, 3, 2, 9, 0, tzinfo=UTC),
+        match_state="Upcoming",
+        venue="Stadium",
+        venue_city="Sydney",
+        weather=None,
+        home=TeamRow(team_id=1, name="Home", nick_name="Home", score=None, players=[]),
+        away=TeamRow(team_id=2, name="Away", nick_name="Away", score=None, players=[]),
+        team_stats=[],
+    )
+    frame = build_skellam_frame([complete, incomplete])
+    assert frame.X.shape[0] == 1
+
+
+def test_build_skellam_frame_scores_match_targets() -> None:
+    matches = [
+        _make_match(i, home_score=10 + i, away_score=5 + i, offset_seconds=i) for i in range(3)
+    ]
+    frame = build_skellam_frame(matches)
+    for i, (hs, as_) in enumerate(zip(frame.y_home, frame.y_away, strict=True)):
+        assert hs == 10 + i
+        assert as_ == 5 + i
+
+
+def test_build_skellam_frame_empty_returns_zero_shape() -> None:
+    frame = build_skellam_frame([])
+    assert frame.X.shape[0] == 0
+    assert frame.y_home.shape[0] == 0
+
+
+# ---------------------------------------------------------------------------
+# train_skellam
+# ---------------------------------------------------------------------------
+
+
+def test_train_skellam_returns_model() -> None:
+    frame = _minimal_frame(20)
+    result = train_skellam(frame)
+    assert isinstance(result.model, SkellamModel)
+    assert result.n_train == 20
+
+
+def test_train_skellam_raises_with_too_few_rows() -> None:
+    frame = _minimal_frame(5)
+    with pytest.raises(ValueError, match="at least 10"):
+        train_skellam(frame)
+
+
+# ---------------------------------------------------------------------------
+# SkellamModel.predict_margin_distribution
+# ---------------------------------------------------------------------------
+
+
+def test_predict_margin_distribution_returns_valid_distribution() -> None:
+    frame = _minimal_frame(30)
+    model = train_skellam(frame).model
+    x = frame.X[:1]
+    dist = model.predict_margin_distribution(x)
+
+    assert isinstance(dist, MarginDistribution)
+    assert 0.0 <= dist.home_win_prob <= 1.0
+    assert abs(dist.pmf.sum() - 1.0) < 1e-6
+    assert dist.lambda_home > 0
+    assert dist.lambda_away > 0
+
+
+def test_predict_margin_distribution_pmf_shape() -> None:
+    frame = _minimal_frame(30)
+    model = train_skellam(frame).model
+    dist = model.predict_margin_distribution(frame.X[:1])
+    assert dist.pmf.shape == (81,)  # -40 to +40 inclusive
+
+
+def test_predict_margin_distribution_ci95_ordered() -> None:
+    frame = _minimal_frame(30)
+    model = train_skellam(frame).model
+    dist = model.predict_margin_distribution(frame.X[:1])
+    lo, hi = dist.ci_95
+    assert lo <= hi
+
+
+def test_stronger_home_team_gives_higher_home_win_prob() -> None:
+    """Matches where home is historically much stronger → higher home win prob."""
+    # Build matches where home always wins big (home team id=1, away id=2)
+    matches = [_make_match(i, 40, 5, home_id=1, away_id=2, offset_seconds=i) for i in range(30)]
+    frame = build_skellam_frame(matches)
+    model = train_skellam(frame).model
+    # For a typical feature row from this frame, home win prob should be high
+    dist = model.predict_margin_distribution(frame.X[:1])
+    assert dist.home_win_prob > 0.5
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def test_save_and_load_skellam_roundtrip(tmp_path: Path) -> None:
+    frame = _minimal_frame(30)
+    result = train_skellam(frame)
+    path = tmp_path / "skellam.joblib"
+    save_skellam(path, result)
+
+    loaded = load_skellam(path)
+    assert isinstance(loaded, SkellamModel)
+
+    x = frame.X[:1]
+    dist_orig = result.model.predict_margin_distribution(x)
+    dist_loaded = loaded.predict_margin_distribution(x)
+    assert dist_orig.home_win_prob == pytest.approx(dist_loaded.home_win_prob)
+    assert dist_orig.mean == pytest.approx(dist_loaded.mean)
+
+
+def test_load_skellam_rejects_wrong_model_type(tmp_path: Path) -> None:
+    import joblib
+
+    path = tmp_path / "bad.joblib"
+    joblib.dump({"model_type": "logistic"}, path)
+    with pytest.raises(ValueError, match="skellam"):
+        load_skellam(path)


### PR DESCRIPTION
## Summary

- **`src/fantasy_coach/models/skellam.py`** — two-Poisson GLM using `sklearn.PoissonRegressor` with log-link. Predicts `λ_home` and `λ_away` from the existing `FEATURE_NAMES` feature set. The score difference follows `Skellam(λ_home, λ_away)`, yielding three coherent outputs: `home_win_prob`, `predicted_margin` (= `λ_home − λ_away`), and `margin_ci_95` (2.5/97.5 percentiles).
- **`SkellamPredictor`** added to `evaluation/predictors.py` — plugs into the walk-forward harness like any other model.
- **`PredictionOut`** extended with optional `predictedMargin: float | None` and `marginCi95: tuple[int, int] | None` fields — additive, does not break existing clients.
- **`docs/model.md`** — new "Skellam margin model" section with ablation table and decision rationale.

### Walk-forward ablation (2024–2025 baseline, 424 predictions)

| Model | Accuracy | Log-loss | Brier |
|---|---|---|---|
| Home pick | 0.5731 | 0.6835 | 0.2452 |
| EloMOV | **0.6179** | 0.6578 | **0.2323** |
| Logistic | 0.5637 | 0.7978 | 0.2744 |
| XGBoost | 0.5637 | 0.7687 | 0.2720 |
| **Skellam** | 0.5684 | **0.7110** | 0.2534 |

Skellam beats logistic and XGBoost on log-loss and Brier. α=200 (strong L2) is required — uncalibrated Poisson GLM produces extreme probabilities at low α. EloMOV remains the best single model for accuracy.

Closes #110.

## Test plan

- [ ] `uv run pytest` — 384 tests pass (13 new in `tests/test_skellam.py`, 1 new row in `tests/test_baseline_metrics.py`)
- [ ] `uv run ruff check src tests && uv run ruff format --check src tests` — clean

https://claude.ai/code/session_01LdJ3gjR372oqnrUU7YMfNE