### PR TITLE
feat(ui): team profile pages + personalised home dashboard (#147, #148)

### DIFF
--- a/src/fantasy_coach/app.py
+++ b/src/fantasy_coach/app.py
@@ -501,7 +501,11 @@ def get_team_profile(
         is_away = m.away.team_id == team_id
         if not (is_home or is_away):
             # Still update Elo for all teams to keep ratings accurate.
-            if m.match_state == "FullTime" and m.home.score is not None and m.away.score is not None:
+            if (
+                m.match_state == "FullTime"
+                and m.home.score is not None
+                and m.away.score is not None
+            ):
                 elo.update(m.home.team_id, m.away.team_id, m.home.score, m.away.score)
             continue
 
@@ -532,29 +536,33 @@ def get_team_profile(
             elo_after = round(elo.rating(team_id), 1)
             completed_entries.append({"elo": elo_after})
 
-            all_fixtures.append({
-                "round": m.round,
-                "matchId": m.match_id,
-                "opponent": opp_name,
-                "opponentId": opp_id,
-                "isHome": is_home,
-                "kickoff": m.start_time.isoformat(),
-                "result": form_char,
-                "score": score,
-                "opponentScore": opp_score,
-            })
+            all_fixtures.append(
+                {
+                    "round": m.round,
+                    "matchId": m.match_id,
+                    "opponent": opp_name,
+                    "opponentId": opp_id,
+                    "isHome": is_home,
+                    "kickoff": m.start_time.isoformat(),
+                    "result": form_char,
+                    "score": score,
+                    "opponentScore": opp_score,
+                }
+            )
         else:
-            all_fixtures.append({
-                "round": m.round,
-                "matchId": m.match_id,
-                "opponent": opp_name,
-                "opponentId": opp_id,
-                "isHome": is_home,
-                "kickoff": m.start_time.isoformat(),
-                "result": None,
-                "score": None,
-                "opponentScore": None,
-            })
+            all_fixtures.append(
+                {
+                    "round": m.round,
+                    "matchId": m.match_id,
+                    "opponent": opp_name,
+                    "opponentId": opp_id,
+                    "isHome": is_home,
+                    "kickoff": m.start_time.isoformat(),
+                    "result": None,
+                    "score": None,
+                    "opponentScore": None,
+                }
+            )
 
     if not team_name:
         raise HTTPException(status_code=404, detail=f"Team {team_id} not found in season {season}")
@@ -564,7 +572,9 @@ def get_team_profile(
     if len(completed_entries) >= 2:
         elo_now = completed_entries[-1]["elo"]
         elo_before = (
-            completed_entries[-3]["elo"] if len(completed_entries) >= 3 else completed_entries[-2]["elo"]
+            completed_entries[-3]["elo"]
+            if len(completed_entries) >= 3
+            else completed_entries[-2]["elo"]
         )
         if elo_now > elo_before + 1:
             elo_trend = "up"

--- a/src/fantasy_coach/app.py
+++ b/src/fantasy_coach/app.py
@@ -442,3 +442,185 @@ def get_team_form(
         season=season,
         matches=entries[-last:],
     )
+
+
+@app.get(
+    "/teams/{team_id}/profile",
+    response_model=TeamProfile,
+    summary="Team profile: record, Elo trend, recent form, and fixtures",
+    description=(
+        "Returns a team's season record, current Elo rating with trend, "
+        "last-10-match form string, next upcoming fixture (with prediction if cached), "
+        "and a full list of season fixtures."
+    ),
+)
+def get_team_profile(
+    team_id: int,
+    season: int = Query(..., description="NRL season year, e.g. 2026"),
+) -> TeamProfile:
+    # Serve from in-process cache if still fresh.
+    cache_key = (team_id, season)
+    cached_entry = _profile_cache.get(cache_key)
+    if cached_entry is not None:
+        ts, cached_profile = cached_entry
+        if time.monotonic() - ts < _PROFILE_CACHE_TTL:
+            return cached_profile
+
+    try:
+        all_matches = _get_repo().list_matches(season)
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=f"Match store unavailable: {exc}") from exc
+
+    # Sort chronologically to walk forward for Elo computation.
+    sorted_matches = sorted(all_matches, key=lambda m: (m.start_time, m.match_id))
+
+    elo = EloMOV()
+    team_name = ""
+    wins = losses = draws = 0
+    form_entries: list[str] = []  # "W"/"L"/"D" for completed matches
+    all_fixtures: list[dict] = []
+    completed_entries: list[dict] = []  # for Elo trend (last 3)
+
+    for m in sorted_matches:
+        is_home = m.home.team_id == team_id
+        is_away = m.away.team_id == team_id
+        if not (is_home or is_away):
+            # Still update Elo for all teams to keep ratings accurate.
+            if m.match_state == "FullTime" and m.home.score is not None and m.away.score is not None:
+                elo.update(m.home.team_id, m.away.team_id, m.home.score, m.away.score)
+            continue
+
+        # Resolve team name on first encounter.
+        if not team_name:
+            team_name = m.home.name if is_home else m.away.name
+
+        opp_id = m.away.team_id if is_home else m.home.team_id
+        opp_name = m.away.name if is_home else m.home.name
+
+        if m.match_state == "FullTime" and m.home.score is not None and m.away.score is not None:
+            elo.update(m.home.team_id, m.away.team_id, m.home.score, m.away.score)
+
+            score = m.home.score if is_home else m.away.score
+            opp_score = m.away.score if is_home else m.home.score
+
+            if score > opp_score:
+                wins += 1
+                form_char = "W"
+            elif score < opp_score:
+                losses += 1
+                form_char = "L"
+            else:
+                draws += 1
+                form_char = "D"
+
+            form_entries.append(form_char)
+            elo_after = round(elo.rating(team_id), 1)
+            completed_entries.append({"elo": elo_after})
+
+            all_fixtures.append({
+                "round": m.round,
+                "matchId": m.match_id,
+                "opponent": opp_name,
+                "opponentId": opp_id,
+                "isHome": is_home,
+                "kickoff": m.start_time.isoformat(),
+                "result": form_char,
+                "score": score,
+                "opponentScore": opp_score,
+            })
+        else:
+            all_fixtures.append({
+                "round": m.round,
+                "matchId": m.match_id,
+                "opponent": opp_name,
+                "opponentId": opp_id,
+                "isHome": is_home,
+                "kickoff": m.start_time.isoformat(),
+                "result": None,
+                "score": None,
+                "opponentScore": None,
+            })
+
+    if not team_name:
+        raise HTTPException(status_code=404, detail=f"Team {team_id} not found in season {season}")
+
+    # Elo trend based on last 3 completed matches.
+    current_elo = round(elo.rating(team_id), 1)
+    if len(completed_entries) >= 2:
+        elo_now = completed_entries[-1]["elo"]
+        elo_before = (
+            completed_entries[-3]["elo"] if len(completed_entries) >= 3 else completed_entries[-2]["elo"]
+        )
+        if elo_now > elo_before + 1:
+            elo_trend = "up"
+        elif elo_now < elo_before - 1:
+            elo_trend = "down"
+        else:
+            elo_trend = "flat"
+    else:
+        elo_trend = "flat"
+
+    # Last 10 results as form pills.
+    recent_form = form_entries[-10:]
+
+    # Next fixture: first match not yet FullTime for this team.
+    next_fixture: dict | None = None
+    for fixture in all_fixtures:
+        if fixture["result"] is None:
+            pred_winner = None
+            pred_prob = None
+            try:
+                preds = _get_store().get(season, fixture["round"])
+                for pred in preds:
+                    if pred.matchId == fixture["matchId"]:
+                        pred_winner = pred.predictedWinner
+                        pred_prob = pred.homeWinProbability
+                        break
+            except Exception:
+                pass
+            next_fixture = {
+                "matchId": fixture["matchId"],
+                "round": fixture["round"],
+                "opponent": fixture["opponent"],
+                "opponentId": fixture["opponentId"],
+                "isHome": fixture["isHome"],
+                "kickoff": fixture["kickoff"],
+                "predWinner": pred_winner,
+                "predProb": pred_prob,
+            }
+            break
+
+    # Enrich upcoming fixtures in allFixtures with predictions.
+    try:
+        upcoming_rounds: dict[int, list[dict]] = {}
+        for fixture in all_fixtures:
+            if fixture["result"] is None:
+                upcoming_rounds.setdefault(fixture["round"], []).append(fixture)
+        for round_num, fixtures_in_round in upcoming_rounds.items():
+            try:
+                preds = _get_store().get(season, round_num)
+                pred_map = {p.matchId: p for p in preds}
+                for fixture in fixtures_in_round:
+                    pred = pred_map.get(fixture["matchId"])
+                    if pred:
+                        fixture["predWinner"] = pred.predictedWinner
+                        fixture["predProb"] = pred.homeWinProbability
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+    profile = TeamProfile(
+        teamId=team_id,
+        teamName=team_name,
+        season=season,
+        currentRecord={"wins": wins, "losses": losses, "draws": draws},
+        currentElo=current_elo,
+        eloTrend=elo_trend,
+        recentForm=recent_form,
+        nextFixture=next_fixture,
+        allFixtures=all_fixtures,
+    )
+
+    _profile_cache[cache_key] = (time.monotonic(), profile)
+    return profile

--- a/src/fantasy_coach/app.py
+++ b/src/fantasy_coach/app.py
@@ -1,7 +1,7 @@
 import os
 import time
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
@@ -88,6 +88,17 @@ class TeamProfile(BaseModel):
     allFixtures: list[dict]  # all fixtures in season
 
 
+class DashboardOut(BaseModel):
+    season: int
+    currentRound: int | None
+    favouriteTeamId: int | None
+    nextFixture: dict | None
+    untippedMatchIds: list[int]
+    seasonAccuracy: float | None
+    totalTips: int
+    correctTips: int
+
+
 ALLOWED_ORIGINS_ENV = "FANTASY_COACH_ALLOWED_ORIGINS"
 DEFAULT_ALLOWED_ORIGINS = (
     "https://fantasy.lopezcloud.dev,http://localhost:5173,http://localhost:4173"
@@ -132,6 +143,10 @@ _repo: Repository | None = None
 # In-process cache for team profile responses: key=(team_id, season), value=(timestamp, data)
 _PROFILE_CACHE_TTL = 60  # seconds
 _profile_cache: dict[tuple[int, int], tuple[float, TeamProfile]] = {}
+
+# In-process cache for dashboard responses: key=(uid, season), value=(timestamp, data)
+_DASHBOARD_CACHE_TTL = 60  # seconds
+_dashboard_cache: dict[tuple[str, int], tuple[float, DashboardOut]] = {}
 
 
 def _get_store() -> PredictionStore | FirestorePredictionStore:
@@ -624,3 +639,145 @@ def get_team_profile(
 
     _profile_cache[cache_key] = (time.monotonic(), profile)
     return profile
+
+
+def _require_auth(request: Request) -> str:
+    uid: str | None = getattr(request.state, "uid", None)
+    return uid if uid is not None else "__dev__"
+
+
+@app.get(
+    "/me/dashboard",
+    response_model=DashboardOut,
+    summary="Personalised dashboard for the authenticated user",
+    description=(
+        "Returns the current round, upcoming untipped matches, next fixture "
+        "for the user's favourite team, and season-to-date tipping accuracy."
+    ),
+)
+def get_dashboard(
+    request: Request,
+    season: int = Query(..., description="NRL season year, e.g. 2026"),
+    favourite_team_id: int | None = Query(
+        default=None, description="Team ID to use for next-fixture lookup"
+    ),
+) -> DashboardOut:
+    uid = _require_auth(request)
+    cache_key = (uid, season)
+    cached_entry = _dashboard_cache.get(cache_key)
+    if cached_entry is not None:
+        ts, cached_dash = cached_entry
+        if time.monotonic() - ts < _DASHBOARD_CACHE_TTL:
+            return cached_dash
+
+    try:
+        matches = _get_repo().list_matches(season)
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=f"Match store unavailable: {exc}") from exc
+
+    # Determine current round: lowest round with at least one non-FullTime match,
+    # falling back to the highest round seen when all matches are complete.
+    rounds_with_upcoming: list[int] = []
+    all_rounds: list[int] = []
+    for m in matches:
+        all_rounds.append(m.round)
+        if m.match_state != "FullTime":
+            rounds_with_upcoming.append(m.round)
+
+    if rounds_with_upcoming:
+        current_round: int | None = min(rounds_with_upcoming)
+    elif all_rounds:
+        current_round = max(all_rounds)
+    else:
+        current_round = None
+
+    # Untipped = current-round matches that have no stored prediction.
+    untipped_match_ids: list[int] = []
+    if current_round is not None:
+        current_round_matches = [m for m in matches if m.round == current_round]
+        try:
+            preds = _get_store().get(season, current_round)
+            tipped_ids = {p.matchId for p in preds}
+        except Exception:
+            tipped_ids = set()
+        untipped_match_ids = [
+            m.match_id for m in current_round_matches if m.match_id not in tipped_ids
+        ]
+
+    # Season-to-date tipping accuracy: compare stored predictions to FullTime results.
+    total_tips = 0
+    correct_tips = 0
+    completed = [
+        m
+        for m in matches
+        if m.match_state == "FullTime" and m.home.score is not None and m.away.score is not None
+    ]
+    completed_rounds = {m.round for m in completed}
+    for rnd in completed_rounds:
+        try:
+            preds = _get_store().get(season, rnd)
+        except Exception:
+            continue
+        result_map = {
+            m.match_id: ("home" if m.home.score > m.away.score else "away")  # type: ignore[operator]
+            for m in completed
+            if m.round == rnd
+        }
+        for p in preds:
+            if p.matchId in result_map:
+                total_tips += 1
+                if p.predictedWinner == result_map[p.matchId]:
+                    correct_tips += 1
+
+    season_accuracy = correct_tips / total_tips if total_tips > 0 else None
+
+    # Next fixture for favourite team.
+    next_fixture: dict | None = None
+    if favourite_team_id is not None:
+        sorted_matches = sorted(matches, key=lambda m: (m.start_time, m.match_id))
+        for m in sorted_matches:
+            is_home = m.home.team_id == favourite_team_id
+            is_away = m.away.team_id == favourite_team_id
+            if not (is_home or is_away):
+                continue
+            if m.match_state == "FullTime":
+                continue
+            opp_name = m.away.name if is_home else m.home.name
+            opp_id = m.away.team_id if is_home else m.home.team_id
+            pred_winner = None
+            pred_prob = None
+            try:
+                preds = _get_store().get(season, m.round)
+                for pred in preds:
+                    if pred.matchId == m.match_id:
+                        pred_winner = pred.predictedWinner
+                        pred_prob = pred.homeWinProbability
+                        break
+            except Exception:
+                pass
+            next_fixture = {
+                "matchId": m.match_id,
+                "round": m.round,
+                "season": season,
+                "opponent": opp_name,
+                "opponentId": opp_id,
+                "isHome": is_home,
+                "kickoff": m.start_time.isoformat(),
+                "predWinner": pred_winner,
+                "predProb": pred_prob,
+            }
+            break
+
+    dashboard = DashboardOut(
+        season=season,
+        currentRound=current_round,
+        favouriteTeamId=favourite_team_id,
+        nextFixture=next_fixture,
+        untippedMatchIds=untipped_match_ids,
+        seasonAccuracy=season_accuracy,
+        totalTips=total_tips,
+        correctTips=correct_tips,
+    )
+
+    _dashboard_cache[cache_key] = (time.monotonic(), dashboard)
+    return dashboard

--- a/src/fantasy_coach/app.py
+++ b/src/fantasy_coach/app.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
@@ -75,6 +76,18 @@ class TeamFormHistory(BaseModel):
     matches: list[TeamFormEntry]
 
 
+class TeamProfile(BaseModel):
+    teamId: int
+    teamName: str
+    season: int
+    currentRecord: dict  # {"wins": n, "losses": n, "draws": n}
+    currentElo: float
+    eloTrend: str  # "up" | "down" | "flat"
+    recentForm: list[str]  # last 10 results as "W"/"L"/"D"
+    nextFixture: dict | None  # next upcoming match details
+    allFixtures: list[dict]  # all fixtures in season
+
+
 ALLOWED_ORIGINS_ENV = "FANTASY_COACH_ALLOWED_ORIGINS"
 DEFAULT_ALLOWED_ORIGINS = (
     "https://fantasy.lopezcloud.dev,http://localhost:5173,http://localhost:4173"
@@ -115,6 +128,10 @@ app.add_middleware(
 # Module-level singletons — created lazily on first use.
 _store: PredictionStore | FirestorePredictionStore | None = None
 _repo: Repository | None = None
+
+# In-process cache for team profile responses: key=(team_id, season), value=(timestamp, data)
+_PROFILE_CACHE_TTL = 60  # seconds
+_profile_cache: dict[tuple[int, int], tuple[float, TeamProfile]] = {}
 
 
 def _get_store() -> PredictionStore | FirestorePredictionStore:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,395 @@
+"""Tests for the GET /me/dashboard endpoint."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fantasy_coach.app import app
+from fantasy_coach.features import MatchRow, TeamRow
+from fantasy_coach.predictions import PredictionOut, PredictionStore, TeamInfo
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_app_singletons():
+    import fantasy_coach.app as app_module
+
+    app_module._store = None
+    app_module._repo = None
+    app_module._dashboard_cache.clear()
+    yield
+    app_module._store = None
+    app_module._repo = None
+    app_module._dashboard_cache.clear()
+
+
+def _make_match(
+    match_id: int,
+    round_: int,
+    home_id: int = 1,
+    away_id: int = 2,
+    home_name: str = "Home",
+    away_name: str = "Away",
+    match_state: str = "Upcoming",
+    home_score: int | None = None,
+    away_score: int | None = None,
+    season: int = 2026,
+    offset_seconds: int = 0,
+) -> MatchRow:
+    return MatchRow(
+        match_id=match_id,
+        season=season,
+        round=round_,
+        start_time=datetime(2026, 4, 1, 9, 0, offset_seconds, tzinfo=UTC),
+        match_state=match_state,
+        venue="Stadium",
+        venue_city="Sydney",
+        weather=None,
+        home=TeamRow(
+            team_id=home_id,
+            name=home_name,
+            nick_name=home_name[:3],
+            score=home_score,
+            players=[],
+        ),
+        away=TeamRow(
+            team_id=away_id,
+            name=away_name,
+            nick_name=away_name[:3],
+            score=away_score,
+            players=[],
+        ),
+        team_stats=[],
+    )
+
+
+def _make_pred(
+    match_id: int,
+    predicted_winner: str = "home",
+    model_version: str = "abc123",
+) -> PredictionOut:
+    return PredictionOut(
+        matchId=match_id,
+        home=TeamInfo(id=1, name="Home"),
+        away=TeamInfo(id=2, name="Away"),
+        kickoff="2026-04-01T09:00:00+00:00",
+        predictedWinner=predicted_winner,
+        homeWinProbability=0.65 if predicted_winner == "home" else 0.35,
+        modelVersion=model_version,
+        featureHash="fh1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy-path tests
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_returns_200_with_correct_shape(client: TestClient, tmp_path: Path) -> None:
+    matches = [
+        _make_match(1, round_=1, match_state="Upcoming"),
+        _make_match(2, round_=1, match_state="Upcoming", offset_seconds=1),
+    ]
+    mock_repo = MagicMock()
+    mock_repo.list_matches.return_value = matches
+    store = PredictionStore(path=tmp_path / "p.db")
+
+    with (
+        patch("fantasy_coach.app._get_repo", return_value=mock_repo),
+        patch("fantasy_coach.app._get_store", return_value=store),
+    ):
+        resp = client.get("/me/dashboard?season=2026")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    # Schema shape check
+    assert "season" in body
+    assert "currentRound" in body
+    assert "favouriteTeamId" in body
+    assert "nextFixture" in body
+    assert "untippedMatchIds" in body
+    assert "seasonAccuracy" in body
+    assert "totalTips" in body
+    assert "correctTips" in body
+
+
+def test_dashboard_current_round_is_lowest_upcoming(client: TestClient, tmp_path: Path) -> None:
+    """currentRound should be the lowest round with at least one non-FullTime match."""
+    matches = [
+        _make_match(10, round_=1, match_state="FullTime", home_score=20, away_score=10),
+        _make_match(20, round_=2, match_state="Upcoming"),
+        _make_match(21, round_=2, match_state="Upcoming", offset_seconds=1),
+    ]
+    mock_repo = MagicMock()
+    mock_repo.list_matches.return_value = matches
+    store = PredictionStore(path=tmp_path / "p.db")
+
+    with (
+        patch("fantasy_coach.app._get_repo", return_value=mock_repo),
+        patch("fantasy_coach.app._get_store", return_value=store),
+    ):
+        resp = client.get("/me/dashboard?season=2026")
+
+    assert resp.status_code == 200
+    assert resp.json()["currentRound"] == 2
+
+
+def test_dashboard_current_round_falls_back_to_max_completed(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """When season is complete, currentRound = highest round seen."""
+    matches = [
+        _make_match(1, round_=1, match_state="FullTime", home_score=20, away_score=10),
+        _make_match(2, round_=2, match_state="FullTime", home_score=14, away_score=12),
+        _make_match(3, round_=3, match_state="FullTime", home_score=8, away_score=6),
+    ]
+    mock_repo = MagicMock()
+    mock_repo.list_matches.return_value = matches
+    store = PredictionStore(path=tmp_path / "p.db")
+
+    with (
+        patch("fantasy_coach.app._get_repo", return_value=mock_repo),
+        patch("fantasy_coach.app._get_store", return_value=store),
+    ):
+        resp = client.get("/me/dashboard?season=2026")
+
+    assert resp.status_code == 200
+    assert resp.json()["currentRound"] == 3
+
+
+def test_dashboard_untipped_match_ids_contains_current_round(
+    client: TestClient, tmp_path: Path
+) -> None:
+    matches = [
+        _make_match(100, round_=5, match_state="Upcoming"),
+        _make_match(101, round_=5, match_state="Upcoming", offset_seconds=1),
+    ]
+    mock_repo = MagicMock()
+    mock_repo.list_matches.return_value = matches
+    store = PredictionStore(path=tmp_path / "p.db")
+
+    with (
+        patch("fantasy_coach.app._get_repo", return_value=mock_repo),
+        patch("fantasy_coach.app._get_store", return_value=store),
+    ):
+        resp = client.get("/me/dashboard?season=2026")
+
+    body = resp.json()
+    assert set(body["untippedMatchIds"]) == {100, 101}
+
+
+def test_dashboard_next_fixture_for_favourite_team(client: TestClient, tmp_path: Path) -> None:
+    matches = [
+        _make_match(
+            10,
+            round_=1,
+            home_id=7,
+            away_id=8,
+            home_name="Broncos",
+            away_name="Roosters",
+            match_state="Upcoming",
+        ),
+        _make_match(
+            11,
+            round_=1,
+            home_id=9,
+            away_id=10,
+            home_name="Storm",
+            away_name="Panthers",
+            match_state="Upcoming",
+            offset_seconds=1,
+        ),
+    ]
+    mock_repo = MagicMock()
+    mock_repo.list_matches.return_value = matches
+    store = PredictionStore(path=tmp_path / "p.db")
+
+    with (
+        patch("fantasy_coach.app._get_repo", return_value=mock_repo),
+        patch("fantasy_coach.app._get_store", return_value=store),
+    ):
+        resp = client.get("/me/dashboard?season=2026&favourite_team_id=7")
+
+    body = resp.json()
+    assert body["favouriteTeamId"] == 7
+    assert body["nextFixture"] is not None
+    fixture = body["nextFixture"]
+    assert fixture["matchId"] == 10
+    assert fixture["isHome"] is True
+    assert fixture["opponent"] == "Roosters"
+    assert fixture["opponentId"] == 8
+    assert fixture["season"] == 2026
+
+
+def test_dashboard_next_fixture_away_team(client: TestClient, tmp_path: Path) -> None:
+    matches = [
+        _make_match(
+            20,
+            round_=3,
+            home_id=1,
+            away_id=5,
+            home_name="Knights",
+            away_name="Tigers",
+            match_state="Upcoming",
+        ),
+    ]
+    mock_repo = MagicMock()
+    mock_repo.list_matches.return_value = matches
+    store = PredictionStore(path=tmp_path / "p.db")
+
+    with (
+        patch("fantasy_coach.app._get_repo", return_value=mock_repo),
+        patch("fantasy_coach.app._get_store", return_value=store),
+    ):
+        resp = client.get("/me/dashboard?season=2026&favourite_team_id=5")
+
+    body = resp.json()
+    fixture = body["nextFixture"]
+    assert fixture is not None
+    assert fixture["isHome"] is False
+    assert fixture["opponent"] == "Knights"
+
+
+def test_dashboard_no_next_fixture_when_all_fulltime(client: TestClient, tmp_path: Path) -> None:
+    matches = [
+        _make_match(
+            1,
+            round_=1,
+            home_id=10,
+            away_id=20,
+            match_state="FullTime",
+            home_score=20,
+            away_score=10,
+        ),
+    ]
+    mock_repo = MagicMock()
+    mock_repo.list_matches.return_value = matches
+    store = PredictionStore(path=tmp_path / "p.db")
+
+    with (
+        patch("fantasy_coach.app._get_repo", return_value=mock_repo),
+        patch("fantasy_coach.app._get_store", return_value=store),
+    ):
+        resp = client.get("/me/dashboard?season=2026&favourite_team_id=10")
+
+    body = resp.json()
+    assert body["nextFixture"] is None
+
+
+def test_dashboard_season_accuracy_and_tips_default_to_zero(
+    client: TestClient, tmp_path: Path
+) -> None:
+    mock_repo = MagicMock()
+    mock_repo.list_matches.return_value = []
+    store = PredictionStore(path=tmp_path / "p.db")
+
+    with (
+        patch("fantasy_coach.app._get_repo", return_value=mock_repo),
+        patch("fantasy_coach.app._get_store", return_value=store),
+    ):
+        resp = client.get("/me/dashboard?season=2026")
+
+    body = resp.json()
+    assert body["seasonAccuracy"] is None
+    assert body["totalTips"] == 0
+    assert body["correctTips"] == 0
+
+
+def test_dashboard_attaches_prediction_to_next_fixture(
+    client: TestClient, tmp_path: Path
+) -> None:
+    matches = [
+        _make_match(
+            50,
+            round_=4,
+            home_id=3,
+            away_id=6,
+            home_name="Titans",
+            away_name="Cowboys",
+            match_state="Upcoming",
+        ),
+    ]
+    mock_repo = MagicMock()
+    mock_repo.list_matches.return_value = matches
+    store = PredictionStore(path=tmp_path / "p.db")
+    store.put(2026, 4, [_make_pred(50, "home")])
+
+    with (
+        patch("fantasy_coach.app._get_repo", return_value=mock_repo),
+        patch("fantasy_coach.app._get_store", return_value=store),
+    ):
+        resp = client.get("/me/dashboard?season=2026&favourite_team_id=3")
+
+    body = resp.json()
+    fixture = body["nextFixture"]
+    assert fixture is not None
+    assert fixture["predWinner"] == "home"
+    assert fixture["predProb"] is not None
+
+
+def test_dashboard_no_favourite_team_when_not_set(client: TestClient, tmp_path: Path) -> None:
+    mock_repo = MagicMock()
+    mock_repo.list_matches.return_value = []
+    store = PredictionStore(path=tmp_path / "p.db")
+
+    with (
+        patch("fantasy_coach.app._get_repo", return_value=mock_repo),
+        patch("fantasy_coach.app._get_store", return_value=store),
+    ):
+        resp = client.get("/me/dashboard?season=2026")
+
+    body = resp.json()
+    assert body["favouriteTeamId"] is None
+    assert body["nextFixture"] is None
+
+
+def test_dashboard_returns_503_when_repo_unavailable(client: TestClient) -> None:
+    mock_repo = MagicMock()
+    mock_repo.list_matches.side_effect = RuntimeError("db gone")
+
+    with patch("fantasy_coach.app._get_repo", return_value=mock_repo):
+        resp = client.get("/me/dashboard?season=2026")
+
+    assert resp.status_code == 503
+    assert "unavailable" in resp.json()["detail"].lower()
+
+
+def test_dashboard_season_value_matches_request(client: TestClient, tmp_path: Path) -> None:
+    mock_repo = MagicMock()
+    mock_repo.list_matches.return_value = []
+    store = PredictionStore(path=tmp_path / "p.db")
+
+    with (
+        patch("fantasy_coach.app._get_repo", return_value=mock_repo),
+        patch("fantasy_coach.app._get_store", return_value=store),
+    ):
+        resp = client.get("/me/dashboard?season=2025")
+
+    assert resp.status_code == 200
+    assert resp.json()["season"] == 2025
+
+
+def test_dashboard_current_round_none_when_no_matches(
+    client: TestClient, tmp_path: Path
+) -> None:
+    mock_repo = MagicMock()
+    mock_repo.list_matches.return_value = []
+    store = PredictionStore(path=tmp_path / "p.db")
+
+    with (
+        patch("fantasy_coach.app._get_repo", return_value=mock_repo),
+        patch("fantasy_coach.app._get_store", return_value=store),
+    ):
+        resp = client.get("/me/dashboard?season=2026")
+
+    assert resp.status_code == 200
+    assert resp.json()["currentRound"] is None

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -304,9 +304,7 @@ def test_dashboard_season_accuracy_and_tips_default_to_zero(
     assert body["correctTips"] == 0
 
 
-def test_dashboard_attaches_prediction_to_next_fixture(
-    client: TestClient, tmp_path: Path
-) -> None:
+def test_dashboard_attaches_prediction_to_next_fixture(client: TestClient, tmp_path: Path) -> None:
     matches = [
         _make_match(
             50,
@@ -378,9 +376,7 @@ def test_dashboard_season_value_matches_request(client: TestClient, tmp_path: Pa
     assert resp.json()["season"] == 2025
 
 
-def test_dashboard_current_round_none_when_no_matches(
-    client: TestClient, tmp_path: Path
-) -> None:
+def test_dashboard_current_round_none_when_no_matches(client: TestClient, tmp_path: Path) -> None:
     mock_repo = MagicMock()
     mock_repo.list_matches.return_value = []
     store = PredictionStore(path=tmp_path / "p.db")

--- a/tests/test_team_profile.py
+++ b/tests/test_team_profile.py
@@ -1,0 +1,244 @@
+"""Tests for the GET /teams/{team_id}/profile endpoint."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fantasy_coach.app import app
+from fantasy_coach.features import MatchRow, TeamRow
+
+
+def _make_match(
+    match_id: int,
+    round_: int,
+    home_id: int,
+    away_id: int,
+    home_score: int | None,
+    away_score: int | None,
+    home_name: str = "Home Team",
+    away_name: str = "Away Team",
+    season: int = 2026,
+    match_state: str = "FullTime",
+    offset_seconds: int = 0,
+) -> MatchRow:
+    return MatchRow(
+        match_id=match_id,
+        season=season,
+        round=round_,
+        start_time=datetime(2026, 3, 1, 9, 0, offset_seconds, tzinfo=UTC),
+        match_state=match_state,
+        venue="Stadium",
+        venue_city="Sydney",
+        weather=None,
+        home=TeamRow(
+            team_id=home_id,
+            name=home_name,
+            nick_name=home_name,
+            score=home_score,
+            players=[],
+        ),
+        away=TeamRow(
+            team_id=away_id,
+            name=away_name,
+            nick_name=away_name,
+            score=away_score,
+            players=[],
+        ),
+        team_stats=[],
+    )
+
+
+def _mock_repo(matches: list[MatchRow]) -> MagicMock:
+    repo = MagicMock()
+    repo.list_matches.return_value = matches
+    return repo
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_app_singletons():
+    import fantasy_coach.app as app_module
+
+    app_module._repo = None
+    app_module._store = None
+    app_module._profile_cache.clear()
+    yield
+    app_module._repo = None
+    app_module._store = None
+    app_module._profile_cache.clear()
+
+
+def test_returns_200_with_correct_structure(client: TestClient) -> None:
+    matches = [
+        _make_match(1, 1, home_id=10, away_id=20, home_score=20, away_score=10, offset_seconds=0),
+        _make_match(2, 2, home_id=20, away_id=10, home_score=14, away_score=22, offset_seconds=1),
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)):
+        response = client.get("/teams/10/profile?season=2026")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["teamId"] == 10
+    assert body["teamName"] == "Home Team"
+    assert body["season"] == 2026
+    assert "currentRecord" in body
+    assert "currentElo" in body
+    assert "eloTrend" in body
+    assert "recentForm" in body
+    assert "nextFixture" in body
+    assert "allFixtures" in body
+
+
+def test_current_record_reflects_results(client: TestClient) -> None:
+    matches = [
+        _make_match(1, 1, home_id=10, away_id=20, home_score=20, away_score=10, offset_seconds=0),
+        _make_match(2, 2, home_id=10, away_id=20, home_score=10, away_score=20, offset_seconds=1),
+        _make_match(3, 3, home_id=10, away_id=20, home_score=15, away_score=15, offset_seconds=2),
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)):
+        response = client.get("/teams/10/profile?season=2026")
+
+    assert response.status_code == 200
+    rec = response.json()["currentRecord"]
+    assert rec == {"wins": 1, "losses": 1, "draws": 1}
+
+
+def test_recent_form_returns_correct_letters(client: TestClient) -> None:
+    matches = [
+        _make_match(1, 1, home_id=10, away_id=20, home_score=20, away_score=10, offset_seconds=0),
+        _make_match(2, 2, home_id=10, away_id=20, home_score=10, away_score=20, offset_seconds=1),
+        _make_match(3, 3, home_id=10, away_id=20, home_score=15, away_score=15, offset_seconds=2),
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)):
+        response = client.get("/teams/10/profile?season=2026")
+
+    assert response.json()["recentForm"] == ["W", "L", "D"]
+
+
+def test_recent_form_capped_at_10(client: TestClient) -> None:
+    matches = [
+        _make_match(
+            i, i, home_id=10, away_id=20, home_score=20, away_score=10, offset_seconds=i
+        )
+        for i in range(1, 16)
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)):
+        response = client.get("/teams/10/profile?season=2026")
+
+    assert len(response.json()["recentForm"]) == 10
+
+
+def test_next_fixture_is_first_upcoming(client: TestClient) -> None:
+    matches = [
+        _make_match(1, 1, home_id=10, away_id=20, home_score=20, away_score=10, offset_seconds=0),
+        _make_match(
+            2, 2, home_id=10, away_id=20,
+            home_score=None, away_score=None,
+            match_state="Upcoming", offset_seconds=1,
+        ),
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)):
+        response = client.get("/teams/10/profile?season=2026")
+
+    body = response.json()
+    assert body["nextFixture"] is not None
+    assert body["nextFixture"]["matchId"] == 2
+    assert body["nextFixture"]["round"] == 2
+
+
+def test_next_fixture_none_when_all_played(client: TestClient) -> None:
+    matches = [
+        _make_match(1, 1, home_id=10, away_id=20, home_score=20, away_score=10),
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)):
+        response = client.get("/teams/10/profile?season=2026")
+
+    assert response.json()["nextFixture"] is None
+
+
+def test_all_fixtures_contains_all_matches(client: TestClient) -> None:
+    matches = [
+        _make_match(1, 1, home_id=10, away_id=20, home_score=20, away_score=10, offset_seconds=0),
+        _make_match(
+            2, 2, home_id=10, away_id=20,
+            home_score=None, away_score=None,
+            match_state="Upcoming", offset_seconds=1,
+        ),
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)):
+        response = client.get("/teams/10/profile?season=2026")
+
+    assert len(response.json()["allFixtures"]) == 2
+
+
+def test_returns_404_when_team_not_in_season(client: TestClient) -> None:
+    matches = [
+        _make_match(1, 1, home_id=10, away_id=20, home_score=20, away_score=10),
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)):
+        response = client.get("/teams/99/profile?season=2026")
+
+    assert response.status_code == 404
+    assert "99" in response.json()["detail"]
+
+
+def test_elo_trend_up_after_wins(client: TestClient) -> None:
+    # Team wins 3 in a row — Elo should trend up.
+    matches = [
+        _make_match(
+            i, i, home_id=10, away_id=20, home_score=30, away_score=10, offset_seconds=i
+        )
+        for i in range(1, 4)
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)):
+        response = client.get("/teams/10/profile?season=2026")
+
+    assert response.json()["eloTrend"] == "up"
+
+
+def test_elo_trend_down_after_losses(client: TestClient) -> None:
+    # Team loses 3 in a row — Elo should trend down.
+    matches = [
+        _make_match(
+            i, i, home_id=10, away_id=20, home_score=10, away_score=30, offset_seconds=i
+        )
+        for i in range(1, 4)
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)):
+        response = client.get("/teams/10/profile?season=2026")
+
+    assert response.json()["eloTrend"] == "down"
+
+
+def test_503_when_repo_unavailable(client: TestClient) -> None:
+    boom_repo = MagicMock()
+    boom_repo.list_matches.side_effect = RuntimeError("db gone")
+
+    with patch("fantasy_coach.app._get_repo", return_value=boom_repo):
+        response = client.get("/teams/10/profile?season=2026")
+
+    assert response.status_code == 503
+
+
+def test_cache_is_used_on_second_request(client: TestClient) -> None:
+    matches = [
+        _make_match(1, 1, home_id=10, away_id=20, home_score=20, away_score=10),
+    ]
+    mock_repo = _mock_repo(matches)
+
+    with patch("fantasy_coach.app._get_repo", return_value=mock_repo):
+        r1 = client.get("/teams/10/profile?season=2026")
+        r2 = client.get("/teams/10/profile?season=2026")
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    # list_matches should only be called once (second hit served from cache).
+    assert mock_repo.list_matches.call_count == 1

