### PR TITLE
feat: three-way consensus panel + player_strength_diff label (#140, #137)

### DIFF
--- a/src/fantasy_coach/predictions.py
+++ b/src/fantasy_coach/predictions.py
@@ -411,6 +411,8 @@ _SENTINEL_PREDICATES: dict[str, Callable[[float], bool]] = {
     "ref_home_penalty_diff": lambda v: v == 0.0,  # no ref penalty data
     "key_absence_diff": lambda v: v == 0.0,  # no missing regulars today
     "h2h_recent_diff": lambda v: v == 0.0,  # no recent head-to-head
+    "missing_player_strength": lambda v: v < 0.5,  # hide when we *do* have player data
+    "missing_odds": lambda v: v < 0.5,  # hide when odds data is present
 }
 
 

--- a/src/fantasy_coach/predictions.py
+++ b/src/fantasy_coach/predictions.py
@@ -36,7 +36,10 @@ logger = logging.getLogger(__name__)
 PREDICTIONS_DB_ENV = "FANTASY_COACH_PREDICTIONS_DB_PATH"
 MODEL_PATH_ENV = "FANTASY_COACH_MODEL_PATH"
 MODEL_GCS_URI_ENV = "FANTASY_COACH_MODEL_GCS_URI"
+LOGISTIC_PATH_ENV = "FANTASY_COACH_LOGISTIC_PATH"
+LOGISTIC_GCS_URI_ENV = "FANTASY_COACH_LOGISTIC_GCS_URI"
 DEFAULT_MODEL_PATH = "artifacts/logistic.joblib"
+DEFAULT_LOGISTIC_PATH = "artifacts/logistic.joblib"
 DEFAULT_PREDICTIONS_DB = "data/predictions.db"
 
 _CREATE_TABLE = """
@@ -55,6 +58,7 @@ CREATE TABLE IF NOT EXISTS predictions (
     feature_hash     TEXT    NOT NULL,
     created_at       TEXT    NOT NULL,
     contributions    TEXT,
+    alternatives     TEXT,
     PRIMARY KEY (season, round, match_id)
 );
 """
@@ -92,6 +96,26 @@ class FeatureContribution(BaseModel):
     detail: dict[str, Any] | None = None
 
 
+class PickSummary(BaseModel):
+    """Compact pick + probability for one source in the three-way consensus panel."""
+
+    predictedWinner: str  # "home" | "away"
+    homeWinProbability: float
+
+
+class AlternativeModels(BaseModel):
+    """Secondary picks shown alongside the primary XGBoost prediction.
+
+    Both fields are optional: ``logistic`` is absent when the logistic
+    artefact path isn't configured (``FANTASY_COACH_LOGISTIC_PATH`` unset);
+    ``bookmaker`` is absent when odds data wasn't available for the match
+    (``missing_odds`` feature = 1.0).
+    """
+
+    logistic: PickSummary | None = None
+    bookmaker: PickSummary | None = None
+
+
 class PredictionOut(BaseModel):
     matchId: int
     home: TeamInfo
@@ -109,6 +133,9 @@ class PredictionOut(BaseModel):
     # break existing SPA clients that ignore unknown fields).
     predictedMargin: float | None = None  # E[home_score - away_score]
     marginCi95: tuple[int, int] | None = None  # (lo, hi) at 2.5/97.5 pct
+    # Three-way consensus (#140): logistic + bookmaker picks alongside the
+    # primary XGBoost pick. Absent on predictions cached before #140 shipped.
+    alternatives: AlternativeModels | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -130,11 +157,12 @@ class PredictionStore:
         self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(_CREATE_TABLE)
-        # Forward-compat for DB files created before #58 shipped — adds the
-        # new column in place; no-op on a fresh DB since CREATE TABLE above
-        # already includes it.
+        # Forward-compat migrations — each ALTER TABLE is a no-op on a fresh
+        # DB (CREATE TABLE above already defines the column).
         with contextlib.suppress(sqlite3.OperationalError):
             self._conn.execute("ALTER TABLE predictions ADD COLUMN contributions TEXT")
+        with contextlib.suppress(sqlite3.OperationalError):
+            self._conn.execute("ALTER TABLE predictions ADD COLUMN alternatives TEXT")
 
     def close(self) -> None:
         self._conn.close()
@@ -155,6 +183,9 @@ class PredictionStore:
                     if p.contributions is not None
                     else None
                 )
