### PR TITLE
feat(features): rolling team-stat features as player-level proxies (closes #160)

### DIFF
--- a/src/fantasy_coach/feature_engineering.py
+++ b/src/fantasy_coach/feature_engineering.py
@@ -34,7 +34,7 @@ from datetime import datetime
 import numpy as np
 
 from fantasy_coach.bookmaker.lines import devig_two_way
-from fantasy_coach.features import MatchRow, PlayerRow
+from fantasy_coach.features import MatchRow, PlayerRow, TeamStat
 from fantasy_coach.models.elo import Elo
 from fantasy_coach.models.elo_mov import EloMOV
 from fantasy_coach.models.player_ratings import PlayerRatings
@@ -130,6 +130,14 @@ FEATURE_NAMES = (
     "home_days_rest",
     "away_days_rest",
     "short_turnaround_diff",
+    # Team-stat rolling features (#160). Per-match team-aggregate stats as
+    # rolling-5 window proxies for player-level contribution signals.
+    # All expressed home minus away; missing_team_stats flags data gaps.
+    "rolling_kick_metres_diff",
+    "rolling_kick_return_metres_diff",
+    "rolling_line_breaks_diff",
+    "rolling_all_runs_diff",
+    "missing_team_stats",
 )
 
 # Plain-English rationale in docs/model.md. These are expert-prior weights:
@@ -172,6 +180,7 @@ DEFAULT_DAYS_REST = 14
 
 REF_WINDOW = 20  # rolling window for referee stats
 REF_SHRINKAGE_N = 10  # shrink toward league mean for fewer than N prior matches
+_TEAM_STATS_WINDOW = 5
 
 
 @dataclass(frozen=True)
@@ -254,6 +263,19 @@ class FeatureBuilder:
         self._adj_points_against: dict[int, deque[float]] = defaultdict(
             lambda: deque(maxlen=ROLLING_WINDOW)
         )
+        # Team-stat rolling deques (#160) — updated in record() after each completed match.
+        self._team_kick_metres: dict[int, deque[float]] = defaultdict(
+            lambda: deque(maxlen=_TEAM_STATS_WINDOW)
+        )
+        self._team_kick_return_metres: dict[int, deque[float]] = defaultdict(
+            lambda: deque(maxlen=_TEAM_STATS_WINDOW)
+        )
+        self._team_line_breaks: dict[int, deque[float]] = defaultdict(
+            lambda: deque(maxlen=_TEAM_STATS_WINDOW)
+        )
+        self._team_all_runs: dict[int, deque[float]] = defaultdict(
+            lambda: deque(maxlen=_TEAM_STATS_WINDOW)
+        )
 
     def feature_row(self, match: MatchRow) -> list[float]:
         h_id, a_id = match.home.team_id, match.away.team_id
@@ -305,6 +327,16 @@ class FeatureBuilder:
             match.home.odds,
             match.away.odds,
         )
+        kick_m_h = _avg(self._team_kick_metres[h_id])
+        kick_m_a = _avg(self._team_kick_metres[a_id])
+        kick_ret_h = _avg(self._team_kick_return_metres[h_id])
+        kick_ret_a = _avg(self._team_kick_return_metres[a_id])
+        lb_h = _avg(self._team_line_breaks[h_id])
+        lb_a = _avg(self._team_line_breaks[a_id])
+        runs_h = _avg(self._team_all_runs[h_id])
+        runs_a = _avg(self._team_all_runs[a_id])
+        missing_ts = 1.0 if len(self._team_kick_metres[h_id]) == 0 else 0.0
+
         return [
             elo_diff,
             form_pf_h - form_pf_a,
@@ -340,6 +372,11 @@ class FeatureBuilder:
             home_dr,
             away_dr,
             st_diff,
+            kick_m_h - kick_m_a,
+            kick_ret_h - kick_ret_a,
+            lb_h - lb_a,
+            runs_h - runs_a,
+            missing_ts,
         ]
 
     def _player_strength(self, players: list[PlayerRow]) -> tuple[float, bool]:
@@ -561,6 +598,22 @@ class FeatureBuilder:
             h_score,
             a_score,
         )
+        # Update team-stat rolling deques (#160). Skip when stat is absent so
+        # the deque correctly reflects the last _TEAM_STATS_WINDOW matches with
+        # real data rather than being diluted by zeros.
+        for team_id, side in ((h_id, "home"), (a_id, "away")):
+            km = _extract_stat(match.team_stats, "Kicking Metres", side)
+            if km is not None:
+                self._team_kick_metres[team_id].append(km)
+            kr = _extract_stat(match.team_stats, "Kick Return Metres", side)
+            if kr is not None:
+                self._team_kick_return_metres[team_id].append(kr)
+            lb = _extract_stat(match.team_stats, "Line Breaks", side)
+            if lb is not None:
+                self._team_line_breaks[team_id].append(lb)
+            ar = _extract_stat(match.team_stats, "All Runs", side)
+            if ar is not None:
+                self._team_all_runs[team_id].append(ar)
 
 
 def build_training_frame(
@@ -690,6 +743,14 @@ def _is_complete(match: MatchRow) -> bool:
         and match.home.score is not None
         and match.away.score is not None
     )
+
+
+def _extract_stat(team_stats: list[TeamStat], title: str, side: str) -> float | None:
+    """Return the home or away value for a named team stat, or None if absent."""
+    for stat in team_stats:
+        if stat.title == title:
+            return stat.home_value if side == "home" else stat.away_value
+    return None
 
 
 def _avg(values: Iterable[int | float]) -> float:

--- a/tests/test_baseline_metrics.py
+++ b/tests/test_baseline_metrics.py
@@ -83,29 +83,21 @@ EXPECTED = {
     "home": {"n": 480, "accuracy": 0.5646, "log_loss": 0.6852, "brier": 0.2460},
     "elo": {"n": 480, "accuracy": 0.5833, "log_loss": 0.6628, "brier": 0.2353},
     "elo_mov": {"n": 480, "accuracy": 0.6125, "log_loss": 0.6668, "brier": 0.2366},
-    # #168 adds h2h_last5_home_win_rate + h2h_last5_avg_margin + missing_h2h.
-    # Logistic regresses slightly — sparse H2H history on the 2024–2026 window
-    # adds noise for logistic regression (less robust to sparse features than
-    # tree-based models). Expected to improve once the 2023 backfill (#158) lands.
-    # XGBoost marginally regresses on this narrow window for the same reason;
-    # feature signal is expected to compound with deeper H2H history.
-    #
-    # #170 adds home_days_rest + away_days_rest + short_turnaround_diff (granular
-    # scheduling features). Logistic accuracy improves +0.83 pp (0.5604 → 0.5687)
-    # on the 2024–2026 baseline; XGBoost and Skellam gain marginally. Logistic
-    # log_loss regresses slightly — extra features add estimation variance on this
-    # narrow training window; expected to improve once the 2023 backfill (#158)
-    # provides more scheduling history.
-    "logistic": {"n": 480, "accuracy": 0.5687, "log_loss": 0.8505, "brier": 0.2780},
-    "xgboost": {"n": 480, "accuracy": 0.5792, "log_loss": 0.7104, "brier": 0.2532},
-    "skellam": {"n": 480, "accuracy": 0.5750, "log_loss": 0.7120, "brier": 0.2538},
-    # #171 stacks XGBoost + Skellam + EloMOV behind a logistic-regression
-    # meta-learner fit on out-of-fold base probabilities. Beats XGBoost on
-    # all three metrics (+1.25 pp accuracy, −3.8 % log_loss, −3.7 % brier)
-    # on this baseline. Still trails EloMOV on accuracy; meta-learner
-    # regularisation on the 20 % val slice dilutes EloMOV's lead.
-    # #170: stacked gains +0.42 pp accuracy (0.5854 → 0.5896).
-    "stacked": {"n": 480, "accuracy": 0.5896, "log_loss": 0.6767, "brier": 0.2407},
+    # #160 adds rolling_kick_metres_diff + rolling_kick_return_metres_diff +
+    # rolling_line_breaks_diff + rolling_all_runs_diff + missing_team_stats
+    # (team-stat proxies for player-level contribution signals, rolling-5).
+    # Logistic regresses slightly (same sparse-feature noise pattern as #108 /
+    # #168) — expected to improve once the 2023 backfill (#158) provides more
+    # rolling-stat history. XGBoost gains +3.54 pp accuracy, −0.017 log_loss,
+    # −0.008 brier — tree-based models extract real signal from the 2024–2026
+    # team-stat data available in the baseline DB.
+    # Skellam accuracy regresses -0.83 pp; log_loss/brier essentially unchanged.
+    # Stacked regresses modestly because it wraps logistic + skellam.
+    "logistic": {"n": 480, "accuracy": 0.5667, "log_loss": 0.8754, "brier": 0.2809},
+    "xgboost": {"n": 480, "accuracy": 0.6146, "log_loss": 0.6936, "brier": 0.2454},
+    "skellam": {"n": 480, "accuracy": 0.5667, "log_loss": 0.7119, "brier": 0.2538},
+    # #160: stacked regresses modestly alongside logistic/skellam (−0.002 acc).
+    "stacked": {"n": 480, "accuracy": 0.5875, "log_loss": 0.6845, "brier": 0.2439},
 }
 
 PREDICTORS: dict[str, type[Predictor]] = {

--- a/tests/test_team_stats_features.py
+++ b/tests/test_team_stats_features.py
@@ -1,0 +1,92 @@
+"""Unit tests for the rolling team-stat features added in #160."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from fantasy_coach.feature_engineering import FEATURE_NAMES, FeatureBuilder
+from fantasy_coach.features import MatchRow, TeamRow, TeamStat
+
+
+def _make_match(
+    match_id: int,
+    round_: int,
+    h_score: int | None = None,
+    a_score: int | None = None,
+    state: str = "FullTime",
+    stats: list[TeamStat] | None = None,
+) -> MatchRow:
+    return MatchRow(
+        match_id=match_id,
+        season=2024,
+        round=round_,
+        start_time=datetime(2024, 3, 1, 9, 0, round_, tzinfo=UTC),
+        match_state=state,
+        venue="Stadium",
+        venue_city="Sydney",
+        weather=None,
+        home=TeamRow(team_id=1, name="Home", nick_name="HOM", score=h_score, players=[]),
+        away=TeamRow(team_id=2, name="Away", nick_name="AWY", score=a_score, players=[]),
+        team_stats=stats or [],
+    )
+
+
+def _stat(title: str, home_val: float, away_val: float) -> TeamStat:
+    return TeamStat(title=title, type="stat", units=None, home_value=home_val, away_value=away_val)
+
+
+def _feature_dict(builder: FeatureBuilder, match: MatchRow) -> dict[str, float]:
+    return dict(zip(FEATURE_NAMES, builder.feature_row(match), strict=True))
+
+
+def test_missing_team_stats_is_1_when_no_history():
+    """missing_team_stats = 1.0 before any stats have been recorded."""
+    builder = FeatureBuilder()
+    m = _make_match(1, 1, state="Upcoming")
+    row = _feature_dict(builder, m)
+    assert row["missing_team_stats"] == 1.0
+
+
+def test_missing_team_stats_clears_after_recording():
+    """missing_team_stats = 0.0 once the home team has at least one recorded stat."""
+    builder = FeatureBuilder()
+    stats = [
+        _stat("Kicking Metres", 400.0, 300.0),
+        _stat("Kick Return Metres", 100.0, 80.0),
+        _stat("Line Breaks", 3.0, 2.0),
+        _stat("All Runs", 120.0, 100.0),
+    ]
+    m1 = _make_match(1, 1, h_score=20, a_score=10, stats=stats)
+    builder.record(m1)
+    m2 = _make_match(2, 2, state="Upcoming")
+    row = _feature_dict(builder, m2)
+    assert row["missing_team_stats"] == 0.0
+
+
+def test_rolling_kick_metres_averages_correctly():
+    """rolling_kick_metres_diff reflects the rolling-5 average of recorded values."""
+    builder = FeatureBuilder()
+    for i in range(1, 4):
+        stats = [
+            _stat("Kicking Metres", float(100 * i), float(50 * i)),
+            _stat("Kick Return Metres", 80.0, 60.0),
+            _stat("Line Breaks", 2.0, 1.0),
+            _stat("All Runs", 100.0, 90.0),
+        ]
+        builder.record(_make_match(i, i, h_score=20, a_score=10, stats=stats))
+
+    m_next = _make_match(10, 10, state="Upcoming")
+    row = _feature_dict(builder, m_next)
+    # Home avg kicking metres = (100+200+300)/3 = 200; away = (50+100+150)/3 = 100
+    assert row["rolling_kick_metres_diff"] == pytest.approx(100.0, abs=0.5)
+
+
+def test_feature_names_count():
+    """FEATURE_NAMES should include the 5 new team-stat features."""
+    assert "rolling_kick_metres_diff" in FEATURE_NAMES
+    assert "rolling_kick_return_metres_diff" in FEATURE_NAMES
+    assert "rolling_line_breaks_diff" in FEATURE_NAMES
+    assert "rolling_all_runs_diff" in FEATURE_NAMES
+    assert "missing_team_stats" in FEATURE_NAMES


### PR DESCRIPTION
## Summary

Adds 5 new `FEATURE_NAMES` entries to `FeatureBuilder` using per-match team-aggregate stats as rolling-5 window proxies for player-level contribution signals.

### New features

| Feature | Signal |
|---------|--------|
| `rolling_kick_metres_diff` | Halfback kicking game / field-position dominance |
| `rolling_kick_return_metres_diff` | Fullback counter-attack effectiveness |
| `rolling_line_breaks_diff` | Attack incisiveness |
| `rolling_all_runs_diff` | Forward pack workload |
| `missing_team_stats` | Imputation flag for historical data gaps |

All features use only past completed-match data via `record()` — no leakage. Missing stat values are skipped (not zeroed) so the deque reflects the last `_TEAM_STATS_WINDOW=5` matches that actually had team-stat data.

### Baseline metrics (n=480, 2024–2026)

| predictor | accuracy | log_loss | brier | vs before |
|-----------|----------|----------|-------|-----------|
| logistic | 0.5667 | 0.8754 | 0.2809 | −0.002 acc (sparse-feature noise, same pattern as #108/#168) |
| **xgboost** | **0.6146** | **0.6936** | **0.2454** | **+3.54 pp acc, −2.4% log_loss, −3.1% brier** |
| skellam | 0.5667 | 0.7119 | 0.2538 | −0.008 acc, log_loss/brier flat |
| stacked | 0.5875 | 0.6845 | 0.2439 | −0.002 acc (wraps logistic/skellam) |

XGBoost improvement is the headline: tree models extract real signal from 2024–2026 team-stat data. Logistic regression is consistent with previous sparse-feature additions (#108, #168) — expected to improve after 2023 backfill (#158).

## Test plan

- [x] `tests/test_team_stats_features.py` — 4 unit tests: missing flag before/after data, rolling average accumulation, FEATURE_NAMES membership
- [x] `tests/test_baseline_metrics.py` — all 7 predictors pass with updated EXPECTED values
- [x] Full test suite passes

Closes #160

https://claude.ai/code/session_012A6Hy5H3tdqEFcndNh8EVK

---
_Generated by [Claude Code](https://claude.ai/code/session_012A6Hy5H3tdqEFcndNh8EVK)_