### PR TITLE
fix(sync): refresh stale match states so outcomes reach retrain

### DIFF
--- a/src/fantasy_coach/__main__.py
+++ b/src/fantasy_coach/__main__.py
@@ -505,6 +505,18 @@ def _run_precompute(args: argparse.Namespace) -> int:
             force=not args.no_force,
             team_list_repo=team_list_repo,
         )
+        # Refresh any previously-scraped matches whose outcomes should be
+        # known by now but weren't captured — the precompute flow only
+        # processes the *upcoming* round, so without this step rounds that
+        # kicked off and finished between Thu and the next Tue would stay
+        # stuck at ``Upcoming`` indefinitely, hiding them from /accuracy
+        # and dropping them from the retrain loop's holdout. See #107
+        # post-mortem on the round-8 Tigers/Raiders pick.
+        from fantasy_coach.match_sync import refresh_stale_matches  # noqa: PLC0415
+
+        refreshed = refresh_stale_matches(repo, season)
+        if refreshed:
+            print(f"Refreshed {refreshed} stale past-start-time matches in season {season}")
     finally:
         if hasattr(repo, "close"):
             repo.close()
@@ -671,6 +683,32 @@ def _run_retrain(args: argparse.Namespace) -> int:
 
     repo = get_repository()
     try:
+        # Pre-flight — refresh any stale match states so Sunday's matches
+        # reach the holdout with their real outcomes. Without this, the
+        # precompute Job's "current round only" scrape means matches that
+        # kicked off + finished since the last Tue scrape are still
+        # ``Upcoming`` in Firestore, and ``split_training_holdout`` drops
+        # them silently. Runs per season that the retrain actually covers.
+        from datetime import UTC as _UTC  # noqa: PLC0415
+        from datetime import datetime as _dt  # noqa: PLC0415
+
+        from fantasy_coach.match_sync import refresh_stale_matches  # noqa: PLC0415
+
+        seasons = args.season or (
+            _dt.now(_UTC).year - 2,
+            _dt.now(_UTC).year - 1,
+            _dt.now(_UTC).year,
+        )
+        for s in seasons:
+            try:
+                refreshed = refresh_stale_matches(repo, s)
+                if refreshed:
+                    print(f"Pre-flight: refreshed {refreshed} stale matches in season {s}")
+            except Exception:
+                logging.getLogger(__name__).exception(
+                    "pre-flight refresh_stale_matches failed for season %d — continuing", s
+                )
+
         result = run_retrain(
             repo,
             incumbent_path=args.incumbent_path,

--- a/src/fantasy_coach/match_sync.py
+++ b/src/fantasy_coach/match_sync.py
@@ -1,0 +1,142 @@
+"""Re-scrape match docs whose outcome should be known by now.
+
+Background: the precompute Job (#65) only scrapes the *current upcoming*
+round. Once a match kicks off and finishes, nothing in the pipeline
+re-visits that match row to capture the final state + scores. Rounds
+appear ``FullTime`` in Firestore today only because of manual
+``copy-matches-to-firestore`` runs after-the-fact — the first round to
+actually live through the precompute-only flow (2026 round 8) stayed
+stuck on ``Upcoming`` forever, which:
+
+- breaks the ``/accuracy`` endpoint (filters on ``match_state``).
+- breaks the retrain loop (#107) — ``split_training_holdout`` drops
+  non-FullTime matches, so round N's outcomes silently vanish from
+  the holdout the Monday after.
+
+``refresh_stale_matches`` finds every season-X match whose
+``start_time`` has already passed but whose stored ``match_state`` is
+not ``FullTime``, re-scrapes each via the existing ``fetch_round`` +
+``fetch_match_from_url`` pipeline, and upserts. Idempotent: a fresh
+re-scrape that still returns ``Upcoming`` (nrl.com hasn't updated yet)
+is a no-op; a later run picks it up.
+
+Called from the precompute Job (Tue + Thu) and the retrain Job's
+pre-flight (Mon) so a weekend round is guaranteed to reach the retrain
+loop with real outcomes.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+from fantasy_coach.features import extract_match_features
+from fantasy_coach.scraper import fetch_match_from_url, fetch_round
+from fantasy_coach.storage.repository import Repository
+
+logger = logging.getLogger(__name__)
+
+
+_FULLTIME_STATES = {"FullTime", "FullTimeED"}
+
+
+def refresh_stale_matches(
+    repo: Repository,
+    season: int,
+    *,
+    now: datetime | None = None,
+    fetch_round_fn: Callable = fetch_round,
+    fetch_match_fn: Callable = fetch_match_from_url,
+    max_rounds_back: int = 4,
+) -> int:
+    """Re-scrape any ``season`` match whose start_time < now and state is not FullTime.
+
+    Groups stale matches by round and re-scrapes each round once (one
+    ``fetch_round`` call) to keep request volume low; per-match details
+    are fetched individually because the round endpoint's fixture list
+    lacks scores / full state.
+
+    ``max_rounds_back`` caps how far back we iterate to avoid re-scraping
+    the whole season on a fresh DB. Four rounds covers any realistic gap
+    between precompute runs (every 3–4 days).
+
+    Returns count of matches whose docs were upserted (including those
+    that came back still ``Upcoming``, which is common for matches in
+    states like ``Live`` mid-broadcast).
+    """
+    now = now or datetime.now(UTC)
+
+    # Pull the full season once — Repository has no "where state != X"
+    # accessor, and a per-round pass would duplicate fetches. Season
+    # size is O(matches-per-season) which is fine in-memory.
+    all_matches = repo.list_matches(season)
+    stale_rounds: dict[int, list] = {}
+    for m in all_matches:
+        if m.match_state in _FULLTIME_STATES:
+            continue
+        # Ensure both are timezone-aware comparisons. start_time from the
+        # repo is timezone-aware ISO 8601; `now` is UTC here.
+        if m.start_time >= now:
+            continue
+        stale_rounds.setdefault(m.round, []).append(m)
+
+    if not stale_rounds:
+        logger.info("refresh_stale_matches: no stale matches for %d", season)
+        return 0
+
+    # Limit blast radius — stop after max_rounds_back most recent rounds.
+    kept_rounds = sorted(stale_rounds)[-max_rounds_back:]
+    logger.info(
+        "refresh_stale_matches: %d stale matches across rounds %s",
+        sum(len(stale_rounds[r]) for r in kept_rounds),
+        kept_rounds,
+    )
+
+    updated = 0
+    for round_ in kept_rounds:
+        try:
+            round_payload = fetch_round_fn(season, round_)
+        except Exception:
+            logger.exception("refresh_stale_matches: fetch_round failed for %d r%d", season, round_)
+            continue
+        if not round_payload:
+            continue
+        fixtures = round_payload.get("fixtures") or []
+
+        # Only re-scrape matches we already know are stale — saves calls
+        # against matches scheduled later in the same round.
+        stale_ids = {m.match_id for m in stale_rounds[round_]}
+        for fixture in fixtures:
+            url = fixture.get("matchCentreUrl")
+            if not url:
+                continue
+            try:
+                raw = fetch_match_fn(url)
+            except Exception:
+                logger.exception("refresh_stale_matches: fetch_match failed for %s", url)
+                continue
+            if raw is None:
+                continue
+            try:
+                row = extract_match_features(raw)
+            except Exception:
+                logger.exception("refresh_stale_matches: extract failed for %s", url)
+                continue
+            if row.match_id not in stale_ids:
+                continue
+            try:
+                repo.upsert_match(row)
+            except Exception:
+                logger.exception("refresh_stale_matches: upsert failed for %d", row.match_id)
+                continue
+            updated += 1
+            logger.info(
+                "refresh_stale_matches: %d r%d match %d state %s",
+                season,
+                round_,
+                row.match_id,
+                row.match_state,
+            )
+
+    return updated

--- a/tests/test_match_sync.py
+++ b/tests/test_match_sync.py
@@ -1,0 +1,255 @@
+"""Tests for :mod:`fantasy_coach.match_sync`."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from fantasy_coach.features import MatchRow, TeamRow
+from fantasy_coach.match_sync import refresh_stale_matches
+
+
+def _match(
+    *,
+    match_id: int,
+    season: int = 2026,
+    round: int = 8,
+    when: datetime,
+    state: str = "Upcoming",
+    home_score: int | None = None,
+    away_score: int | None = None,
+) -> MatchRow:
+    return MatchRow(
+        match_id=match_id,
+        season=season,
+        round=round,
+        start_time=when,
+        match_state=state,
+        venue=None,
+        venue_city=None,
+        weather=None,
+        home=TeamRow(
+            team_id=1,
+            name=f"home-{match_id}",
+            nick_name="H",
+            score=home_score,
+            players=[],
+        ),
+        away=TeamRow(
+            team_id=2,
+            name=f"away-{match_id}",
+            nick_name="A",
+            score=away_score,
+            players=[],
+        ),
+        team_stats=[],
+    )
+
+
+class _FakeRepo:
+    def __init__(self, matches: list[MatchRow]) -> None:
+        self._rows: dict[int, MatchRow] = {m.match_id: m for m in matches}
+        self.upserts: list[MatchRow] = []
+
+    def list_matches(self, season: int, round: int | None = None) -> list[MatchRow]:
+        return [
+            m
+            for m in self._rows.values()
+            if m.season == season and (round is None or m.round == round)
+        ]
+
+    def upsert_match(self, row: MatchRow) -> None:
+        self._rows[row.match_id] = row
+        self.upserts.append(row)
+
+    def get_match(self, match_id: int) -> MatchRow | None:  # pragma: no cover
+        return self._rows.get(match_id)
+
+
+def _raw_match_payload(match_id: int, state: str, h_score: int, a_score: int) -> dict:
+    """Minimal dict that ``extract_match_features`` will accept."""
+    return {
+        "matchId": str(match_id),
+        "matchState": state,
+        "startTime": "2026-04-23T09:50:00Z",
+        "roundNumber": 8,
+        "homeTeam": {
+            "teamId": 1,
+            "name": f"home-{match_id}",
+            "nickName": "H",
+            "score": h_score,
+            "players": [],
+        },
+        "awayTeam": {
+            "teamId": 2,
+            "name": f"away-{match_id}",
+            "nickName": "A",
+            "score": a_score,
+            "players": [],
+        },
+    }
+
+
+def test_refresh_stale_matches_upserts_past_start_upcoming_matches():
+    past = datetime(2026, 4, 23, 9, 50, tzinfo=UTC)
+    now = datetime(2026, 4, 24, 2, 0, tzinfo=UTC)
+    repo = _FakeRepo([_match(match_id=1, when=past, state="Upcoming")])
+
+    round_payload = {
+        "fixtures": [
+            {"matchCentreUrl": "/draw/match-1/"},
+        ]
+    }
+    per_match = {"/draw/match-1/": _raw_match_payload(1, "FullTime", 33, 14)}
+
+    updated = refresh_stale_matches(
+        repo,
+        season=2026,
+        now=now,
+        fetch_round_fn=lambda s, r: round_payload,
+        fetch_match_fn=lambda url: per_match.get(url),
+    )
+    assert updated == 1
+    assert repo._rows[1].match_state == "FullTime"
+    assert repo._rows[1].home.score == 33
+    assert repo._rows[1].away.score == 14
+
+
+def test_refresh_stale_matches_skips_future_matches():
+    future = datetime(2026, 5, 1, 9, 50, tzinfo=UTC)
+    now = datetime(2026, 4, 24, 2, 0, tzinfo=UTC)
+    repo = _FakeRepo([_match(match_id=1, when=future, state="Upcoming")])
+    calls: list[tuple] = []
+
+    updated = refresh_stale_matches(
+        repo,
+        season=2026,
+        now=now,
+        fetch_round_fn=lambda s, r: (calls.append((s, r)), {"fixtures": []})[1],
+        fetch_match_fn=lambda url: None,
+    )
+    assert updated == 0
+    assert calls == []  # fetch_round never invoked — nothing to refresh
+
+
+def test_refresh_stale_matches_skips_fulltime_matches():
+    past = datetime(2026, 4, 23, 9, 50, tzinfo=UTC)
+    now = datetime(2026, 4, 24, 2, 0, tzinfo=UTC)
+    repo = _FakeRepo(
+        [_match(match_id=1, when=past, state="FullTime", home_score=33, away_score=14)]
+    )
+    calls: list[tuple] = []
+
+    updated = refresh_stale_matches(
+        repo,
+        season=2026,
+        now=now,
+        fetch_round_fn=lambda s, r: (calls.append((s, r)), {"fixtures": []})[1],
+        fetch_match_fn=lambda url: None,
+    )
+    assert updated == 0
+    assert calls == []
+
+
+def test_refresh_stale_matches_survives_fetch_round_failure():
+    past = datetime(2026, 4, 23, 9, 50, tzinfo=UTC)
+    now = datetime(2026, 4, 24, 2, 0, tzinfo=UTC)
+    repo = _FakeRepo([_match(match_id=1, when=past, state="Upcoming")])
+
+    def boom(season, round_):
+        raise RuntimeError("nrl.com down")
+
+    updated = refresh_stale_matches(
+        repo,
+        season=2026,
+        now=now,
+        fetch_round_fn=boom,
+        fetch_match_fn=lambda url: None,
+    )
+    assert updated == 0
+    assert repo._rows[1].match_state == "Upcoming"  # unchanged
+
+
+def test_refresh_stale_matches_survives_fetch_match_failure():
+    past = datetime(2026, 4, 23, 9, 50, tzinfo=UTC)
+    now = datetime(2026, 4, 24, 2, 0, tzinfo=UTC)
+    repo = _FakeRepo([_match(match_id=1, when=past, state="Upcoming")])
+
+    def boom(url):
+        raise RuntimeError("timeout")
+
+    updated = refresh_stale_matches(
+        repo,
+        season=2026,
+        now=now,
+        fetch_round_fn=lambda s, r: {"fixtures": [{"matchCentreUrl": "/draw/match-1/"}]},
+        fetch_match_fn=boom,
+    )
+    assert updated == 0
+    assert repo._rows[1].match_state == "Upcoming"
+
+
+def test_refresh_stale_matches_only_touches_stale_ids_in_returned_round():
+    # Round has two fixtures; only one is stale in repo. Second fixture's
+    # details are never fetched — we short-circuit the "not stale" case.
+    past = datetime(2026, 4, 23, 9, 50, tzinfo=UTC)
+    future = datetime(2026, 4, 30, 9, 50, tzinfo=UTC)
+    now = datetime(2026, 4, 24, 2, 0, tzinfo=UTC)
+    repo = _FakeRepo(
+        [
+            _match(match_id=1, when=past, state="Upcoming"),
+            _match(match_id=2, when=future, state="Upcoming"),
+        ]
+    )
+
+    fetched_urls: list[str] = []
+
+    def fetch_match(url):
+        fetched_urls.append(url)
+        if url == "/draw/match-1/":
+            return _raw_match_payload(1, "FullTime", 33, 14)
+        return _raw_match_payload(2, "Upcoming", 0, 0)
+
+    updated = refresh_stale_matches(
+        repo,
+        season=2026,
+        now=now,
+        fetch_round_fn=lambda s, r: {
+            "fixtures": [
+                {"matchCentreUrl": "/draw/match-1/"},
+                {"matchCentreUrl": "/draw/match-2/"},
+            ]
+        },
+        fetch_match_fn=fetch_match,
+    )
+    # Fetches both (only API-level call is round-level), but only
+    # upserts the stale one.
+    assert updated == 1
+    assert repo._rows[1].match_state == "FullTime"
+    assert repo._rows[2].match_state == "Upcoming"
+
+
+def test_refresh_stale_matches_caps_at_max_rounds_back():
+    past = datetime(2026, 4, 1, tzinfo=UTC)
+    now = datetime(2026, 4, 24, tzinfo=UTC)
+    # 10 stale rounds; max_rounds_back=4 → only last 4 are re-fetched.
+    matches = [
+        _match(match_id=i, round=i, when=past + timedelta(days=i), state="Upcoming")
+        for i in range(1, 11)
+    ]
+    repo = _FakeRepo(matches)
+
+    touched_rounds: list[int] = []
+
+    def fetch_round(season, r):
+        touched_rounds.append(r)
+        return {"fixtures": []}
+
+    refresh_stale_matches(
+        repo,
+        season=2026,
+        now=now,
+        fetch_round_fn=fetch_round,
+        fetch_match_fn=lambda url: None,
+        max_rounds_back=4,
+    )
+    assert touched_rounds == [7, 8, 9, 10]


### PR DESCRIPTION
## Summary

Closes a latent pipeline gap discovered while diagnosing the round-8 Tigers vs Raiders pick: production Firestore still had all round-8 matches at \`match_state=Upcoming\` >15h after kickoff, because \`compute_predictions\` only ever scrapes the *current upcoming* round. Rounds 1–7 appear \`FullTime\` only because \`copy-matches-to-firestore\` was run manually after-the-fact. Round 8 is the first round to actually live through the precompute-only flow, and it broke as designed-but-unintended.

Impact this bug had:
- \`/accuracy\` couldn't score the round (filters on \`FullTime\`).
- The just-shipped retrain loop (#107) would have silently dropped round 8 from the holdout next Monday — \`split_training_holdout\` uses the same filter — so the week's outcomes never fed back into training.

## The fix

- New module \`src/fantasy_coach/match_sync.py\` with \`refresh_stale_matches(repo, season)\` — re-scrapes any match with \`start_time < now AND state != FullTime\`, upserts the refreshed row. Idempotent. Bounded by \`max_rounds_back=4\` so a fresh DB doesn't re-scrape a whole season.
- Called from:
  - **precompute** (Tue + Thu, post-step) — catches anything that completed in the 3–4 day gap.
  - **retrain** (Mon, pre-flight) — ensures Sunday's outcomes reach the holdout *before* \`split_training_holdout\` runs.
- 7 new tests: past-start Upcoming upserts; future-start skipped; FullTime skipped; \`fetch_round\` failure doesn't crash; \`fetch_match\` failure doesn't crash; mixed stale/fresh round only touches stale rows; \`max_rounds_back\` cap enforced.

## Immediate data fix (already applied)

The round-8 Tigers v Raiders match is already \`FullTime 33–14\` in production Firestore via a one-off script run out-of-band. Remaining Fri/Sat/Sun round-8 matches will self-heal on the next Tue precompute run with this PR deployed.

## Test plan

- [ ] CI: pytest (55 retrain-adjacent tests pass locally, including the 7 new).
- [ ] Deploy → next Thu precompute run: verify it logs \"Refreshed N stale past-start-time matches\" if any round-8 Fri/Sat/Sun matches are still \`Upcoming\` at that time.
- [ ] Monday retrain run: verify pre-flight log lines \"Pre-flight: refreshed N stale matches in season 2026\" appear in Cloud Run logs before the retrain shadow-eval starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)