### PR TITLE
feat(predictions): XGBoost contribution dispatcher + train-xgboost CLI (closes #136)

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -281,6 +281,35 @@ to logistic regression. It uses the same feature set (see the table above) and i
 time-series-aware hyperparameter search (`GridSearchCV` + `TimeSeriesSplit(n_splits=3)`)
 over `max_depth ∈ {3, 4, 5}`, `n_estimators ∈ {100, 200}`, `learning_rate ∈ {0.05, 0.1}`.
 
+### Production model: XGBoost (switched 2026-04-22, #136)
+
+The comparison table below is from the pre-#136 state. After the bookmaker-
+odds feature (#26) landed, XGBoost's edge over logistic compounded enough
+— and logistic's multicollinearity-driven wrong-sign coefficient on
+``player_strength_diff`` (#109) became misleading enough on per-feature
+attribution — that we flipped the production artefact.
+
+**What changed:** ``artifacts/xgboost.joblib`` is now uploaded to
+``gs://fantasy-coach-lcd-models/logistic/latest.joblib`` (the path keeps
+the old name for now — renaming is a tiny follow-up but needs a paired
+deploy-workflow edit). ``models.loader.load_model`` dispatches by
+``model_type`` embedded in the joblib blob, so the same path serves either
+model without code changes.
+
+**What stayed:** logistic training still works (``python -m fantasy_coach
+train-logistic``); the comparison baseline below is still the source of
+truth for ablation reporting; the EXPECTED dict in ``test_baseline_metrics``
+pins walk-forward numbers for *both* models so regressions on either side
+are caught.
+
+**Contribution attribution:** ``_compute_contributions`` in
+``predictions.py`` now dispatches by model type:
+- logistic: ``coef × (x − mean) / scale`` (unchanged).
+- XGBoost: booster ``predict(pred_contribs=True)`` — returns per-feature
+  margin contributions (log-odds for binary classification), drops the
+  bias column. Output shape matches logistic so the sentinel filter +
+  detail enrichment + UI rendering all work without branching.
+
 ### Comparison (2024–2025 walk-forward baseline, 424 predictions)
 
 | Model    | Accuracy | Log-loss | Brier  |

--- a/src/fantasy_coach/__main__.py
+++ b/src/fantasy_coach/__main__.py
@@ -74,6 +74,25 @@ def main(argv: list[str] | None = None) -> int:
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
     )
 
+    txg = sub.add_parser(
+        "train-xgboost",
+        help=(
+            "Train the XGBoost model against backfilled matches. Produces a "
+            "joblib artefact at the same shape as train-logistic; the "
+            "inference loader (``models.loader.load_model``) dispatches by "
+            "``model_type`` so either artefact can serve at the same GCS path."
+        ),
+    )
+    txg.add_argument("--season", type=int, action="append", required=True)
+    txg.add_argument("--db", type=Path, default=Path("data/nrl.db"))
+    txg.add_argument("--out", type=Path, default=Path("artifacts/xgboost.joblib"))
+    txg.add_argument("--test-fraction", type=float, default=0.2)
+    txg.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+
     ev = sub.add_parser(
         "evaluate",
         help="Walk-forward evaluation across one or more models.",
@@ -230,6 +249,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_backfill(args)
     if args.command == "train-logistic":
         return _run_train_logistic(args)
+    if args.command == "train-xgboost":
+        return _run_train_xgboost(args)
     if args.command == "evaluate":
         return _run_evaluate(args)
     if args.command == "precompute":
@@ -285,6 +306,42 @@ def _run_train_logistic(args: argparse.Namespace) -> int:
         f"Trained on {result.n_train} matches, tested on {result.n_test}. "
         f"Train acc={result.train_accuracy:.3f} "
         f"test acc={result.test_accuracy:.3f}. "
+        f"Saved to {args.out}"
+    )
+    return 0
+
+
+def _run_train_xgboost(args: argparse.Namespace) -> int:
+    """Train XGBoost + write artefact at the same joblib shape as logistic.
+
+    ``models.loader.load_model`` dispatches by ``model_type``, so swapping
+    artefacts at the GCS path the Job pulls from is the only step needed
+    to promote XGBoost to production (#136).
+    """
+    from fantasy_coach.models.xgboost_model import (  # noqa: PLC0415
+        save_model as save_xgb,
+    )
+    from fantasy_coach.models.xgboost_model import (
+        train_xgboost,
+    )
+
+    repo = SQLiteRepository(args.db)
+    try:
+        matches = []
+        for season in args.season:
+            matches.extend(repo.list_matches(season))
+    finally:
+        repo.close()
+
+    frame = build_training_frame(matches)
+    result = train_xgboost(frame, test_fraction=args.test_fraction)
+    save_xgb(result, args.out)
+
+    print(
+        f"Trained on {result.n_train} matches, tested on {result.n_test}. "
+        f"Train acc={result.train_accuracy:.3f} "
+        f"test acc={result.test_accuracy:.3f}. "
+        f"best_params={result.best_params}. "
         f"Saved to {args.out}"
     )
     return 0

--- a/src/fantasy_coach/predictions.py
+++ b/src/fantasy_coach/predictions.py
@@ -386,47 +386,42 @@ def _compute_contributions(
     builder: Any = None,
     match: Any = None,
 ) -> list[FeatureContribution] | None:
-    """Return top-K signed log-odds contributions for a logistic pipeline.
+    """Return top-K signed log-odds contributions for the loaded model.
 
-    Contribution_i = coef_i × (x_i − mean_i) / scale_i, i.e. the per-feature
-    push on the log-odds produced by the ``lr`` step of the pipeline. Sum of
-    contributions + intercept = z = logit(home_win_prob) for an uncalibrated
-    logistic model. Calibrated probabilities apply a monotone transform on
-    top, so the ordering of contributions stays meaningful as "which features
-    pushed hardest" even though the absolute sum no longer equals logit(p).
+    Both logistic and XGBoost produce per-feature contributions in log-odds
+    units — the dispatcher picks whichever path the artefact supports:
 
-    Returns ``None`` for non-logistic artefacts (ensemble/xgboost). Callers
-    should ``p.contributions = result`` either way — the UI hides its reasons
-    panel gracefully when the field is absent.
+    - **Logistic** (``loaded.pipeline`` is a sklearn ``Pipeline`` with
+      ``scale`` + ``lr`` steps): ``contribution_i = coef_i × (x_i − mean_i)
+      / scale_i``. Sum of contributions + intercept = logit(home_win_prob)
+      for the uncalibrated pipeline.
+
+    - **XGBoost** (``loaded.estimator`` is an ``XGBClassifier``): uses the
+      booster's built-in ``pred_contribs=True`` mode, which returns per-
+      feature contributions to the raw margin (log-odds-equivalent for
+      binary classification). Drops the bias column.
+
+    Ensemble artefacts currently return ``None`` — attributing a weighted
+    average of two correlated bases back to features doesn't have a clean
+    interpretation and nothing in the UI consumes it yet.
 
     ``builder`` + ``match`` are optional; when both are supplied we enrich
     specific rows with structured ``detail`` (today: the missing-regulars
     list behind ``key_absence_diff``).
     """
-    pipeline = getattr(loaded, "pipeline", None)
-    if pipeline is None:
-        return None
-    try:
-        scaler = pipeline.named_steps["scale"]
-        lr = pipeline.named_steps["lr"]
-    except (KeyError, AttributeError):
-        return None
-
     feature_names = getattr(loaded, "feature_names", None)
     if not feature_names:
         return None
 
     raw = np.asarray(x, dtype=float).reshape(-1)
-    mean = np.asarray(getattr(scaler, "mean_", None))
-    scale = np.asarray(getattr(scaler, "scale_", None))
-    coef = np.asarray(getattr(lr, "coef_", None)).reshape(-1)
-    if mean.shape != raw.shape or scale.shape != raw.shape or coef.shape != raw.shape:
+    if len(raw) != len(feature_names):
         return None
 
-    # Guard against a zero-variance column that would have shipped as
-    # scale_=0. sklearn normally replaces those with 1.0 but be defensive.
-    safe_scale = np.where(scale == 0.0, 1.0, scale)
-    contributions = coef * (raw - mean) / safe_scale
+    contributions = _logistic_raw_contribs(loaded, raw)
+    if contributions is None:
+        contributions = _xgboost_raw_contribs(loaded, x)
+    if contributions is None:
+        return None
 
     # Rank all features by |contribution|, then filter out sentinel/flag
     # rows before slicing to top_k. Filtering *after* the rank keeps us
@@ -450,6 +445,76 @@ def _compute_contributions(
         if len(picked) >= top_k:
             break
     return picked
+
+
+def _logistic_raw_contribs(loaded: Any, raw: np.ndarray) -> np.ndarray | None:
+    """Compute per-feature log-odds contributions for a logistic pipeline.
+
+    Returns ``None`` when ``loaded`` isn't a logistic pipeline — caller
+    dispatches to the XGBoost path in that case.
+    """
+    pipeline = getattr(loaded, "pipeline", None)
+    if pipeline is None:
+        return None
+    try:
+        scaler = pipeline.named_steps["scale"]
+        lr = pipeline.named_steps["lr"]
+    except (KeyError, AttributeError):
+        return None
+
+    mean = np.asarray(getattr(scaler, "mean_", None))
+    scale = np.asarray(getattr(scaler, "scale_", None))
+    coef = np.asarray(getattr(lr, "coef_", None)).reshape(-1)
+    if mean.shape != raw.shape or scale.shape != raw.shape or coef.shape != raw.shape:
+        return None
+
+    # Guard against a zero-variance column that would have shipped as
+    # scale_=0. sklearn normally replaces those with 1.0 but be defensive.
+    safe_scale = np.where(scale == 0.0, 1.0, scale)
+    return coef * (raw - mean) / safe_scale
+
+
+def _xgboost_raw_contribs(loaded: Any, x: np.ndarray) -> np.ndarray | None:
+    """Compute per-feature margin contributions for an XGBoost estimator.
+
+    Uses the booster's ``pred_contribs=True`` mode, which returns per-
+    sample, per-feature contributions in raw-margin (log-odds for binary
+    classification). The final column is the bias and is dropped. Returns
+    ``None`` if the artefact isn't an XGBoost model or xgboost isn't
+    importable in this environment (macOS without libomp).
+    """
+    estimator = getattr(loaded, "estimator", None)
+    if estimator is None:
+        return None
+    get_booster = getattr(estimator, "get_booster", None)
+    if not callable(get_booster):
+        return None
+
+    try:
+        import xgboost as xgb  # noqa: PLC0415
+    except Exception:  # pragma: no cover — libomp-missing safety net
+        return None
+
+    try:
+        booster = get_booster()
+    except Exception:
+        return None
+
+    feature_names = getattr(loaded, "feature_names", None)
+    try:
+        dmatrix = xgb.DMatrix(
+            np.asarray(x, dtype=float),
+            feature_names=list(feature_names) if feature_names else None,
+        )
+        contribs = booster.predict(dmatrix, pred_contribs=True)
+    except Exception:
+        return None
+
+    arr = np.asarray(contribs)
+    if arr.ndim != 2 or arr.shape[0] < 1:
+        return None
+    # Last column is the bias term; drop it to align with feature_names.
+    return arr[0, :-1]
 
 
 def _contribution_detail(feature: str, builder: Any, match: Any) -> dict[str, Any] | None:

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -465,6 +465,48 @@ def test_compute_contributions_filters_sentinel_and_flag_features() -> None:
     assert "key_absence_diff" not in surfaced
 
 
+def test_compute_contributions_dispatches_to_xgboost() -> None:
+    """XGBoost artefacts use pred_contribs instead of coef × scaled-feature,
+    but the returned shape is the same (top-K FeatureContribution list) and
+    the sentinel filter still applies."""
+    try:
+        from xgboost import XGBClassifier
+
+        from fantasy_coach.models.xgboost_model import LoadedModel as XGBLoaded
+    except Exception:
+        pytest.skip("xgboost / libomp not importable")
+
+    from fantasy_coach.feature_engineering import FEATURE_NAMES
+
+    rng = np.random.default_rng(7)
+    n = 120
+    X = rng.standard_normal((n, len(FEATURE_NAMES)))
+    # Make feature 0 carry real signal; seed a few constant sentinel columns.
+    y = (X[:, 0] > 0).astype(int)
+    X[:, FEATURE_NAMES.index("is_home_field")] = 1.0
+    X[:, FEATURE_NAMES.index("missing_weather")] = 0.0
+
+    est = XGBClassifier(n_estimators=40, max_depth=3, eval_metric="logloss", verbosity=0)
+    est.fit(X, y)
+    loaded = XGBLoaded(estimator=est, feature_names=FEATURE_NAMES)
+
+    # Same inference row the logistic ablation used — strong signal on feat 0.
+    x = np.zeros((1, len(FEATURE_NAMES)))
+    x[0, 0] = 2.0
+    x[0, FEATURE_NAMES.index("is_home_field")] = 1.0
+    x[0, FEATURE_NAMES.index("missing_weather")] = 0.0
+
+    contribs = _compute_contributions(loaded, x, top_k=5)
+    assert contribs is not None
+    surfaced = {c.feature for c in contribs}
+    # Sentinel / flag features never surface, no matter how large their
+    # coefficient/split contribution happens to be.
+    assert "is_home_field" not in surfaced
+    assert "missing_weather" not in surfaced
+    # Top contribution has the real signal feature at rank 1.
+    assert contribs[0].feature == "elo_diff"  # FEATURE_NAMES[0]
+
+
 def test_compute_contributions_enriches_key_absence_with_missing_players() -> None:
     """When builder + match are provided, ``key_absence_diff`` gets a
     structured detail list of missing-regular players the UI can render."""


### PR DESCRIPTION
## Summary
Promotes XGBoost to the production artefact. Two code paths needed:

**1. Contributions dispatcher** — `_compute_contributions` now picks between:
- `_logistic_raw_contribs`: `coef × (x − mean) / scale` (unchanged behaviour).
- `_xgboost_raw_contribs`: booster `predict(pred_contribs=True)` — per-feature margin contributions (log-odds-equivalent for binary classification). Bias column dropped.

Both return a same-shape vector so the downstream sentinel filter + detail enrichment + top-K slice is shared. Ensemble still returns None — separate follow-up if attribution becomes useful there.

**2. `train-xgboost` CLI** — mirrors `train-logistic`; produces an XGBoost `.joblib` at the same shape. `models.loader.load_model` dispatches by the `model_type` field in the blob, so either artefact can serve at the GCS path without code changes.

## Why now
- #27 ablation: XGBoost +2.1pp acc, improves log_loss + brier, logistic regresses on log_loss.
- #109 ablation: XGBoost +2.1pp acc, improves all three, logistic regresses + learns wrong-sign coefficient on `player_strength_diff`.
- #26 ablation: XGBoost +0.9pp acc, improves all three; logistic also improves but smaller.
- Compounding evidence: three feature additions, three ablations, XGBoost wins each time. The `player_strength_diff` sign bug (#136's original scope) disappears because tree splits handle correlation natively.

## Operator steps (post-merge)
```bash
uv run python -m fantasy_coach train-xgboost --season 2024 --season 2025 \
  --db data/nrl.db --out artifacts/xgboost.joblib

# Path keeps the old name from #93 — renaming is a trivial follow-up.
gcloud storage cp artifacts/xgboost.joblib \
  gs://fantasy-coach-lcd-models/logistic/latest.joblib

gcloud run jobs execute fantasy-coach-precompute \
  --region australia-southeast1 --wait
```

## Test plan
- [x] `uv run pytest` — 369 tests pass. New `test_compute_contributions_dispatches_to_xgboost` verifies the xgboost path returns the right shape + sentinel filter still trims `is_home_field` + `missing_weather`.
- [x] `ruff check` + `ruff format --check` — clean.
- [x] Manually verified: loading the retrained `artifacts/xgboost.joblib` + computing contributions on the live Dragons round-8 feature vector returns 5 sensible rows (no sentinels, real feature names).
- [ ] Post-merge + operator steps: Dragons round-8 `/predictions` contributions now come from XGBoost (tree splits, not logistic coefs). Spot-check that sign-of-contribution lines up with sign-of-value for the high-confidence picks (no more `player_strength_diff` wrong-sign).

## Follow-ups still open
- **#137** — UI label for `player_strength_diff` + odds. The sign-guard half of that issue becomes moot after this lands.
- **Naming drift** — the GCS path is `logistic/latest.joblib` but now hosts an XGBoost artefact. Rename once, then delete the legacy path. Small follow-up (needs paired deploy.yml edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)