--- a/tests/test_team_profile.py
+++ b/tests/test_team_profile.py
@@ -125,9 +125,7 @@ def test_recent_form_returns_correct_letters(client: TestClient) -> None:
 
 def test_recent_form_capped_at_10(client: TestClient) -> None:
     matches = [
-        _make_match(
-            i, i, home_id=10, away_id=20, home_score=20, away_score=10, offset_seconds=i
-        )
+        _make_match(i, i, home_id=10, away_id=20, home_score=20, away_score=10, offset_seconds=i)
         for i in range(1, 16)
     ]
     with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)):
@@ -140,9 +138,14 @@ def test_next_fixture_is_first_upcoming(client: TestClient) -> None:
     matches = [
         _make_match(1, 1, home_id=10, away_id=20, home_score=20, away_score=10, offset_seconds=0),
         _make_match(
-            2, 2, home_id=10, away_id=20,
-            home_score=None, away_score=None,
-            match_state="Upcoming", offset_seconds=1,
+            2,
+            2,
+            home_id=10,
+            away_id=20,
+            home_score=None,
+            away_score=None,
+            match_state="Upcoming",
+            offset_seconds=1,
         ),
     ]
     with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)):
@@ -168,9 +171,14 @@ def test_all_fixtures_contains_all_matches(client: TestClient) -> None:
     matches = [
         _make_match(1, 1, home_id=10, away_id=20, home_score=20, away_score=10, offset_seconds=0),
         _make_match(
-            2, 2, home_id=10, away_id=20,
-            home_score=None, away_score=None,
-            match_state="Upcoming", offset_seconds=1,
+            2,
+            2,
+            home_id=10,
+            away_id=20,
+            home_score=None,
+            away_score=None,
+            match_state="Upcoming",
+            offset_seconds=1,
         ),
     ]
     with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)):
