### PR TITLE
feat(ui): team profile page /team/:teamId + stretched-link MatchCard (#147)

### DIFF
--- a/src/fantasy_coach/app.py
+++ b/src/fantasy_coach/app.py
@@ -75,6 +75,36 @@ class TeamFormHistory(BaseModel):
     matches: list[TeamFormEntry]
 
 
+class TeamScheduleEntry(BaseModel):
+    round: int
+    matchId: int
+    kickoff: str  # ISO 8601 UTC
+    isHome: bool
+    opponentId: int
+    opponentName: str
+    matchState: str
+    score: int | None
+    opponentScore: int | None
+    result: str | None  # "win" | "loss" | "draw" | None (upcoming)
+    eloAfter: float | None
+    eloDelta: float | None
+    modelPredictedWinner: str | None  # "home" | "away"
+    modelCorrect: bool | None  # None when match not yet FullTime
+
+
+class TeamProfile(BaseModel):
+    teamId: int
+    teamName: str
+    season: int
+    wins: int
+    losses: int
+    draws: int
+    currentElo: float | None
+    eloTrend: float | None  # current Elo minus first-match Elo; positive = rising
+    schedule: list[TeamScheduleEntry]  # full season, chronological
+    rivals: list[TeamOption]  # opponents this team faces this season
+
+
 ALLOWED_ORIGINS_ENV = "FANTASY_COACH_ALLOWED_ORIGINS"
 DEFAULT_ALLOWED_ORIGINS = (
     "https://fantasy.lopezcloud.dev,http://localhost:5173,http://localhost:4173"
@@ -424,4 +454,154 @@ def get_team_form(
         teamName=team_name,
         season=season,
         matches=entries[-last:],
+    )
+
+
+@app.get(
+    "/teams/{team_id}",
+    response_model=TeamProfile,
+    summary="Team season profile: record, Elo, full schedule with prediction accuracy",
+    description=(
+        "Returns the full season profile for a team including W/L/D record, "
+        "current Elo rating and trend, and a chronological schedule of all "
+        "matches (completed + upcoming) with prediction accuracy where available."
+    ),
+)
+def get_team_profile(
+    team_id: int,
+    season: int = Query(..., description="NRL season year, e.g. 2026"),
+) -> TeamProfile:
+    try:
+        all_matches = _get_repo().list_matches(season)
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=f"Match store unavailable: {exc}") from exc
+
+    # All matches this season involving this team, in chronological order.
+    team_matches = sorted(
+        [m for m in all_matches if m.home.team_id == team_id or m.away.team_id == team_id],
+        key=lambda m: (m.start_time, m.match_id),
+    )
+    if not team_matches:
+        raise HTTPException(status_code=404, detail=f"Team {team_id} not found in season {season}")
+
+    # Replay Elo across ALL completed matches this season (for accurate ratings).
+    completed_all = sorted(
+        [
+            m
+            for m in all_matches
+            if m.match_state == "FullTime" and m.home.score is not None and m.away.score is not None
+        ],
+        key=lambda m: (m.start_time, m.match_id),
+    )
+    elo = EloMOV()
+    elo_after: dict[int, float] = {}  # match_id → team's Elo after that match
+    elo_delta: dict[int, float] = {}
+    for m in completed_all:
+        home_delta, away_delta = elo.update(
+            m.home.team_id,
+            m.away.team_id,
+            m.home.score,
+            m.away.score,  # type: ignore[arg-type]
+        )
+        if m.home.team_id == team_id:
+            elo_after[m.match_id] = round(elo.rating(team_id), 1)
+            elo_delta[m.match_id] = round(home_delta, 1)
+        elif m.away.team_id == team_id:
+            elo_after[m.match_id] = round(elo.rating(team_id), 1)
+            elo_delta[m.match_id] = round(away_delta, 1)
+
+    # Fetch predictions for each round the team plays (best-effort).
+    rounds_played = sorted({m.round for m in team_matches})
+    preds_by_match: dict[int, str] = {}  # match_id → predictedWinner
+    for rnd in rounds_played:
+        try:
+            preds = _get_store().get(season, rnd) or []
+        except Exception:
+            preds = []
+        for p in preds:
+            preds_by_match[p.matchId] = p.predictedWinner
+
+    # Build schedule entries and W/L/D counters.
+    team_name = ""
+    rivals: dict[int, str] = {}
+    wins = losses = draws = 0
+    schedule: list[TeamScheduleEntry] = []
+
+    for m in team_matches:
+        is_home = m.home.team_id == team_id
+        if is_home:
+            opp_id, opp_name = m.away.team_id, m.away.name
+            if not team_name:
+                team_name = m.home.name
+        else:
+            opp_id, opp_name = m.home.team_id, m.home.name
+            if not team_name:
+                team_name = m.away.name
+        rivals[opp_id] = opp_name
+
+        score = opp_score = result = None
+        if m.match_state == "FullTime" and m.home.score is not None and m.away.score is not None:
+            score = m.home.score if is_home else m.away.score
+            opp_score = m.away.score if is_home else m.home.score
+            if score > opp_score:
+                result = "win"
+                wins += 1
+            elif score < opp_score:
+                result = "loss"
+                losses += 1
+            else:
+                result = "draw"
+                draws += 1
+
+        predicted_winner = preds_by_match.get(m.match_id)
+        model_correct: bool | None = None
+        if predicted_winner and result and score is not None and opp_score is not None:
+            if score > opp_score:
+                actual_winner = "home" if is_home else "away"
+            elif score < opp_score:
+                actual_winner = "away" if is_home else "home"
+            else:
+                actual_winner = None
+            if actual_winner:
+                model_correct = predicted_winner == actual_winner
+
+        schedule.append(
+            TeamScheduleEntry(
+                round=m.round,
+                matchId=m.match_id,
+                kickoff=m.start_time.isoformat(),
+                isHome=is_home,
+                opponentId=opp_id,
+                opponentName=opp_name,
+                matchState=m.match_state,
+                score=score,
+                opponentScore=opp_score,
+                result=result,
+                eloAfter=elo_after.get(m.match_id),
+                eloDelta=elo_delta.get(m.match_id),
+                modelPredictedWinner=predicted_winner,
+                modelCorrect=model_correct,
+            )
+        )
+
+    current_elo = round(elo.rating(team_id), 1) if elo_after else None
+    elo_values = [elo_after[m.match_id] for m in team_matches if m.match_id in elo_after]
+    elo_trend = round(elo_values[-1] - elo_values[0], 1) if len(elo_values) >= 2 else None
+
+    rivals_list = sorted(
+        [TeamOption(id=tid, name=name) for tid, name in rivals.items()],
+        key=lambda t: t.name,
+    )
+
+    return TeamProfile(
+        teamId=team_id,
+        teamName=team_name,
+        season=season,
+        wins=wins,
+        losses=losses,
+        draws=draws,
+        currentElo=current_elo,
+        eloTrend=elo_trend,
+        schedule=schedule,
+        rivals=rivals_list,
     )

--- a/web/src/components/MatchCard.tsx
+++ b/web/src/components/MatchCard.tsx
@@ -57,92 +57,109 @@ export function MatchCard({
   const isKickedOff = new Date(p.kickoff) <= new Date();
 
   return (
-    <Link
-      to={`/round/${season}/${round}/${p.matchId}`}
-      className="match-card-link"
-      aria-label={`${p.home.name} vs ${p.away.name} — view why`}
-    >
-      <article className="match-card">
-        <header className="match-card-head">
-          <div className="teams">
-            <span className="team home">{p.home.name}</span>
-            <span className="muted"> vs </span>
-            <span className="team away">{p.away.name}</span>
-          </div>
-          <time className="kickoff muted" dateTime={p.kickoff}>
-            {formatKickoff(p.kickoff)}
-          </time>
-        </header>
+    <article className="match-card">
+      {/*
+       * Stretched link covers the full card so clicking anywhere navigates to match detail.
+       * Team-name links have position: relative; z-index: 2 so they sit above this overlay.
+       */}
+      <Link
+        to={`/round/${season}/${round}/${p.matchId}`}
+        className="match-card-link"
+        aria-label={`${p.home.name} vs ${p.away.name} — view match detail`}
+      />
 
-        {(homeForm || awayForm) && (
-          <div className="form-sparklines" aria-hidden="false">
-            <TeamFormSparkline
-              matches={homeForm?.matches ?? []}
-              teamName={p.home.name}
-            />
-            <TeamFormSparkline
-              matches={awayForm?.matches ?? []}
-              teamName={p.away.name}
-            />
-          </div>
-        )}
+      <header className="match-card-head">
+        <div className="teams">
+          <Link
+            to={`/team/${p.home.id}?season=${season}`}
+            className="team home team-profile-link"
+            aria-label={`View ${p.home.name} team profile`}
+          >
+            {p.home.name}
+          </Link>
+          <span className="muted"> vs </span>
+          <Link
+            to={`/team/${p.away.id}?season=${season}`}
+            className="team away team-profile-link"
+            aria-label={`View ${p.away.name} team profile`}
+          >
+            {p.away.name}
+          </Link>
+        </div>
+        <time className="kickoff muted" dateTime={p.kickoff}>
+          {formatKickoff(p.kickoff)}
+        </time>
+      </header>
 
-        <div className="prob-bar" role="img" aria-label={`Home win probability ${homePct}%`}>
-          <span
-            className="prob-bar-home"
-            style={{ width: `${homePct}%` }}
-            aria-hidden="true"
+      {(homeForm || awayForm) && (
+        <div className="form-sparklines" aria-hidden="false">
+          <TeamFormSparkline
+            matches={homeForm?.matches ?? []}
+            teamName={p.home.name}
+          />
+          <TeamFormSparkline
+            matches={awayForm?.matches ?? []}
+            teamName={p.away.name}
           />
         </div>
-        <div className="prob-labels">
-          <span>
-            <strong>{p.home.name}</strong> {homePct}%
-          </span>
-          <span>
-            {awayPct}% <strong>{p.away.name}</strong>
-          </span>
-        </div>
+      )}
 
-        <p className="pick">
-          Pick: <strong>{winnerName}</strong> ({winnerPct}%)
-        </p>
+      <div className="prob-bar" role="img" aria-label={`Home win probability ${homePct}%`}>
+        <span
+          className="prob-bar-home"
+          style={{ width: `${homePct}%` }}
+          aria-hidden="true"
+        />
+      </div>
+      <div className="prob-labels">
+        <span>
+          <strong>{p.home.name}</strong> {homePct}%
+        </span>
+        <span>
+          {awayPct}% <strong>{p.away.name}</strong>
+        </span>
+      </div>
 
-        {(() => {
-          const status = consensusStatus(p.predictedWinner, p.alternatives);
-          if (!status) return null;
-          return (
-            <span
-              className={`consensus-badge consensus-badge--${status}`}
-              aria-label={
-                status === "unanimous"
-                  ? "All sources agree on this pick"
-                  : "Sources disagree on this pick"
-              }
-            >
-              {status === "unanimous" ? "Consensus" : "Split pick"}
-            </span>
-          );
-        })()}
+      <p className="pick">
+        Pick: <strong>{winnerName}</strong> ({winnerPct}%)
+      </p>
 
-        {preview ? <p className="preview">{preview}</p> : null}
-
-        {onTip != null && (
-          <div
-            onClick={(e) => e.preventDefault()}
-            onKeyDown={(e) => e.preventDefault()}
-            role="none"
+      {(() => {
+        const status = consensusStatus(p.predictedWinner, p.alternatives);
+        if (!status) return null;
+        return (
+          <span
+            className={`consensus-badge consensus-badge--${status}`}
+            aria-label={
+              status === "unanimous"
+                ? "All sources agree on this pick"
+                : "Sources disagree on this pick"
+            }
           >
-            <TipEntry
-              homeTeam={p.home.name}
-              awayTeam={p.away.name}
-              value={tip ?? null}
-              locked={isKickedOff}
-              saving={savingTip ?? false}
-              onTip={onTip}
-            />
-          </div>
-        )}
-      </article>
-    </Link>
+            {status === "unanimous" ? "Consensus" : "Split pick"}
+          </span>
+        );
+      })()}
+
+      {preview ? <p className="preview">{preview}</p> : null}
+
+      {onTip != null && (
+        <div
+          className="tip-entry-wrap"
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+          role="none"
+        >
+          <TipEntry
+            homeTeam={p.home.name}
+            awayTeam={p.away.name}
+            value={tip ?? null}
+            locked={isKickedOff}
+            saving={savingTip ?? false}
+            onTip={onTip}
+          />
+        </div>
+      )}
+    </article>
   );
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,6 +8,7 @@ import Home from "./routes/Home";
 import MatchDetail from "./routes/MatchDetail";
 import Round from "./routes/Round";
 import Scoreboard from "./routes/Scoreboard";
+import TeamProfileRoute from "./routes/TeamProfile";
 import "./styles.css";
 
 const router = createBrowserRouter([
@@ -20,6 +21,7 @@ const router = createBrowserRouter([
       { path: "round/:season/:round/:matchId", element: <MatchDetail /> },
       { path: "scoreboard", element: <Scoreboard /> },
       { path: "accuracy", element: <Accuracy /> },
+      { path: "team/:teamId", element: <TeamProfileRoute /> },
     ],
   },
 ]);

--- a/web/src/routes/TeamProfile.tsx
+++ b/web/src/routes/TeamProfile.tsx
@@ -1,0 +1,305 @@
+import { useEffect, useState } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+
+import { apiFetch, ApiError, NotSignedInError } from "../api";
+import { useAuth } from "../auth";
+import { SignInRequired } from "../components/SignInRequired";
+import type { TeamProfile, TeamScheduleEntry, TeamOption } from "../types";
+
+const CURRENT_SEASON = new Date().getFullYear();
+
+type Status =
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "ok"; data: TeamProfile };
+
+function ResultPill({ result }: { result: "win" | "loss" | "draw" }) {
+  const cls =
+    result === "win"
+      ? "result-pill result-pill--win"
+      : result === "loss"
+        ? "result-pill result-pill--loss"
+        : "result-pill result-pill--draw";
+  const label = result === "win" ? "W" : result === "loss" ? "L" : "D";
+  return (
+    <span className={cls} aria-label={result}>
+      {label}
+    </span>
+  );
+}
+
+function EloTrendArrow({ trend }: { trend: number | null }) {
+  if (trend === null) return null;
+  if (trend > 5) return <span className="elo-trend elo-trend--up" aria-label="Rising">↑</span>;
+  if (trend < -5) return <span className="elo-trend elo-trend--down" aria-label="Falling">↓</span>;
+  return <span className="elo-trend elo-trend--flat" aria-label="Stable">→</span>;
+}
+
+function ModelBadge({ correct }: { correct: boolean | null }) {
+  if (correct === null) return <span className="muted">—</span>;
+  return (
+    <span
+      className={`model-badge ${correct ? "model-badge--correct" : "model-badge--wrong"}`}
+      aria-label={correct ? "Model correct" : "Model wrong"}
+    >
+      {correct ? "✓" : "✗"}
+    </span>
+  );
+}
+
+function formatKickoff(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function RecentFormStrip({ schedule }: { schedule: TeamScheduleEntry[] }) {
+  const completed = schedule.filter((e) => e.result !== null);
+  const last10 = completed.slice(-10);
+  if (last10.length === 0) return <p className="muted">No completed matches yet.</p>;
+  return (
+    <div className="form-strip" aria-label="Recent form (last 10 completed matches)">
+      {last10.map((e) => (
+        <ResultPill key={e.matchId} result={e.result!} />
+      ))}
+    </div>
+  );
+}
+
+function H2HSection({
+  schedule,
+  rivals,
+}: {
+  schedule: TeamScheduleEntry[];
+  rivals: TeamOption[];
+}) {
+  const [rivalId, setRivalId] = useState<number | null>(
+    rivals.length > 0 ? rivals[0].id : null,
+  );
+
+  const h2h = schedule
+    .filter((e) => e.opponentId === rivalId && e.result !== null)
+    .slice(-10);
+
+  return (
+    <section className="team-section" aria-label="Head to head">
+      <h2 className="accuracy-section-title">Head to Head</h2>
+      <div className="accuracy-filters">
+        <label className="accuracy-filter-label">
+          Opponent
+          <select
+            value={rivalId ?? ""}
+            onChange={(e) => setRivalId(e.target.value ? Number(e.target.value) : null)}
+            aria-label="Select opponent"
+          >
+            {rivals.map((r) => (
+              <option key={r.id} value={r.id}>
+                {r.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {h2h.length === 0 ? (
+        <p className="muted">No completed matches vs this opponent yet this season.</p>
+      ) : (
+        <div className="accuracy-table-wrap">
+          <table className="accuracy-table">
+            <thead>
+              <tr>
+                <th>Round</th>
+                <th>Venue</th>
+                <th>Score</th>
+                <th>Result</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[...h2h].reverse().map((e) => (
+                <tr key={e.matchId}>
+                  <td>
+                    <Link to={`/round/${e.kickoff.slice(0, 4)}/${e.round}/${e.matchId}`}>
+                      Rd {e.round}
+                    </Link>
+                  </td>
+                  <td>{e.isHome ? "Home" : "Away"}</td>
+                  <td>
+                    {e.score}–{e.opponentScore}
+                  </td>
+                  <td>
+                    <ResultPill result={e.result!} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default function TeamProfileRoute() {
+  const { teamId } = useParams<{ teamId: string }>();
+  const { user, loading: authLoading } = useAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [season, setSeason] = useState(() => {
+    const s = searchParams.get("season");
+    return s ? Number(s) : CURRENT_SEASON;
+  });
+
+  const [status, setStatus] = useState<Status>({ kind: "loading" });
+
+  useEffect(() => {
+    if (authLoading || !user || !teamId) return;
+
+    setSearchParams({ season: String(season) }, { replace: true });
+
+    let cancelled = false;
+    setStatus({ kind: "loading" });
+    apiFetch<TeamProfile>(`/teams/${teamId}?season=${season}`)
+      .then((data) => {
+        if (!cancelled) setStatus({ kind: "ok", data });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof NotSignedInError) {
+          setStatus({ kind: "error", message: "Sign in required." });
+        } else if (err instanceof ApiError) {
+          setStatus({ kind: "error", message: err.message });
+        } else {
+          setStatus({ kind: "error", message: "Couldn't load team profile." });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, user, teamId, season]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (authLoading) return <p>Loading…</p>;
+  if (!user) return <SignInRequired message="Sign in to view team profiles." />;
+
+  return (
+    <section className="team-profile-page">
+      <div className="round-selector">
+        <label>
+          Season
+          <input
+            type="number"
+            value={season}
+            min={2024}
+            max={CURRENT_SEASON}
+            onChange={(e) => setSeason(Number(e.target.value))}
+          />
+        </label>
+      </div>
+
+      {status.kind === "loading" && <p role="status">Loading team profile…</p>}
+
+      {status.kind === "error" && (
+        <div className="error-box" role="alert">
+          {status.message}
+        </div>
+      )}
+
+      {status.kind === "ok" && (
+        <>
+          {/* Header */}
+          <header className="team-profile-header">
+            <h1 className="team-profile-name">{status.data.teamName}</h1>
+            <div className="team-profile-meta">
+              <span className="team-record" aria-label="Season record">
+                {status.data.wins}W–{status.data.losses}L
+                {status.data.draws > 0 ? `–${status.data.draws}D` : ""}
+              </span>
+              {status.data.currentElo !== null && (
+                <span className="team-elo" aria-label="Current Elo rating">
+                  Elo {status.data.currentElo}
+                  <EloTrendArrow trend={status.data.eloTrend} />
+                </span>
+              )}
+            </div>
+          </header>
+
+          {/* Recent form */}
+          <section className="team-section" aria-label="Recent form">
+            <h2 className="accuracy-section-title">Recent Form</h2>
+            <RecentFormStrip schedule={status.data.schedule} />
+          </section>
+
+          {/* Full season schedule */}
+          <section className="team-section" aria-label="Season schedule">
+            <h2 className="accuracy-section-title">Season Schedule</h2>
+            <div className="accuracy-table-wrap">
+              <table className="accuracy-table">
+                <thead>
+                  <tr>
+                    <th>Round</th>
+                    <th>Opponent</th>
+                    <th>Venue</th>
+                    <th>Kickoff</th>
+                    <th>Score</th>
+                    <th>Result</th>
+                    <th>Model</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {status.data.schedule.map((e) => (
+                    <tr
+                      key={e.matchId}
+                      className={e.matchState === "FullTime" ? "" : "schedule-upcoming"}
+                    >
+                      <td>
+                        <Link
+                          to={`/round/${e.kickoff.slice(0, 4)}/${e.round}/${e.matchId}`}
+                          aria-label={`Round ${e.round} match detail`}
+                        >
+                          Rd {e.round}
+                        </Link>
+                      </td>
+                      <td>
+                        <Link
+                          to={`/team/${e.opponentId}?season=${season}`}
+                          aria-label={`View ${e.opponentName} profile`}
+                        >
+                          {e.opponentName}
+                        </Link>
+                      </td>
+                      <td>{e.isHome ? "Home" : "Away"}</td>
+                      <td>
+                        <time dateTime={e.kickoff}>{formatKickoff(e.kickoff)}</time>
+                      </td>
+                      <td>
+                        {e.score !== null && e.opponentScore !== null
+                          ? `${e.score}–${e.opponentScore}`
+                          : "—"}
+                      </td>
+                      <td>
+                        {e.result ? <ResultPill result={e.result} /> : <span className="muted">—</span>}
+                      </td>
+                      <td>
+                        <ModelBadge correct={e.modelCorrect} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          {/* Head-to-head */}
+          {status.data.rivals.length > 0 && (
+            <H2HSection schedule={status.data.schedule} rivals={status.data.rivals} />
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -15,6 +15,8 @@
   --color-error:           #c0392b;
   --color-error-bg:        #fdecea;
   --color-error-text:      #5a1a13;
+  --color-success:         #27ae60;
+  --color-muted:           #666666;
   --color-track:           #e0e0e0;
 
   /* Elevation */
@@ -44,6 +46,8 @@
   --color-error:           #e97070;
   --color-error-bg:        #291616;
   --color-error-text:      #fbc9c9;
+  --color-success:         #68d391;
+  --color-muted:           #9a9a9a;
   --color-track:           #2e2e2e;
   --shadow-card:           0 2px 6px rgba(0, 0, 0, 0.4);
 }
@@ -63,6 +67,8 @@
     --color-error:           #e97070;
     --color-error-bg:        #291616;
     --color-error-text:      #fbc9c9;
+    --color-success:         #68d391;
+    --color-muted:           #9a9a9a;
     --color-track:           #2e2e2e;
     --shadow-card:           0 2px 6px rgba(0, 0, 0, 0.4);
   }
@@ -404,6 +410,7 @@ a:focus-visible {
 /* ── Match card ────────────────────────────────────────────────────────── */
 
 .match-card {
+  position: relative;
   padding: 1rem;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
@@ -411,6 +418,15 @@ a:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.match-card:has(.match-card-link:hover),
+.match-card:has(.match-card-link:focus-visible) {
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-card);
 }
 
 .match-card-head {
@@ -468,20 +484,23 @@ a:focus-visible {
 
 /* ── Match card link wrapper ───────────────────────────────────────────── */
 
+/* Stretched-link overlay: covers the full card so clicking anywhere navigates
+ * to the match detail. Team-name links (.team-profile-link) sit above it
+ * via z-index: 2.  Using ::after keeps the <a> in normal flow (no position
+ * tricks on the host element) and avoids nested-<a> invalidity. */
 .match-card-link {
-  display: block;
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: inherit;
   color: inherit;
   text-decoration: none;
-  border-radius: var(--radius-lg);
-  transition:
-    transform 120ms ease,
-    box-shadow 120ms ease;
 }
 
-.match-card-link:hover .match-card,
-.match-card-link:focus-visible .match-card {
-  border-color: var(--color-primary);
-  box-shadow: var(--shadow-card);
+.match-card-link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
 }
 
 .match-card-link:focus-visible {
@@ -489,9 +508,21 @@ a:focus-visible {
   outline-offset: 2px;
 }
 
+/* Team-profile links float above the card stretched-link */
+.team-profile-link {
+  position: relative;
+  z-index: 2;
+  color: inherit;
+  text-decoration: none;
+}
+
+.team-profile-link:hover {
+  text-decoration: underline;
+}
+
 /* ── Reduced-motion override ───────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
-  .match-card-link {
+  .match-card {
     transition: none;
   }
 }
@@ -1117,4 +1148,116 @@ a:focus-visible {
 /* Inline badge on MatchCard */
 .match-card .consensus-badge {
   margin-top: 0.25rem;
+}
+
+/* ── Team profile page (#147) ──────────────────────────────────────────── */
+
+.team-profile-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.team-profile-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.team-profile-name {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.team-profile-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.team-record {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.team-elo {
+  font-size: 1rem;
+  color: var(--color-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.elo-trend {
+  font-size: 1.1rem;
+}
+
+.elo-trend--up {
+  color: var(--color-success);
+}
+
+.elo-trend--down {
+  color: var(--color-error-text);
+}
+
+.elo-trend--flat {
+  color: var(--color-muted);
+}
+
+.team-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+/* Recent form strip — horizontal W/L/D pills */
+.form-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.result-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 50%;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.result-pill--win {
+  background: var(--color-success);
+}
+
+.result-pill--loss {
+  background: var(--color-error-text);
+}
+
+.result-pill--draw {
+  background: var(--color-muted);
+}
+
+/* Model correct/wrong badge */
+.model-badge {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.model-badge--correct {
+  color: var(--color-success);
+}
+
+.model-badge--wrong {
+  color: var(--color-error-text);
+}
+
+/* Upcoming match rows in schedule table */
+.schedule-upcoming {
+  opacity: 0.65;
+  font-style: italic;
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -88,6 +88,36 @@ export type TeamOption = {
   name: string;
 };
 
+export type TeamScheduleEntry = {
+  round: number;
+  matchId: number;
+  kickoff: string;
+  isHome: boolean;
+  opponentId: number;
+  opponentName: string;
+  matchState: string;
+  score: number | null;
+  opponentScore: number | null;
+  result: "win" | "loss" | "draw" | null;
+  eloAfter: number | null;
+  eloDelta: number | null;
+  modelPredictedWinner: "home" | "away" | null;
+  modelCorrect: boolean | null;
+};
+
+export type TeamProfile = {
+  teamId: number;
+  teamName: string;
+  season: number;
+  wins: number;
+  losses: number;
+  draws: number;
+  currentElo: number | null;
+  eloTrend: number | null;
+  schedule: TeamScheduleEntry[];
+  rivals: TeamOption[];
+};
+
 export type AccuracyFilters = {
   teamId: number | null;
   venue: string | null;


### PR DESCRIPTION
Superseded by #195 which includes the full team profile + dashboard implementation with passing tests.\n\nhttps://claude.ai/code/session_012A6Hy5H3tdqEFcndNh8EVK