+                alts_json = (
+                    json.dumps(p.alternatives.model_dump()) if p.alternatives is not None else None
+                )
                 self._conn.execute(
                     """
                     INSERT OR REPLACE INTO predictions
@@ -162,8 +193,8 @@ class PredictionStore:
                          home_id, home_name, away_id, away_name,
                          kickoff, predicted_winner, home_win_prob,
                          model_version, feature_hash, created_at,
-                         contributions)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                         contributions, alternatives)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         season,
@@ -180,16 +211,20 @@ class PredictionStore:
                         p.featureHash,
                         now,
                         contribs_json,
+                        alts_json,
                     ),
                 )
 
 
 def _row_to_out(r: sqlite3.Row) -> PredictionOut:
     # sqlite3.Row exposes column names via .keys(); plain `in r` iterates values.
-    contribs_raw = r["contributions"] if "contributions" in tuple(r.keys()) else None
+    cols = tuple(r.keys())
+    contribs_raw = r["contributions"] if "contributions" in cols else None
     contribs = (
         [FeatureContribution(**c) for c in json.loads(contribs_raw)] if contribs_raw else None
     )
+    alts_raw = r["alternatives"] if "alternatives" in cols else None
+    alternatives = AlternativeModels(**json.loads(alts_raw)) if alts_raw else None
     return PredictionOut(
         matchId=r["match_id"],
         home=TeamInfo(id=r["home_id"], name=r["home_name"]),
@@ -200,6 +235,7 @@ def _row_to_out(r: sqlite3.Row) -> PredictionOut:
         modelVersion=r["model_version"],
         featureHash=r["feature_hash"],
         contributions=contribs,
+        alternatives=alternatives,
     )
 
 
@@ -530,6 +566,63 @@ def _contribution_detail(feature: str, builder: Any, match: Any) -> dict[str, An
     return None
 
 
+def _bookmaker_pick_summary(x: np.ndarray, feature_names: tuple[str, ...]) -> PickSummary | None:
+    """Derive a bookmaker-implied pick from the odds_home_win_prob feature.
+
+    Returns None when odds data is absent (``missing_odds`` = 1.0) or when
+    the feature names tuple doesn't contain the expected columns.
+    """
+    try:
+        odds_idx = feature_names.index("odds_home_win_prob")
+        missing_idx = feature_names.index("missing_odds")
+    except ValueError:
+        return None
+    raw = np.asarray(x, dtype=float).reshape(-1)
+    if len(raw) <= max(odds_idx, missing_idx):
+        return None
+    if raw[missing_idx] > 0.5:  # odds not available for this match
+        return None
+    prob = round(float(raw[odds_idx]), 4)
+    return PickSummary(
+        predictedWinner="home" if prob >= 0.5 else "away",
+        homeWinProbability=prob,
+    )
+
+
+def _try_load_secondary_model(path: Path, gcs_uri_env: str) -> Any | None:
+    """Load an optional secondary model artefact; return None on any failure.
+
+    Used for the alternatives panel (#140): loads the logistic artefact
+    alongside the primary XGBoost model so both picks can be shown. Returns
+    None silently when the file is missing and no GCS URI is configured, so
+    the absence of a secondary model never blocks prediction computation.
+    """
+    try:
+        if not path.exists():
+            gcs_uri = os.getenv(gcs_uri_env)
+            if not gcs_uri:
+                return None
+            if not gcs_uri.startswith("gs://"):
+                logger.warning("Secondary model GCS URI malformed: %s", gcs_uri)
+                return None
+            bucket_name, _, blob_name = gcs_uri.removeprefix("gs://").partition("/")
+            if not bucket_name or not blob_name:
+                logger.warning("Secondary model GCS URI malformed: %s", gcs_uri)
+                return None
+            from google.cloud import storage as gcs  # noqa: PLC0415
+
+            path.parent.mkdir(parents=True, exist_ok=True)
+            logger.info("Downloading secondary model from %s to %s", gcs_uri, path)
+            client = gcs.Client()
+            client.bucket(bucket_name).blob(blob_name).download_to_filename(str(path))
+        return load_model(path)
+    except Exception:
+        logger.debug(
+            "Secondary model not available at %s — alternatives panel will be partial", path
+        )
+        return None
+
+
 def _build_inference_state(history: list[MatchRow]) -> FeatureBuilder:
     builder = FeatureBuilder()
     for match in sorted(history, key=lambda m: (m.start_time, m.match_id)):
@@ -552,6 +645,7 @@ def compute_predictions(
     store: PredictionStore,
     *,
     model_path: Path | None = None,
+    logistic_path: Path | None = None,
     fetch_round_fn: Any = fetch_round,
     fetch_match_fn: Any = fetch_match_from_url,
     force: bool = False,
@@ -583,7 +677,7 @@ def compute_predictions(
             )
             return cached
 
-    # Resolve and load the model — fetching from GCS on first miss if
+    # Resolve and load the primary model — fetching from GCS on first miss if
     # FANTASY_COACH_MODEL_GCS_URI is set (production path).
     path = model_path or Path(os.getenv(MODEL_PATH_ENV, DEFAULT_MODEL_PATH))
     _ensure_model(path)
@@ -591,6 +685,13 @@ def compute_predictions(
     loaded = load_model(path)
     mv = _model_version(path)
     fh = _feature_hash()
+
+    # Load the secondary logistic model for the three-way consensus panel (#140).
+    # Returns None when unconfigured — alternatives.logistic will be absent.
+    log_path = logistic_path or Path(os.getenv(LOGISTIC_PATH_ENV, DEFAULT_LOGISTIC_PATH))
+    logistic_loaded = None
+    if log_path != path:  # skip if operator pointed both models at the same artefact
+        logistic_loaded = _try_load_secondary_model(log_path, LOGISTIC_GCS_URI_ENV)
 
     # Scrape fixtures for the requested round
     round_payload = fetch_round_fn(season, round_)
@@ -634,10 +735,28 @@ def compute_predictions(
 
     builder = _build_inference_state(history)
 
+    _fn = getattr(loaded, "feature_names", None)
+    feature_names: tuple[str, ...] = _fn if isinstance(_fn, tuple) else FEATURE_NAMES
     predictions: list[PredictionOut] = []
     for match in sorted(round_matches, key=lambda m: (m.start_time, m.match_id)):
         x = np.asarray([builder.feature_row(match)], dtype=float)
         prob = round(float(loaded.predict_home_win_prob(x)[0]), 4)
+
+        # Build the three-way consensus alternatives (#140).
+        logistic_pick: PickSummary | None = None
+        if logistic_loaded is not None:
+            lprob = round(float(logistic_loaded.predict_home_win_prob(x)[0]), 4)
+            logistic_pick = PickSummary(
+                predictedWinner="home" if lprob >= 0.5 else "away",
+                homeWinProbability=lprob,
+            )
+        bm_pick = _bookmaker_pick_summary(x, feature_names)
+        alternatives = (
+            AlternativeModels(logistic=logistic_pick, bookmaker=bm_pick)
+            if (logistic_pick is not None or bm_pick is not None)
+            else None
+        )
+
         predictions.append(
             PredictionOut(
                 matchId=match.match_id,
@@ -649,6 +768,7 @@ def compute_predictions(
                 modelVersion=mv,
                 featureHash=fh,
                 contributions=_compute_contributions(loaded, x, builder=builder, match=match),
+                alternatives=alternatives,
             )
         )
 

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -21,15 +21,19 @@ from sklearn.preprocessing import StandardScaler
 from fantasy_coach.app import app
 from fantasy_coach.features import extract_match_features
 from fantasy_coach.predictions import (
+    AlternativeModels,
     FeatureContribution,
     FirestorePredictionStore,
+    PickSummary,
     PredictionOut,
     PredictionStore,
     TeamInfo,
+    _bookmaker_pick_summary,
     _compute_contributions,
     _ensure_model,
     _feature_hash,
     _record_team_list_snapshots,
+    _try_load_secondary_model,
     compute_predictions,
     get_prediction_store,
 )
@@ -932,3 +936,230 @@ def test_endpoint_returns_cached_predictions(client: TestClient, tmp_path: Path)
     assert pred["homeWinProbability"] == 0.65
     assert pred["modelVersion"] == "abc123"
     assert "featureHash" in pred
+
+
+# ---------------------------------------------------------------------------
+# _bookmaker_pick_summary — bookmaker implied pick (#140)
+# ---------------------------------------------------------------------------
+
+
+def test_bookmaker_pick_summary_returns_pick_when_odds_available() -> None:
+    from fantasy_coach.feature_engineering import FEATURE_NAMES
+
+    x = np.zeros((1, len(FEATURE_NAMES)))
+    odds_idx = FEATURE_NAMES.index("odds_home_win_prob")
+    missing_idx = FEATURE_NAMES.index("missing_odds")
+    x[0, odds_idx] = 0.72
+    x[0, missing_idx] = 0.0  # odds available
+
+    pick = _bookmaker_pick_summary(x, FEATURE_NAMES)
+    assert pick is not None
+    assert pick.predictedWinner == "home"
+    assert pick.homeWinProbability == pytest.approx(0.72)
+
+
+def test_bookmaker_pick_summary_away_when_prob_below_half() -> None:
+    from fantasy_coach.feature_engineering import FEATURE_NAMES
+
+    x = np.zeros((1, len(FEATURE_NAMES)))
+    x[0, FEATURE_NAMES.index("odds_home_win_prob")] = 0.38
+    x[0, FEATURE_NAMES.index("missing_odds")] = 0.0
+
+    pick = _bookmaker_pick_summary(x, FEATURE_NAMES)
+    assert pick is not None
+    assert pick.predictedWinner == "away"
+    assert pick.homeWinProbability == pytest.approx(0.38)
+
+
+def test_bookmaker_pick_summary_returns_none_when_odds_missing() -> None:
+    from fantasy_coach.feature_engineering import FEATURE_NAMES
+
+    x = np.zeros((1, len(FEATURE_NAMES)))
+    x[0, FEATURE_NAMES.index("odds_home_win_prob")] = 0.65
+    x[0, FEATURE_NAMES.index("missing_odds")] = 1.0  # no odds data
+
+    pick = _bookmaker_pick_summary(x, FEATURE_NAMES)
+    assert pick is None
+
+
+def test_bookmaker_pick_summary_returns_none_for_unknown_feature_names() -> None:
+    pick = _bookmaker_pick_summary(np.zeros((1, 3)), ("feat_a", "feat_b", "feat_c"))
+    assert pick is None
+
+
+# ---------------------------------------------------------------------------
+# _try_load_secondary_model — graceful loading of logistic artefact (#140)
+# ---------------------------------------------------------------------------
+
+
+def test_try_load_secondary_model_returns_none_when_missing_and_no_gcs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("FANTASY_COACH_LOGISTIC_GCS_URI", raising=False)
+    result = _try_load_secondary_model(
+        tmp_path / "missing.joblib", "FANTASY_COACH_LOGISTIC_GCS_URI"
+    )
+    assert result is None
+
+
+def test_try_load_secondary_model_loads_when_file_exists(tmp_path: Path) -> None:
+    from fantasy_coach.feature_engineering import FEATURE_NAMES, TrainingFrame
+    from fantasy_coach.models.logistic import save_model, train_logistic
+
+    rng = np.random.default_rng(0)
+    n = 60
+    X = rng.standard_normal((n, len(FEATURE_NAMES)))
+    y = (X[:, 0] > 0).astype(int)
+    frame = TrainingFrame(
+        X=X,
+        y=y,
+        match_ids=np.arange(n),
+        start_times=np.arange(n, dtype=float),
+        feature_names=FEATURE_NAMES,
+    )
+    result = train_logistic(frame, test_fraction=0.0)
+    model_path = tmp_path / "logistic.joblib"
+    save_model(result, model_path)
+
+    loaded = _try_load_secondary_model(model_path, "FANTASY_COACH_LOGISTIC_GCS_URI")
+    assert loaded is not None
+    x = np.zeros((1, len(FEATURE_NAMES)))
+    prob = loaded.predict_home_win_prob(x)
+    assert 0.0 <= prob[0] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# AlternativeModels round-trip through SQLite store (#140)
+# ---------------------------------------------------------------------------
+
+
+def test_store_roundtrips_alternatives(store: PredictionStore) -> None:
+    pred = PredictionOut(
+        matchId=55,
+        home=TeamInfo(id=1, name="A"),
+        away=TeamInfo(id=2, name="B"),
+        kickoff="2026-05-01T08:00:00+00:00",
+        predictedWinner="home",
+        homeWinProbability=0.65,
+        modelVersion="mv",
+        featureHash="fh",
+        alternatives=AlternativeModels(
+            logistic=PickSummary(predictedWinner="away", homeWinProbability=0.45),
+            bookmaker=PickSummary(predictedWinner="home", homeWinProbability=0.68),
+        ),
+    )
+    store.put(2026, 8, [pred])
+    loaded = store.get(2026, 8)
+    assert len(loaded) == 1
+    alts = loaded[0].alternatives
+    assert alts is not None
+    assert alts.logistic is not None
+    assert alts.logistic.predictedWinner == "away"
+    assert alts.logistic.homeWinProbability == pytest.approx(0.45)
+    assert alts.bookmaker is not None
+    assert alts.bookmaker.predictedWinner == "home"
+    assert alts.bookmaker.homeWinProbability == pytest.approx(0.68)
+
+
+def test_store_roundtrips_null_alternatives(store: PredictionStore) -> None:
+    pred = PredictionOut(
+        matchId=56,
+        home=TeamInfo(id=1, name="A"),
+        away=TeamInfo(id=2, name="B"),
+        kickoff="2026-05-01T08:00:00+00:00",
+        predictedWinner="home",
+        homeWinProbability=0.7,
+        modelVersion="mv",
+        featureHash="fh",
+        # alternatives intentionally absent
+    )
+    store.put(2026, 8, [pred])
+    loaded = store.get(2026, 8)
+    assert loaded[0].alternatives is None
+
+
+# ---------------------------------------------------------------------------
+# compute_predictions — alternatives populated when logistic model present (#140)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_populates_alternatives_when_logistic_model_provided(
+    store: PredictionStore, sqlite_repo: SQLiteRepository, tmp_path: Path
+) -> None:
+    from fantasy_coach.feature_engineering import FEATURE_NAMES, TrainingFrame
+    from fantasy_coach.models.logistic import save_model, train_logistic
+
+    raw_match = _load_fixture(UPCOMING_FIXTURE)
+    mock_round = MagicMock(return_value=_sample_round_payload("/match/url"))
+    mock_match = MagicMock(return_value=raw_match)
+
+    # Primary model (mock — stands in for XGBoost)
+    primary_model = _make_mock_model(0.72)
+    primary_path = tmp_path / "primary.joblib"
+    primary_path.write_bytes(b"primary-bytes")
+
+    # Secondary logistic model (real — needs proper feature_names for bookmaker pick)
+    rng = np.random.default_rng(1)
+    n = 60
+    X = rng.standard_normal((n, len(FEATURE_NAMES)))
+    y = (X[:, 0] > 0).astype(int)
+    frame = TrainingFrame(
+        X=X,
+        y=y,
+        match_ids=np.arange(n),
+        start_times=np.arange(n, dtype=float),
+        feature_names=FEATURE_NAMES,
+    )
+    logistic_result = train_logistic(frame, test_fraction=0.0)
+    logistic_path = tmp_path / "logistic.joblib"
+    save_model(logistic_result, logistic_path)
+
+    with patch("fantasy_coach.predictions.load_model", return_value=primary_model):
+        result = compute_predictions(
+            2026,
+            8,
+            sqlite_repo,
+            store,
+            model_path=primary_path,
+            logistic_path=logistic_path,
+            fetch_round_fn=mock_round,
+            fetch_match_fn=mock_match,
+        )
+
+    assert len(result) == 1
+    pred = result[0]
+    assert pred.alternatives is not None
+    # Logistic pick must be present and valid
+    assert pred.alternatives.logistic is not None
+    assert pred.alternatives.logistic.predictedWinner in ("home", "away")
+    assert 0.0 <= pred.alternatives.logistic.homeWinProbability <= 1.0
+
+
+def test_compute_alternatives_absent_when_same_path(
+    store: PredictionStore, sqlite_repo: SQLiteRepository, tmp_path: Path
+) -> None:
+    """When primary and logistic paths point at the same artefact, skip secondary load."""
+    raw_match = _load_fixture(UPCOMING_FIXTURE)
+    mock_round = MagicMock(return_value=_sample_round_payload("/match/url"))
+    mock_match = MagicMock(return_value=raw_match)
+    mock_model = _make_mock_model(0.55)
+    same_path = tmp_path / "model.joblib"
+    same_path.write_bytes(b"bytes")
+
+    with patch("fantasy_coach.predictions.load_model", return_value=mock_model):
+        result = compute_predictions(
+            2026,
+            8,
+            sqlite_repo,
+            store,
+            model_path=same_path,
+            logistic_path=same_path,  # same as primary
+            fetch_round_fn=mock_round,
+            fetch_match_fn=mock_match,
+        )
+
+    assert len(result) == 1
+    # alternatives may be None or only have bookmaker (odds-based) — logistic must not be set
+    pred = result[0]
+    if pred.alternatives is not None:
+        assert pred.alternatives.logistic is None

--- a/web/src/components/MatchCard.tsx
+++ b/web/src/components/MatchCard.tsx
@@ -3,7 +3,18 @@ import { Link } from "react-router-dom";
 import { TeamFormSparkline } from "./TeamFormSparkline";
 import { TipEntry } from "./TipEntry";
 import type { TipChoice } from "../tips";
-import type { Prediction, TeamFormHistory } from "../types";
+import type { AlternativeModels, Prediction, TeamFormHistory } from "../types";
+
+function consensusStatus(
+  primaryWinner: "home" | "away",
+  alternatives: AlternativeModels | null | undefined,
+): "unanimous" | "split" | null {
+  if (!alternatives) return null;
+  const others = [alternatives.logistic, alternatives.bookmaker].filter(Boolean);
+  if (others.length === 0) return null;
+  const allAgree = others.every((p) => p!.predictedWinner === primaryWinner);
+  return allAgree ? "unanimous" : "split";
+}
 
 function formatKickoff(iso: string): string {
   const d = new Date(iso);
@@ -95,6 +106,23 @@ export function MatchCard({
         <p className="pick">
           Pick: <strong>{winnerName}</strong> ({winnerPct}%)
         </p>
+
+        {(() => {
+          const status = consensusStatus(p.predictedWinner, p.alternatives);
+          if (!status) return null;
+          return (
+            <span
+              className={`consensus-badge consensus-badge--${status}`}
+              aria-label={
+                status === "unanimous"
+                  ? "All sources agree on this pick"
+                  : "Sources disagree on this pick"
+              }
+            >
+              {status === "unanimous" ? "Consensus" : "Split pick"}
+            </span>
+          );
+        })()}
 
         {preview ? <p className="preview">{preview}</p> : null}
 

--- a/web/src/features.ts
+++ b/web/src/features.ts
@@ -153,6 +153,14 @@ function describe(
       const disadvantaged = value >= 0 ? home : away;
       return `${disadvantaged} missing weighted regulars (${rounded(mag)})`;
     }
+    case "player_strength_diff": {
+      // Availability-adjusted composite lineup rating (player Elo × position weight).
+      // Positive = home named XIII is rated stronger overall.
+      const who = teamFavoured(value, home, away);
+      return `${who}'s named lineup rated ${rounded(mag, 0)} points stronger`;
+    }
+    case "missing_player_strength":
+      return value > 0.5 ? "Player strength data unavailable" : "Player strength data available";
     default:
       // Fallback for unknown feature names (e.g. future feature additions).
       return `${feature} = ${rounded(value, 2)}`;

--- a/web/src/routes/MatchDetail.tsx
+++ b/web/src/routes/MatchDetail.tsx
@@ -6,7 +6,7 @@ import { useAuth } from "../auth";
 import { TeamFormChart } from "../components/TeamFormChart";
 import { labelFor } from "../features";
 import { SignInRequired } from "../components/SignInRequired";
-import type { Prediction, TeamFormHistory } from "../types";
+import type { AlternativeModels, PickSummary, Prediction, TeamFormHistory } from "../types";
 
 type Status =
   | { kind: "loading" }
@@ -132,6 +132,73 @@ export default function MatchDetail() {
 
 const MOBILE_TOP = 3;
 
+type ConsensusRow = {
+  label: string;
+  pick: PickSummary;
+  isPrimary?: boolean;
+};
+
+function ConsensusPanel({
+  primary,
+  alternatives,
+  home,
+  away,
+}: {
+  primary: PickSummary;
+  alternatives: AlternativeModels;
+  home: string;
+  away: string;
+}) {
+  const rows: ConsensusRow[] = [
+    { label: "XGBoost", pick: primary, isPrimary: true },
+    ...(alternatives.logistic ? [{ label: "Logistic", pick: alternatives.logistic }] : []),
+    ...(alternatives.bookmaker ? [{ label: "Market", pick: alternatives.bookmaker }] : []),
+  ];
+
+  const allAgree = rows.every((r) => r.pick.predictedWinner === primary.predictedWinner);
+  const winnerName = primary.predictedWinner === "home" ? home : away;
+
+  return (
+    <section className="consensus-panel" aria-labelledby="consensus-heading">
+      <h2 id="consensus-heading">Three-way consensus</h2>
+      {allAgree && rows.length === 3 ? (
+        <div className="consensus-unanimous" role="status">
+          <span className="consensus-badge consensus-badge--agree">Unanimous</span>
+          <p>
+            All three sources agree: <strong>{winnerName}</strong> wins.
+          </p>
+        </div>
+      ) : null}
+      <ol className="consensus-list">
+        {rows.map((row) => {
+          const agrees = row.pick.predictedWinner === primary.predictedWinner;
+          const pct = Math.round(row.pick.homeWinProbability * 100);
+          const pickName = row.pick.predictedWinner === "home" ? home : away;
+          return (
+            <li key={row.label} className="consensus-row">
+              <span className="consensus-source">{row.label}</span>
+              <span className="consensus-pick">
+                <strong>{pickName}</strong> ({row.pick.predictedWinner === "home" ? pct : 100 - pct}%)
+              </span>
+              {!row.isPrimary && (
+                <span
+                  className={`consensus-badge consensus-badge--${agrees ? "agree" : "disagree"}`}
+                  aria-label={agrees ? "Agrees with primary" : "Disagrees with primary"}
+                >
+                  {agrees ? "agree" : "disagree"}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+      <p className="muted fine-print">
+        XGBoost is the primary pick. Logistic and Market are shown for cross-reference only.
+      </p>
+    </section>
+  );
+}
+
 function MatchDetailBody({
   prediction,
   homeForm,
@@ -233,6 +300,20 @@ function MatchDetailBody({
           This prediction was generated before per-feature explanations were available.
         </p>
       )}
+
+      {prediction.alternatives &&
+        (prediction.alternatives.logistic != null ||
+          prediction.alternatives.bookmaker != null) && (
+          <ConsensusPanel
+            primary={{
+              predictedWinner: prediction.predictedWinner,
+              homeWinProbability: prediction.homeWinProbability,
+            }}
+            alternatives={prediction.alternatives}
+            home={prediction.home.name}
+            away={prediction.away.name}
+          />
+        )}
     </article>
   );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1020,3 +1020,101 @@ a:focus-visible {
   padding: 0.1rem 0.3rem;
   border-radius: 3px;
 }
+
+/* ── Three-way consensus panel (#140) ───────────────────────────────────── */
+
+.consensus-panel {
+  margin-top: 2rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem 1.5rem;
+}
+
+.consensus-panel h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+}
+
+.consensus-unanimous {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.consensus-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.consensus-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.consensus-source {
+  min-width: 5rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+
+.consensus-pick {
+  flex: 1;
+}
+
+/* Badges — used both in the consensus panel and on MatchCard */
+.consensus-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 0.15rem 0.45rem;
+  border-radius: var(--radius-full);
+}
+
+.consensus-badge--agree,
+.consensus-badge--unanimous {
+  background: #e6f4ea;
+  color: #1e6e35;
+}
+
+.consensus-badge--disagree {
+  background: #fdecea;
+  color: var(--color-error-text);
+}
+
+.consensus-badge--split {
+  background: #fff3e0;
+  color: #7a4f00;
+}
+
+[data-theme="dark"] .consensus-badge--agree,
+[data-theme="dark"] .consensus-badge--unanimous {
+  background: #0d2b15;
+  color: #68d391;
+}
+
+[data-theme="dark"] .consensus-badge--disagree {
+  background: var(--color-error-bg);
+  color: var(--color-error-text);
+}
+
+[data-theme="dark"] .consensus-badge--split {
+  background: #2d1f00;
+  color: #f6c90e;
+}
+
+/* Inline badge on MatchCard */
+.match-card .consensus-badge {
+  margin-top: 0.25rem;
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -28,6 +28,16 @@ export type FeatureContribution = {
   } | null;
 };
 
+export type PickSummary = {
+  predictedWinner: "home" | "away";
+  homeWinProbability: number;
+};
+
+export type AlternativeModels = {
+  logistic?: PickSummary | null;
+  bookmaker?: PickSummary | null;
+};
+
 export type Prediction = {
   matchId: number;
   home: Team;
@@ -39,6 +49,8 @@ export type Prediction = {
   featureHash: string;
   contributions?: FeatureContribution[] | null;
   actualWinner?: "home" | "away" | null;
+  // Three-way consensus (#140): absent on predictions cached before #140 shipped.
+  alternatives?: AlternativeModels | null;
 };
 
 export type RoundAccuracy = {


### PR DESCRIPTION
## Summary

### #140 — Three-way consensus panel (XGBoost + logistic + bookmaker)

- **Backend**: New `PickSummary` / `AlternativeModels` Pydantic models on `PredictionOut`. `compute_predictions` loads a secondary logistic artefact (configurable via `FANTASY_COACH_LOGISTIC_PATH` / `FANTASY_COACH_LOGISTIC_GCS_URI`) and derives the bookmaker implied pick directly from `odds_home_win_prob` in the feature vector. Failure to load the secondary model is silent — the precompute Job is never blocked.
- **Storage**: SQLite gains an `alternatives TEXT` column with a forward-compat `ALTER TABLE` migration; Firestore handles the new field automatically via Pydantic serialisation.
- **Frontend**: `ConsensusPanel` on MatchDetail shows three rows (XGBoost / Logistic / Market) each with agree/disagree badges; collapses to a single "Unanimous" card when all three agree. `MatchCard` gains a subtle inline badge ("Consensus" / "Split pick") when alternatives are populated. Older cached predictions without `alternatives` gracefully hide the panel.

### #137 — player_strength_diff label + missing_player_strength sentinel

- `web/src/features.ts`: Added `player_strength_diff` case (`"<Team>'s named lineup rated N points stronger"`); added `missing_player_strength` case for the data-availability flag.
- `src/fantasy_coach/predictions.py`: Added `missing_player_strength` and `missing_odds` to `_SENTINEL_PREDICATES` — these flag rows now hide themselves from the contribution list when data IS present.
- The sign-guard design question from #137 is superseded by the XGBoost promotion (#136): SHAP contributions have correct sign alignment so no client-side filter is needed.

## Test plan

- [ ] `uv run pytest` — 415 tests pass
- [ ] `cd web && npm run lint` — TypeScript type-check passes
- [ ] Manually verify MatchDetail consensus panel renders for a round with odds data
- [ ] Verify MatchDetail gracefully hides panel when `alternatives` is absent (older predictions)
- [ ] Verify MatchCard shows "Consensus" / "Split pick" badge on round grid
- [ ] Verify `player_strength_diff` contribution row renders meaningful text in the "Why this pick" list

Closes #140
Closes #137

https://claude.ai/code/session_01XHUnKnk7hXjMghCYBfhTKq