@@ -193,9 +201,7 @@ def test_returns_404_when_team_not_in_season(client: TestClient) -> None:
 def test_elo_trend_up_after_wins(client: TestClient) -> None:
     # Team wins 3 in a row — Elo should trend up.
     matches = [
-        _make_match(
-            i, i, home_id=10, away_id=20, home_score=30, away_score=10, offset_seconds=i
-        )
+        _make_match(i, i, home_id=10, away_id=20, home_score=30, away_score=10, offset_seconds=i)
         for i in range(1, 4)
     ]
     with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)):
@@ -207,9 +213,7 @@ def test_elo_trend_up_after_wins(client: TestClient) -> None:
 def test_elo_trend_down_after_losses(client: TestClient) -> None:
     # Team loses 3 in a row — Elo should trend down.
     matches = [
-        _make_match(
-            i, i, home_id=10, away_id=20, home_score=10, away_score=30, offset_seconds=i
-        )
+        _make_match(i, i, home_id=10, away_id=20, home_score=10, away_score=30, offset_seconds=i)
         for i in range(1, 4)
     ]
     with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)):

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,5 @@
 import { getFirebaseAuth, API_BASE_URL } from "./firebase";
+import type { DashboardOut } from "./types";
 
 export class ApiError extends Error {
   constructor(
@@ -15,6 +16,17 @@ export class NotSignedInError extends Error {
     super("Sign in required");
     this.name = "NotSignedInError";
   }
+}
+
+export async function getDashboard(
+  season: number,
+  favouriteTeamId?: number | null,
+): Promise<DashboardOut> {
+  const params = new URLSearchParams({ season: String(season) });
+  if (favouriteTeamId != null) {
+    params.set("favourite_team_id", String(favouriteTeamId));
+  }
+  return apiFetch<DashboardOut>(`/me/dashboard?${params.toString()}`);
 }
 
 export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {

--- a/web/src/components/MatchCard.tsx
+++ b/web/src/components/MatchCard.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import { TeamFormSparkline } from "./TeamFormSparkline";
 import { TipEntry } from "./TipEntry";
@@ -49,6 +49,7 @@ export function MatchCard({
   homeForm?: TeamFormHistory | null;
   awayForm?: TeamFormHistory | null;
 }) {
+  const navigate = useNavigate();
   const p = prediction;
   const homePct = Math.round(p.homeWinProbability * 100);
   const awayPct = 100 - homePct;
@@ -65,9 +66,25 @@ export function MatchCard({
       <article className="match-card">
         <header className="match-card-head">
           <div className="teams">
-            <span className="team home">{p.home.name}</span>
+            <span
+              className="team home team-link"
+              role="link"
+              tabIndex={0}
+              onClick={(e) => { e.preventDefault(); navigate(`/team/${p.home.id}`); }}
+              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); navigate(`/team/${p.home.id}`); } }}
+            >
+              {p.home.name}
+            </span>
             <span className="muted"> vs </span>
-            <span className="team away">{p.away.name}</span>
+            <span
+              className="team away team-link"
+              role="link"
+              tabIndex={0}
+              onClick={(e) => { e.preventDefault(); navigate(`/team/${p.away.id}`); }}
+              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); navigate(`/team/${p.away.id}`); } }}
+            >
+              {p.away.name}
+            </span>
           </div>
           <time className="kickoff muted" dateTime={p.kickoff}>
             {formatKickoff(p.kickoff)}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,6 +8,7 @@ import Home from "./routes/Home";
 import MatchDetail from "./routes/MatchDetail";
 import Round from "./routes/Round";
 import Scoreboard from "./routes/Scoreboard";
+import Team from "./routes/Team";
 import "./styles.css";
 
 const router = createBrowserRouter([
@@ -20,6 +21,7 @@ const router = createBrowserRouter([
       { path: "round/:season/:round/:matchId", element: <MatchDetail /> },
       { path: "scoreboard", element: <Scoreboard /> },
       { path: "accuracy", element: <Accuracy /> },
+      { path: "team/:teamId", element: <Team /> },
     ],
   },
 ]);

--- a/web/src/routes/Home.tsx
+++ b/web/src/routes/Home.tsx
@@ -1,23 +1,344 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { getDashboard, ApiError, NotSignedInError } from "../api";
 import { useAuth } from "../auth";
-import { RoundSelector } from "../components/RoundSelector";
 import { SignInRequired } from "../components/SignInRequired";
+import type { DashboardOut } from "../types";
+
+const CURRENT_SEASON = 2026;
+const FAV_TEAM_KEY = "fc:fav_team_id";
+
+function getFavouriteTeamId(): number | null {
+  try {
+    const raw = localStorage.getItem(FAV_TEAM_KEY);
+    if (raw === null) return null;
+    const n = parseInt(raw, 10);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+function setFavouriteTeamId(id: number | null): void {
+  try {
+    if (id === null) {
+      localStorage.removeItem(FAV_TEAM_KEY);
+    } else {
+      localStorage.setItem(FAV_TEAM_KEY, String(id));
+    }
+  } catch {
+    // storage full — ignore
+  }
+}
+
+function formatKickoff(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Team picker — minimal form for entering a team ID
+// ---------------------------------------------------------------------------
+
+function TeamPicker({ onPick }: { onPick: (id: number | null) => void }) {
+  const [input, setInput] = useState("");
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const n = parseInt(input, 10);
+    if (Number.isFinite(n) && n > 0) {
+      onPick(n);
+    }
+  }
+
+  return (
+    <form className="dashboard-team-picker-form" onSubmit={handleSubmit}>
+      <label>
+        Team ID
+        <input
+          type="number"
+          value={input}
+          min={1}
+          placeholder="e.g. 7"
+          onChange={(e) => setInput(e.target.value)}
+        />
+      </label>
+      <button type="submit" disabled={input === ""}>
+        Set favourite
+      </button>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard cards
+// ---------------------------------------------------------------------------
+
+function YourTeamCard({
+  dashboard,
+  onTeamChange,
+}: {
+  dashboard: DashboardOut;
+  onTeamChange: (id: number | null) => void;
+}) {
+  const fixture = dashboard.nextFixture;
+
+  return (
+    <div className="dashboard-card">
+      <h2 className="dashboard-card-title">Your Team</h2>
+      {dashboard.favouriteTeamId == null ? (
+        <div className="dashboard-team-picker">
+          <p className="muted">No favourite team set.</p>
+          <TeamPicker onPick={onTeamChange} />
+        </div>
+      ) : fixture != null ? (
+        <div>
+          <p className="muted dashboard-card-subtitle">Next fixture</p>
+          <p className="dashboard-fixture-line">
+            <strong>Round {fixture.round}</strong>
+            {" — "}
+            {fixture.isHome ? "Home vs " : "Away @ "}
+            <Link to={`/team/${fixture.opponentId}`}>{fixture.opponent}</Link>
+          </p>
+          <p className="muted">
+            <time dateTime={fixture.kickoff}>{formatKickoff(fixture.kickoff)}</time>
+          </p>
+          {fixture.predWinner != null && (
+            <p className="dashboard-prediction muted">
+              Model pick:{" "}
+              <strong>
+                {fixture.predWinner === "home"
+                  ? fixture.isHome
+                    ? "your team"
+                    : fixture.opponent
+                  : fixture.isHome
+                    ? fixture.opponent
+                    : "your team"}
+              </strong>
+              {fixture.predProb != null && (
+                <span>
+                  {" "}
+                  (
+                  {Math.round(
+                    (fixture.predWinner === "home"
+                      ? fixture.predProb
+                      : 1 - fixture.predProb) * 100,
+                  )}
+                  %)
+                </span>
+              )}
+            </p>
+          )}
+          <button
+            type="button"
+            className="dashboard-change-team"
+            onClick={() => onTeamChange(null)}
+          >
+            Change team
+          </button>
+        </div>
+      ) : (
+        <div>
+          <p className="muted">No upcoming fixtures for your team this season.</p>
+          <button
+            type="button"
+            className="dashboard-change-team"
+            onClick={() => onTeamChange(null)}
+          >
+            Change team
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TipRoundCard({ dashboard }: { dashboard: DashboardOut }) {
+  const round = dashboard.currentRound;
+  const matchIds = dashboard.untippedMatchIds;
+
+  if (round == null) {
+    return (
+      <div className="dashboard-card">
+        <h2 className="dashboard-card-title">Tip Round</h2>
+        <p className="muted">No active round found.</p>
+      </div>
+    );
+  }
+
+  if (matchIds.length === 0) {
+    return (
+      <div className="dashboard-card">
+        <h2 className="dashboard-card-title">Round {round}</h2>
+        <p className="dashboard-round-complete">Round {round} complete ✓</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="dashboard-card">
+      <h2 className="dashboard-card-title">Tip Round {round}</h2>
+      <p className="muted dashboard-card-subtitle">
+        {matchIds.length} match{matchIds.length !== 1 ? "es" : ""} this round
+      </p>
+      <Link
+        to={`/round/${dashboard.season}/${round}`}
+        className="dashboard-view-round-link"
+      >
+        View predictions →
+      </Link>
+    </div>
+  );
+}
+
+function AccuracyCard({ dashboard }: { dashboard: DashboardOut }) {
+  const { seasonAccuracy, totalTips, correctTips } = dashboard;
+
+  return (
+    <div className="dashboard-card">
+      <h2 className="dashboard-card-title">Your Accuracy</h2>
+      {totalTips === 0 ? (
+        <p className="muted">No tips yet this season.</p>
+      ) : (
+        <div>
+          <p className="dashboard-accuracy-value">
+            {seasonAccuracy != null
+              ? `${Math.round(seasonAccuracy * 100)}%`
+              : "—"}
+          </p>
+          <p className="muted">
+            {correctTips} correct from {totalTips} tip{totalTips !== 1 ? "s" : ""}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Signed-in personalised dashboard
+// ---------------------------------------------------------------------------
+
+type DashStatus =
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "ok"; data: DashboardOut };
+
+function PersonalisedDashboard() {
+  const { user } = useAuth();
+  const [favTeamId, setFavTeamId] = useState<number | null>(() =>
+    getFavouriteTeamId(),
+  );
+  const [status, setStatus] = useState<DashStatus>({ kind: "loading" });
+
+  useEffect(() => {
+    if (!user) return;
+    let cancelled = false;
+
+    setStatus({ kind: "loading" });
+    getDashboard(CURRENT_SEASON, favTeamId)
+      .then((data) => {
+        if (!cancelled) setStatus({ kind: "ok", data });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof NotSignedInError) {
+          setStatus({ kind: "error", message: "Sign in required." });
+        } else if (err instanceof ApiError) {
+          setStatus({
+            kind: "error",
+            message: `Could not load dashboard (${err.status}).`,
+          });
+        } else {
+          setStatus({ kind: "error", message: "Could not load dashboard." });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user, favTeamId]);
+
+  function handleTeamChange(id: number | null) {
+    setFavouriteTeamId(id);
+    setFavTeamId(id);
+  }
+
+  if (status.kind === "loading") {
+    return <p role="status">Loading dashboard…</p>;
+  }
+
+  if (status.kind === "error") {
+    return (
+      <div className="error-box" role="alert">
+        {status.message}
+      </div>
+    );
+  }
+
+  const { data } = status;
+
+  return (
+    <section className="dashboard">
+      <h1>Dashboard</h1>
+      <div className="dashboard-grid">
+        <YourTeamCard dashboard={data} onTeamChange={handleTeamChange} />
+        <TipRoundCard dashboard={data} />
+        <AccuracyCard dashboard={data} />
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Landing page for signed-out visitors
+// ---------------------------------------------------------------------------
+
+function LandingPage() {
+  return (
+    <section>
+      <h1>Fantasy Coach</h1>
+      <p>
+        NRL match predictions powered by machine learning. Pick your round to see
+        predicted winners and home-win probabilities for every match.
+      </p>
+      <div className="landing-features">
+        <div className="landing-feature">
+          <strong>XGBoost predictions</strong>
+          <p>Machine-learning model trained on historical NRL data.</p>
+        </div>
+        <div className="landing-feature">
+          <strong>Feature insights</strong>
+          <p>See which factors drove each prediction.</p>
+        </div>
+        <div className="landing-feature">
+          <strong>Accuracy tracking</strong>
+          <p>Walk-forward model accuracy updated each round.</p>
+        </div>
+      </div>
+      <SignInRequired message="Sign in to view predictions and track your tips." />
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Root Home route
+// ---------------------------------------------------------------------------
 
 export default function Home() {
   const { user, loading } = useAuth();
 
   if (loading) return <p role="status">Loading…</p>;
 
-  return (
-    <section>
-      <h1>Predictions</h1>
-      <p>
-        Pick a round to see predicted winners and home-win probabilities for every match.
-      </p>
-      {user ? (
-        <RoundSelector />
-      ) : (
-        <SignInRequired message="Sign in to pick a round and view predictions." />
-      )}
-    </section>
-  );
+  if (!user) return <LandingPage />;
+
+  return <PersonalisedDashboard />;
 }

--- a/web/src/routes/Team.tsx
+++ b/web/src/routes/Team.tsx
@@ -1,0 +1,251 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { apiFetch, ApiError, NotSignedInError } from "../api";
+import { useAuth } from "../auth";
+import { SignInRequired } from "../components/SignInRequired";
+import type { TeamProfile } from "../types";
+
+const CURRENT_SEASON = 2026;
+
+type Status =
+  | { kind: "loading" }
+  | { kind: "notfound" }
+  | { kind: "error"; message: string }
+  | { kind: "ok"; profile: TeamProfile };
+
+function formatKickoff(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function EloTrendArrow({ trend }: { trend: "up" | "down" | "flat" }) {
+  if (trend === "up") return <span aria-label="trending up" style={{ color: "var(--color-win, #22c55e)" }}>↑</span>;
+  if (trend === "down") return <span aria-label="trending down" style={{ color: "var(--color-loss, #ef4444)" }}>↓</span>;
+  return <span aria-label="flat" style={{ color: "var(--color-text-muted)" }}>→</span>;
+}
+
+function FormPill({ result }: { result: string }) {
+  let bg = "var(--color-text-muted)";
+  let color = "#fff";
+  if (result === "W") { bg = "var(--color-win, #22c55e)"; }
+  else if (result === "L") { bg = "var(--color-loss, #ef4444)"; }
+  return (
+    <span
+      aria-label={result === "W" ? "Win" : result === "L" ? "Loss" : "Draw"}
+      style={{
+        display: "inline-block",
+        width: "1.5rem",
+        height: "1.5rem",
+        lineHeight: "1.5rem",
+        textAlign: "center",
+        borderRadius: "0.25rem",
+        fontSize: "0.75rem",
+        fontWeight: 700,
+        background: bg,
+        color,
+        marginRight: "0.25rem",
+      }}
+    >
+      {result}
+    </span>
+  );
+}
+
+export default function Team() {
+  const { teamId: teamIdParam } = useParams<{ teamId: string }>();
+  const { user, loading: authLoading } = useAuth();
+  const [status, setStatus] = useState<Status>({ kind: "loading" });
+
+  const teamId = Number(teamIdParam);
+  const validId = Number.isFinite(teamId) && teamId > 0;
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) return;
+    if (!validId) {
+      setStatus({ kind: "error", message: "Invalid team ID." });
+      return;
+    }
+
+    let cancelled = false;
+    setStatus({ kind: "loading" });
+
+    apiFetch<TeamProfile>(`/teams/${teamId}/profile?season=${CURRENT_SEASON}`)
+      .then((profile) => {
+        if (!cancelled) setStatus({ kind: "ok", profile });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof NotSignedInError) {
+          setStatus({ kind: "error", message: "Sign in required." });
+        } else if (err instanceof ApiError) {
+          if (err.status === 404) {
+            setStatus({ kind: "notfound" });
+          } else {
+            setStatus({ kind: "error", message: `API error (${err.status}): ${err.message}` });
+          }
+        } else {
+          setStatus({ kind: "error", message: "Could not load team profile." });
+        }
+      });
+
+    return () => { cancelled = true; };
+  }, [authLoading, user, teamId, validId]);
+
+  if (authLoading) return <p>Loading…</p>;
+  if (!user) return <SignInRequired message="Sign in to view team profiles." />;
+
+  if (status.kind === "loading") {
+    return <p role="status">Loading team profile…</p>;
+  }
+
+  if (status.kind === "notfound") {
+    return (
+      <div className="error-box" role="alert">
+        Team not found in {CURRENT_SEASON}. The team may not have played any matches yet.
+      </div>
+    );
+  }
+
+  if (status.kind === "error") {
+    return (
+      <div className="error-box" role="alert">
+        {status.message}
+      </div>
+    );
+  }
+
+  const { profile } = status;
+  const { wins, losses, draws } = profile.currentRecord;
+
+  return (
+    <section className="team-profile">
+      {/* Header */}
+      <header className="team-profile-header">
+        <h1 className="team-profile-name">{profile.teamName}</h1>
+        <p className="team-profile-record muted">
+          {wins}W – {losses}L{draws > 0 ? ` – ${draws}D` : ""} &nbsp;|&nbsp; {CURRENT_SEASON}
+        </p>
+      </header>
+
+      {/* Elo */}
+      <div className="team-profile-elo">
+        <span className="team-profile-elo-value">Elo: <strong>{profile.currentElo}</strong></span>
+        {" "}
+        <EloTrendArrow trend={profile.eloTrend} />
+      </div>
+
+      {/* Recent form */}
+      {profile.recentForm.length > 0 && (
+        <div className="team-profile-form">
+          <h2>Recent Form</h2>
+          <div className="team-profile-form-pills" aria-label="Last 10 results">
+            {profile.recentForm.map((r, i) => (
+              <FormPill key={i} result={r} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Next fixture */}
+      {profile.nextFixture && (
+        <div className="team-profile-next">
+          <h2>Next Fixture</h2>
+          <div className="team-profile-next-card">
+            <p>
+              <strong>Round {profile.nextFixture.round}</strong>
+              {" — "}
+              {profile.nextFixture.isHome ? "Home vs " : "Away @ "}
+              <Link to={`/team/${profile.nextFixture.opponentId}`}>
+                {profile.nextFixture.opponent}
+              </Link>
+            </p>
+            <p className="muted">
+              <time dateTime={profile.nextFixture.kickoff}>
+                {formatKickoff(profile.nextFixture.kickoff)}
+              </time>
+            </p>
+            {profile.nextFixture.predWinner != null && (
+              <p className="team-profile-prediction">
+                Prediction:{" "}
+                <strong>
+                  {profile.nextFixture.predWinner === "home"
+                    ? (profile.nextFixture.isHome ? profile.teamName : profile.nextFixture.opponent)
+                    : (profile.nextFixture.isHome ? profile.nextFixture.opponent : profile.teamName)}
+                </strong>
+                {profile.nextFixture.predProb != null && (
+                  <span className="muted">
+                    {" "}({Math.round(
+                      (profile.nextFixture.predWinner === "home"
+                        ? profile.nextFixture.predProb
+                        : 1 - profile.nextFixture.predProb) * 100
+                    )}%)
+                  </span>
+                )}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* All fixtures */}
+      {profile.allFixtures.length > 0 && (
+        <div className="team-profile-fixtures">
+          <h2>Season Fixtures</h2>
+          <table className="team-profile-fixture-table">
+            <thead>
+              <tr>
+                <th>Rd</th>
+                <th>Opponent</th>
+                <th>H/A</th>
+                <th>Kickoff</th>
+                <th>Result</th>
+              </tr>
+            </thead>
+            <tbody>
+              {profile.allFixtures.map((f) => (
+                <tr key={f.matchId} className={f.result ? `fixture-row--${f.result === "W" ? "win" : f.result === "L" ? "loss" : "draw"}` : ""}>
+                  <td>{f.round}</td>
+                  <td>
+                    <Link to={`/team/${f.opponentId}`}>{f.opponent}</Link>
+                  </td>
+                  <td>{f.isHome ? "H" : "A"}</td>
+                  <td className="muted">
+                    <time dateTime={f.kickoff}>{formatKickoff(f.kickoff)}</time>
+                  </td>
+                  <td>
+                    {f.result ? (
+                      <span>
+                        <FormPill result={f.result} />
+                        {f.score}–{f.opponentScore}
+                      </span>
+                    ) : f.predWinner != null ? (
+                      <span className="muted">
+                        Pred: {f.predWinner === "home"
+                          ? (f.isHome ? profile.teamName : f.opponent)
+                          : (f.isHome ? f.opponent : profile.teamName)}
+                        {f.predProb != null && (
+                          <> ({Math.round((f.predWinner === "home" ? f.predProb : 1 - f.predProb) * 100)}%)</>
+                        )}
+                      </span>
+                    ) : (
+                      <span className="muted">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1118,3 +1118,265 @@ a:focus-visible {
 .match-card .consensus-badge {
   margin-top: 0.25rem;
 }
+
+/* Team name links inside MatchCard */
+.team-link {
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+}
+
+.team-link:hover {
+  text-decoration-style: solid;
+}
+
+/* ── Team Profile ──────────────────────────────────────────────────────── */
+
+.team-profile {
+  max-width: 800px;
+}
+
+.team-profile-header {
+  margin-bottom: 1rem;
+}
+
+.team-profile-name {
+  margin: 0 0 0.25rem;
+}
+
+.team-profile-record {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.team-profile-elo {
+  font-size: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.team-profile-form h2,
+.team-profile-next h2,
+.team-profile-fixtures h2 {
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.team-profile-form-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.team-profile-next {
+  margin-bottom: 1.5rem;
+}
+
+.team-profile-next-card {
+  padding: 0.75rem 1rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+}
+
+.team-profile-next-card p {
+  margin: 0 0 0.4rem;
+}
+
+.team-profile-next-card p:last-child {
+  margin-bottom: 0;
+}
+
+.team-profile-prediction {
+  font-size: 0.9rem;
+}
+
+.team-profile-fixture-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.team-profile-fixture-table th {
+  text-align: left;
+  padding: 0.4rem 0.5rem;
+  border-bottom: 2px solid var(--color-border);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+}
+
+.team-profile-fixture-table td {
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+  vertical-align: middle;
+}
+
+.fixture-row--win td:first-child {
+  border-left: 3px solid var(--color-win, #22c55e);
+}
+
+.fixture-row--loss td:first-child {
+  border-left: 3px solid var(--color-loss, #ef4444);
+}
+
+.fixture-row--draw td:first-child {
+  border-left: 3px solid var(--color-text-muted);
+}
+
+/* ── Dashboard (personalised home) ────────────────────────────────────── */
+
+.dashboard h1 {
+  margin-top: 0;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin-top: 1.25rem;
+}
+
+@media (min-width: 640px) {
+  .dashboard-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 900px) {
+  .dashboard-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.dashboard-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dashboard-card-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.dashboard-card-subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.dashboard-fixture-line {
+  margin: 0;
+}
+
+.dashboard-prediction {
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.dashboard-change-team {
+  margin-top: 0.5rem;
+  background: transparent;
+  border-color: var(--color-border-subtle);
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  padding: 0.25rem 0.6rem;
+}
+
+.dashboard-change-team:hover {
+  background: transparent;
+  border-color: var(--color-primary);
+  color: var(--color-text);
+}
+
+.dashboard-team-picker p {
+  margin: 0 0 0.75rem;
+}
+
+.dashboard-team-picker-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: flex-end;
+}
+
+.dashboard-team-picker-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.dashboard-team-picker-form input {
+  font: inherit;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  width: 6rem;
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.dashboard-round-complete {
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.dashboard-view-round-link {
+  display: inline-block;
+  margin-top: 0.25rem;
+  font-size: 0.9rem;
+  color: var(--color-text);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.dashboard-accuracy-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0;
+  line-height: 1.2;
+}
+
+/* ── Landing page (signed-out) ─────────────────────────────────────────── */
+
+.landing-features {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+@media (min-width: 600px) {
+  .landing-features {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.landing-feature {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+}
+
+.landing-feature strong {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.landing-feature p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -142,3 +142,24 @@ export type AccuracyOut = {
   venues: string[];
   modelVersions: string[];
 };
+
+export type DashboardOut = {
+  season: number;
+  currentRound: number | null;
+  favouriteTeamId: number | null;
+  nextFixture: {
+    matchId: number;
+    round: number;
+    opponent: string;
+    opponentId: number;
+    isHome: boolean;
+    kickoff: string;
+    predWinner: "home" | "away" | null;
+    predProb: number | null;
+    season: number;
+  } | null;
+  untippedMatchIds: number[];
+  seasonAccuracy: number | null;
+  totalTips: number;
+  correctTips: number;
+};

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -94,6 +94,43 @@ export type AccuracyFilters = {
   modelVersion: string | null;
 };
 
+export type TeamFixture = {
+  round: number;
+  matchId: number;
+  opponent: string;
+  opponentId: number;
+  isHome: boolean;
+  kickoff: string;
+  result: "W" | "L" | "D" | null;
+  score: number | null;
+  opponentScore: number | null;
+  predWinner?: "home" | "away" | null;
+  predProb?: number | null;
+};
+
+export type TeamNextFixture = {
+  matchId: number;
+  round: number;
+  opponent: string;
+  opponentId: number;
+  isHome: boolean;
+  kickoff: string;
+  predWinner: "home" | "away" | null;
+  predProb: number | null;
+};
+
+export type TeamProfile = {
+  teamId: number;
+  teamName: string;
+  season: number;
+  currentRecord: { wins: number; losses: number; draws: number };
+  currentElo: number;
+  eloTrend: "up" | "down" | "flat";
+  recentForm: string[];
+  nextFixture: TeamNextFixture | null;
+  allFixtures: TeamFixture[];
+};
+
 export type AccuracyOut = {
   rounds: RoundAccuracy[];
   byModelVersion: Array<{ modelVersion: string; total: number; correct: number; accuracy: number }>;


### PR DESCRIPTION
## Summary

- **#147 Team profile pages** — new `GET /teams/{team_id}/profile` API endpoint + `/team/:teamId` React route
- **#148 Personalised home dashboard** — new `GET /me/dashboard` API endpoint + types/helpers

## Changes

### Backend (`src/fantasy_coach/app.py`)

**`GET /teams/{team_id}/profile`**
- Returns `TeamProfile`: W-L-D season record, current Elo rating with trend (`up`/`down`/`flat` based on last 3 matches), last-10-match form string (`["W","L","D",...]`), next upcoming fixture (with prediction if cached), and full season fixture list
- 60s in-process cache per `(team_id, season)` to avoid re-replaying full Elo history on every request
- Returns 503 if the match store is unavailable; 404 if team not found in season

**`GET /me/dashboard`**
- Returns `DashboardOut`: favourite team ID + next fixture, current round untipped match IDs, season-to-date accuracy, total/correct tips
- Auth via `_require_auth` dependency (reads `request.state.uid` set by `FirebaseAuthMiddleware`; returns `__dev__` sentinel for local SQLite dev)
- 60s per-user cache

### Frontend

- **`web/src/routes/Team.tsx`** — `/team/:teamId` route: form pills, Elo trend arrow, next fixture card, full fixture list with results, loading/error/404 states
- **`web/src/components/MatchCard.tsx`** — team name text made into `Link` to `/team/:teamId`
- **`web/src/types.ts`** — `TeamProfile`, `TeamNextFixture`, `TeamFixture`, `DashboardOut` types
- **`web/src/api.ts`** — `getDashboard()` helper

### Tests

- **`tests/test_team_profile.py`** — 12 unit tests: record calculation, form string, Elo trend, cache hit (single `list_matches` call on repeat requests), 404, 503
- **`tests/test_dashboard.py`** — dashboard endpoint unit tests

## Test plan

- [x] `uv run python -m pytest tests/test_team_profile.py tests/test_dashboard.py -v` — all pass
- [x] `uv run python -m pytest tests/ -x -q` — full suite passes
- [ ] Manual: visit `/team/500014` (Melbourne Storm) in dev and verify form pills + next fixture render

Closes #147, Closes #148

---
_Generated by [Claude Code](https://claude.ai/code/session_012A6Hy5H3tdqEFcndNh8EVK)_