### PR TITLE
feat(ui): personalised home dashboard + /me/dashboard API (#148, #158) [SUPERSEDED]

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -182,6 +182,32 @@ required by the API, the precompute Job, or the CLI's `merge-closing-lines`
 command. The runtime image (`uv sync --no-dev`) skips it; local HPO runs
 use `uv sync --extra training`.
 
+## Data operations
+
+### Backfilling a season
+
+`backfill_season()` is fully parameterised — any season from the NRL JSON
+API works identically to 2024 or 2025. To backfill historical data (e.g. 2023):
+
+```bash
+python -m fantasy_coach backfill --season 2023 --db data/nrl.db
+```
+
+The command is idempotent: a `*.backfill.json` sidecar records per-round state so
+interrupted runs resume cleanly. To backfill multiple seasons in sequence:
+
+```bash
+for year in 2021 2022 2023; do
+    python -m fantasy_coach backfill --season $year --db data/nrl.db
+done
+```
+
+After backfilling, copy to Firestore for production use:
+
+```bash
+python -m fantasy_coach copy-matches-to-firestore --season 2023
+```
+
 ## Rolling back
 
 Cloud Run keeps every revision. To roll back:

--- a/src/fantasy_coach/app.py
+++ b/src/fantasy_coach/app.py
@@ -1,6 +1,7 @@
 import os
+import time
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
@@ -75,6 +76,17 @@ class TeamFormHistory(BaseModel):
     matches: list[TeamFormEntry]
 
 
+class DashboardOut(BaseModel):
+    season: int
+    currentRound: int | None
+    favouriteTeamId: int | None
+    nextFixture: dict | None  # {matchId, round, opponent, opponentId, isHome, kickoff, predWinner, predProb, season}
+    untippedMatchIds: list[int]
+    seasonAccuracy: float | None
+    totalTips: int
+    correctTips: int
+
+
 ALLOWED_ORIGINS_ENV = "FANTASY_COACH_ALLOWED_ORIGINS"
 DEFAULT_ALLOWED_ORIGINS = (
     "https://fantasy.lopezcloud.dev,http://localhost:5173,http://localhost:4173"
@@ -115,6 +127,18 @@ app.add_middleware(
 # Module-level singletons — created lazily on first use.
 _store: PredictionStore | FirestorePredictionStore | None = None
 _repo: Repository | None = None
+
+# Dashboard cache: (uid, season) → (monotonic_timestamp, DashboardOut)
+_DASHBOARD_CACHE_TTL = 60
+_dashboard_cache: dict[tuple[str, int], tuple[float, DashboardOut]] = {}
+
+
+def _require_auth(request: Request) -> str:
+    """Return the authenticated UID, or the dev sentinel when auth is disabled."""
+    uid: str | None = getattr(request.state, "uid", None)
+    if uid is None:
+        return "__dev__"
+    return uid
 
 
 def _get_store() -> PredictionStore | FirestorePredictionStore:
@@ -425,3 +449,113 @@ def get_team_form(
         season=season,
         matches=entries[-last:],
     )
+
+
+@app.get(
+    "/me/dashboard",
+    response_model=DashboardOut,
+    summary="Personalised dashboard for the signed-in user",
+    description=(
+        "Returns the current round, next fixture for the user's favourite team, "
+        "and season accuracy for the season. Results are cached in-process for "
+        f"{_DASHBOARD_CACHE_TTL}s per (uid, season) pair."
+    ),
+)
+def get_dashboard(
+    request: Request,
+    season: int = Query(..., description="NRL season year, e.g. 2026"),
+    favourite_team_id: int | None = Query(
+        default=None, description="Favourite team ID stored client-side"
+    ),
+) -> DashboardOut:
+    uid = _require_auth(request)
+    cache_key = (uid, season)
+    cached = _dashboard_cache.get(cache_key)
+    if cached is not None:
+        ts, dashboard = cached
+        if time.monotonic() - ts < _DASHBOARD_CACHE_TTL:
+            # Refresh favouriteTeamId from query param even on cache hit.
+            if favourite_team_id != dashboard.favouriteTeamId:
+                dashboard = dashboard.model_copy(update={"favouriteTeamId": favourite_team_id})
+            return dashboard
+
+    try:
+        all_matches = _get_repo().list_matches(season)
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=f"Match store unavailable: {exc}") from exc
+
+    # Current round: lowest round with at least one non-FullTime match.
+    # Falls back to the highest completed round if the season is over.
+    non_fulltime_rounds: set[int] = set()
+    completed_rounds: set[int] = set()
+    for m in all_matches:
+        if m.match_state != "FullTime":
+            non_fulltime_rounds.add(m.round)
+        else:
+            completed_rounds.add(m.round)
+
+    if non_fulltime_rounds:
+        current_round: int | None = min(non_fulltime_rounds)
+    elif completed_rounds:
+        current_round = max(completed_rounds)
+    else:
+        current_round = None
+
+    # Untipped match IDs: matches in the current round that are not FullTime.
+    untipped_match_ids: list[int] = []
+    if current_round is not None:
+        for m in all_matches:
+            if m.round == current_round and m.match_state != "FullTime":
+                untipped_match_ids.append(m.match_id)
+
+    fav_team_id = favourite_team_id
+
+    # Next fixture for the favourite team.
+    next_fixture: dict | None = None
+    if fav_team_id is not None:
+        sorted_matches = sorted(all_matches, key=lambda m: (m.start_time, m.match_id))
+        for m in sorted_matches:
+            is_home = m.home.team_id == fav_team_id
+            is_away = m.away.team_id == fav_team_id
+            if not (is_home or is_away):
+                continue
+            if m.match_state != "FullTime":
+                opp_id = m.away.team_id if is_home else m.home.team_id
+                opp_name = m.away.name if is_home else m.home.name
+                pred_winner = None
+                pred_prob = None
+                try:
+                    preds = _get_store().get(season, m.round)
+                    for pred in preds:
+                        if pred.matchId == m.match_id:
+                            pred_winner = pred.predictedWinner
+                            pred_prob = pred.homeWinProbability
+                            break
+                except Exception:
+                    pass
+                next_fixture = {
+                    "matchId": m.match_id,
+                    "round": m.round,
+                    "opponent": opp_name,
+                    "opponentId": opp_id,
+                    "isHome": is_home,
+                    "kickoff": m.start_time.isoformat(),
+                    "predWinner": pred_winner,
+                    "predProb": pred_prob,
+                    "season": season,
+                }
+                break
+
+    dashboard = DashboardOut(
+        season=season,
+        currentRound=current_round,
+        favouriteTeamId=fav_team_id,
+        nextFixture=next_fixture,
+        untippedMatchIds=untipped_match_ids,
+        seasonAccuracy=None,  # tip store not implemented yet
+        totalTips=0,
+        correctTips=0,
+    )
+
+    _dashboard_cache[cache_key] = (time.monotonic(), dashboard)
+    return dashboard

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,262 @@
+"""Tests for the GET /me/dashboard endpoint (#148)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fantasy_coach.app import app
+from fantasy_coach.features import MatchRow, TeamRow
+
+
+def _make_match(
+    match_id: int,
+    round_: int,
+    home_id: int,
+    away_id: int,
+    home_score: int | None,
+    away_score: int | None,
+    home_name: str = "Home Team",
+    away_name: str = "Away Team",
+    season: int = 2026,
+    match_state: str = "FullTime",
+    offset_seconds: int = 0,
+) -> MatchRow:
+    return MatchRow(
+        match_id=match_id,
+        season=season,
+        round=round_,
+        start_time=datetime(2026, 3, 1, 9, 0, offset_seconds, tzinfo=UTC),
+        match_state=match_state,
+        venue="Stadium",
+        venue_city="Sydney",
+        weather=None,
+        home=TeamRow(
+            team_id=home_id,
+            name=home_name,
+            nick_name=home_name,
+            score=home_score,
+            players=[],
+        ),
+        away=TeamRow(
+            team_id=away_id,
+            name=away_name,
+            nick_name=away_name,
+            score=away_score,
+            players=[],
+        ),
+        team_stats=[],
+    )
+
+
+def _mock_repo(matches: list[MatchRow]) -> MagicMock:
+    repo = MagicMock()
+    repo.list_matches.return_value = matches
+    return repo
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_app_singletons():
+    import fantasy_coach.app as app_module
+
+    app_module._repo = None
+    app_module._store = None
+    app_module._dashboard_cache.clear()
+    yield
+    app_module._repo = None
+    app_module._store = None
+    app_module._dashboard_cache.clear()
+
+
+# ── Basic shape ──────────────────────────────────────────────────────────────
+
+
+def test_dashboard_returns_200_with_correct_shape(client: TestClient) -> None:
+    matches = [
+        _make_match(1, 1, home_id=10, away_id=20, home_score=20, away_score=10),
+        _make_match(2, 2, home_id=20, away_id=10, home_score=None, away_score=None,
+                    match_state="Pre Game"),
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)), \
+         patch("fantasy_coach.app._get_store", return_value=MagicMock(get=MagicMock(return_value=[]))):
+        resp = client.get("/me/dashboard?season=2026")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "season" in data
+    assert "currentRound" in data
+    assert "untippedMatchIds" in data
+    assert "totalTips" in data
+    assert "correctTips" in data
+
+
+def test_dashboard_current_round_is_lowest_upcoming(client: TestClient) -> None:
+    matches = [
+        _make_match(1, 1, 10, 20, 20, 10),
+        _make_match(2, 2, 20, 10, None, None, match_state="Pre Game"),
+        _make_match(3, 3, 10, 30, None, None, match_state="Pre Game"),
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)), \
+         patch("fantasy_coach.app._get_store", return_value=MagicMock(get=MagicMock(return_value=[]))):
+        resp = client.get("/me/dashboard?season=2026")
+    assert resp.json()["currentRound"] == 2
+
+
+def test_dashboard_current_round_falls_back_to_max_completed(client: TestClient) -> None:
+    matches = [
+        _make_match(1, 1, 10, 20, 20, 10),
+        _make_match(2, 2, 20, 10, 14, 22),
+        _make_match(3, 3, 10, 30, 30, 12),
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)), \
+         patch("fantasy_coach.app._get_store", return_value=MagicMock(get=MagicMock(return_value=[]))):
+        resp = client.get("/me/dashboard?season=2026")
+    assert resp.json()["currentRound"] == 3
+
+
+def test_dashboard_current_round_none_when_no_matches(client: TestClient) -> None:
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo([])), \
+         patch("fantasy_coach.app._get_store", return_value=MagicMock(get=MagicMock(return_value=[]))):
+        resp = client.get("/me/dashboard?season=2026")
+    assert resp.json()["currentRound"] is None
+
+
+# ── Untipped match IDs ───────────────────────────────────────────────────────
+
+
+def test_dashboard_untipped_match_ids_contains_current_round(client: TestClient) -> None:
+    matches = [
+        _make_match(1, 1, 10, 20, 20, 10),
+        _make_match(2, 2, 20, 10, None, None, match_state="Pre Game"),
+        _make_match(3, 2, 10, 30, None, None, match_state="Pre Game"),
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)), \
+         patch("fantasy_coach.app._get_store", return_value=MagicMock(get=MagicMock(return_value=[]))):
+        resp = client.get("/me/dashboard?season=2026")
+    data = resp.json()
+    assert set(data["untippedMatchIds"]) == {2, 3}
+
+
+# ── Next fixture ─────────────────────────────────────────────────────────────
+
+
+def test_dashboard_next_fixture_for_favourite_team(client: TestClient) -> None:
+    matches = [
+        _make_match(1, 1, 10, 20, None, None, home_name="Tigers", away_name="Roosters",
+                    match_state="Pre Game"),
+        _make_match(2, 2, 10, 30, None, None, home_name="Tigers", away_name="Broncos",
+                    match_state="Pre Game"),
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)), \
+         patch("fantasy_coach.app._get_store", return_value=MagicMock(get=MagicMock(return_value=[]))):
+        resp = client.get("/me/dashboard?season=2026&favourite_team_id=10")
+    data = resp.json()
+    assert data["nextFixture"] is not None
+    assert data["nextFixture"]["matchId"] == 1
+    assert data["nextFixture"]["isHome"] is True
+    assert data["nextFixture"]["opponent"] == "Roosters"
+
+
+def test_dashboard_next_fixture_away_team(client: TestClient) -> None:
+    matches = [
+        _make_match(1, 1, 20, 10, None, None, home_name="Roosters", away_name="Tigers",
+                    match_state="Pre Game"),
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)), \
+         patch("fantasy_coach.app._get_store", return_value=MagicMock(get=MagicMock(return_value=[]))):
+        resp = client.get("/me/dashboard?season=2026&favourite_team_id=10")
+    data = resp.json()
+    assert data["nextFixture"]["isHome"] is False
+    assert data["nextFixture"]["opponent"] == "Roosters"
+
+
+def test_dashboard_no_next_fixture_when_all_fulltime(client: TestClient) -> None:
+    matches = [
+        _make_match(1, 1, 10, 20, 20, 10),
+        _make_match(2, 2, 10, 30, 14, 20),
+    ]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)), \
+         patch("fantasy_coach.app._get_store", return_value=MagicMock(get=MagicMock(return_value=[]))):
+        resp = client.get("/me/dashboard?season=2026&favourite_team_id=10")
+    assert resp.json()["nextFixture"] is None
+
+
+def test_dashboard_no_favourite_team_when_not_set(client: TestClient) -> None:
+    matches = [_make_match(1, 1, 10, 20, None, None, match_state="Pre Game")]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)), \
+         patch("fantasy_coach.app._get_store", return_value=MagicMock(get=MagicMock(return_value=[]))):
+        resp = client.get("/me/dashboard?season=2026")
+    data = resp.json()
+    assert data["favouriteTeamId"] is None
+    assert data["nextFixture"] is None
+
+
+# ── Prediction attachment ─────────────────────────────────────────────────────
+
+
+def test_dashboard_attaches_prediction_to_next_fixture(client: TestClient) -> None:
+    from fantasy_coach.predictions import PredictionOut
+
+    matches = [
+        _make_match(1, 1, 10, 20, None, None, home_name="Tigers", away_name="Roosters",
+                    match_state="Pre Game"),
+    ]
+    pred = PredictionOut(
+        matchId=1,
+        home={"id": 10, "name": "Tigers"},
+        away={"id": 20, "name": "Roosters"},
+        kickoff="2026-03-01T09:00:00",
+        predictedWinner="home",
+        homeWinProbability=0.65,
+        modelVersion="abc123",
+        featureHash="xyz",
+    )
+    mock_store = MagicMock()
+    mock_store.get.return_value = [pred]
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo(matches)), \
+         patch("fantasy_coach.app._get_store", return_value=mock_store):
+        resp = client.get("/me/dashboard?season=2026&favourite_team_id=10")
+    data = resp.json()
+    assert data["nextFixture"]["predWinner"] == "home"
+    assert abs(data["nextFixture"]["predProb"] - 0.65) < 0.001
+
+
+# ── Accuracy defaults ────────────────────────────────────────────────────────
+
+
+def test_dashboard_season_accuracy_and_tips_default_to_zero(client: TestClient) -> None:
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo([])), \
+         patch("fantasy_coach.app._get_store", return_value=MagicMock(get=MagicMock(return_value=[]))):
+        resp = client.get("/me/dashboard?season=2026")
+    data = resp.json()
+    assert data["totalTips"] == 0
+    assert data["correctTips"] == 0
+    assert data["seasonAccuracy"] is None
+
+
+# ── Season passthrough ───────────────────────────────────────────────────────
+
+
+def test_dashboard_season_value_matches_request(client: TestClient) -> None:
+    with patch("fantasy_coach.app._get_repo", return_value=_mock_repo([])), \
+         patch("fantasy_coach.app._get_store", return_value=MagicMock(get=MagicMock(return_value=[]))):
+        resp = client.get("/me/dashboard?season=2024")
+    assert resp.json()["season"] == 2024
+
+
+# ── Error handling ───────────────────────────────────────────────────────────
+
+
+def test_dashboard_returns_503_when_repo_unavailable(client: TestClient) -> None:
+    broken_repo = MagicMock()
+    broken_repo.list_matches.side_effect = RuntimeError("DB down")
+    with patch("fantasy_coach.app._get_repo", return_value=broken_repo):
+        resp = client.get("/me/dashboard?season=2026")
+    assert resp.status_code == 503

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,5 @@
 import { getFirebaseAuth, API_BASE_URL } from "./firebase";
+import type { DashboardOut } from "./types";
 
 export class ApiError extends Error {
   constructor(
@@ -39,4 +40,15 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
     throw new ApiError(res.status, body || res.statusText);
   }
   return (await res.json()) as T;
+}
+
+export async function getDashboard(
+  season: number,
+  favouriteTeamId?: number | null,
+): Promise<DashboardOut> {
+  const params = new URLSearchParams({ season: String(season) });
+  if (favouriteTeamId != null) {
+    params.set("favourite_team_id", String(favouriteTeamId));
+  }
+  return apiFetch<DashboardOut>(`/me/dashboard?${params.toString()}`);
 }

--- a/web/src/routes/Home.tsx
+++ b/web/src/routes/Home.tsx
@@ -1,23 +1,275 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { useAuth } from "../auth";
-import { RoundSelector } from "../components/RoundSelector";
 import { SignInRequired } from "../components/SignInRequired";
+import { getDashboard } from "../api";
+import type { DashboardOut } from "../types";
+
+// ── Local storage helpers ────────────────────────────────────────────────────
+
+const FAV_TEAM_KEY = "fc:fav_team_id";
+
+function getFavouriteTeamId(): number | null {
+  const raw = localStorage.getItem(FAV_TEAM_KEY);
+  if (raw === null) return null;
+  const n = parseInt(raw, 10);
+  return isNaN(n) ? null : n;
+}
+
+function setFavouriteTeamId(id: number | null): void {
+  if (id === null) {
+    localStorage.removeItem(FAV_TEAM_KEY);
+  } else {
+    localStorage.setItem(FAV_TEAM_KEY, String(id));
+  }
+}
+
+// ── Current NRL season ───────────────────────────────────────────────────────
+// Update each year or derive dynamically if needed.
+const CURRENT_SEASON = new Date().getFullYear();
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+function TeamPicker({ onPick }: { onPick: (id: number) => void }) {
+  const [value, setValue] = useState("");
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const n = parseInt(value, 10);
+    if (!isNaN(n) && n > 0) {
+      onPick(n);
+    }
+  }
+
+  return (
+    <form className="dashboard-team-picker-form" onSubmit={handleSubmit}>
+      <label htmlFor="team-id-input">Enter your team ID</label>
+      <input
+        id="team-id-input"
+        type="number"
+        min={1}
+        placeholder="e.g. 500019"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <button type="submit">Save</button>
+    </form>
+  );
+}
+
+function YourTeamCard({
+  data,
+  onChangeFav,
+  onPickTeam,
+}: {
+  data: DashboardOut;
+  onChangeFav: () => void;
+  onPickTeam: (id: number) => void;
+}) {
+  const { nextFixture, favouriteTeamId } = data;
+
+  if (favouriteTeamId === null) {
+    return (
+      <div className="dashboard-card">
+        <h2 className="dashboard-card-title">Your Team</h2>
+        <p className="dashboard-card-subtitle">Pick a team to track their next fixture.</p>
+        <TeamPicker onPick={onPickTeam} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="dashboard-card">
+      <h2 className="dashboard-card-title">Your Team</h2>
+      {nextFixture ? (
+        <div>
+          <p className="dashboard-card-subtitle">
+            Round {nextFixture.round} — {nextFixture.isHome ? "vs" : "@"}{" "}
+            <strong>{nextFixture.opponent}</strong>
+          </p>
+          <p>
+            {new Date(nextFixture.kickoff).toLocaleDateString("en-AU", {
+              weekday: "short",
+              day: "numeric",
+              month: "short",
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </p>
+          {nextFixture.predWinner !== null && nextFixture.predProb !== null && (
+            <p>
+              Tip:{" "}
+              <strong>
+                {nextFixture.predWinner === "home"
+                  ? nextFixture.isHome
+                    ? "Win"
+                    : "Loss"
+                  : nextFixture.isHome
+                    ? "Loss"
+                    : "Win"}
+              </strong>{" "}
+              ({Math.round((nextFixture.isHome ? nextFixture.predProb : 1 - nextFixture.predProb) * 100)}%)
+            </p>
+          )}
+          <Link
+            className="dashboard-view-round-link"
+            to={`/round?season=${nextFixture.season}&round=${nextFixture.round}`}
+          >
+            View round {nextFixture.round} predictions
+          </Link>
+        </div>
+      ) : (
+        <p className="dashboard-card-subtitle">No upcoming fixtures found.</p>
+      )}
+      <button className="dashboard-change-team" onClick={onChangeFav}>
+        Change team
+      </button>
+    </div>
+  );
+}
+
+function TipRoundCard({ data }: { data: DashboardOut }) {
+  const { currentRound, untippedMatchIds, season } = data;
+
+  if (currentRound === null) {
+    return (
+      <div className="dashboard-card">
+        <h2 className="dashboard-card-title">Tip Round</h2>
+        <p className="dashboard-card-subtitle">Season complete.</p>
+      </div>
+    );
+  }
+
+  const hasUntipped = untippedMatchIds.length > 0;
+
+  return (
+    <div className="dashboard-card">
+      <h2 className="dashboard-card-title">Tip Round</h2>
+      {hasUntipped ? (
+        <div>
+          <p className="dashboard-card-subtitle">
+            Round {currentRound} — {untippedMatchIds.length} match
+            {untippedMatchIds.length !== 1 ? "es" : ""} to view
+          </p>
+          <Link
+            className="dashboard-view-round-link"
+            to={`/round?season=${season}&round=${currentRound}`}
+          >
+            View round {currentRound}
+          </Link>
+        </div>
+      ) : (
+        <p className="dashboard-round-complete">Round {currentRound} complete</p>
+      )}
+    </div>
+  );
+}
+
+function AccuracyCard({ data }: { data: DashboardOut }) {
+  const { seasonAccuracy, totalTips, correctTips } = data;
+
+  return (
+    <div className="dashboard-card">
+      <h2 className="dashboard-card-title">Your Accuracy</h2>
+      {totalTips === 0 ? (
+        <p className="dashboard-card-subtitle">No tips yet this season.</p>
+      ) : (
+        <div>
+          <p className="dashboard-accuracy-value">
+            {seasonAccuracy !== null ? `${Math.round(seasonAccuracy * 100)}%` : "—"}
+          </p>
+          <p className="dashboard-card-subtitle">
+            {correctTips} correct from {totalTips} tips
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Personalised dashboard ───────────────────────────────────────────────────
+
+function PersonalisedDashboard() {
+  const [favTeamId, setFavTeamIdState] = useState<number | null>(getFavouriteTeamId);
+  const [data, setData] = useState<DashboardOut | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  function reload() {
+    setLoading(true);
+    setError(null);
+    getDashboard(CURRENT_SEASON, favTeamId)
+      .then((d: DashboardOut) => {
+        setData(d);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "Failed to load dashboard.");
+        setLoading(false);
+      });
+  }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(reload, [favTeamId]);
+
+  function handleChangeFav() {
+    setFavouriteTeamId(null);
+    setFavTeamIdState(null);
+  }
+
+  function handlePickTeam(id: number) {
+    setFavouriteTeamId(id);
+    setFavTeamIdState(id);
+  }
+
+  if (loading) return <p role="status">Loading dashboard…</p>;
+  if (error) return <p role="alert" style={{ color: "var(--color-error, red)" }}>{error}</p>;
+  if (!data) return null;
+
+  // Merge locally chosen fav into dashboard data so YourTeamCard sees it
+  // even before the cache refreshes with the server-side value.
+  const merged: DashboardOut = { ...data, favouriteTeamId: favTeamId };
+
+  return (
+    <section>
+      <h1>Dashboard</h1>
+      <div className="dashboard-grid">
+        <YourTeamCard
+          data={merged}
+          onChangeFav={handleChangeFav}
+          onPickTeam={handlePickTeam}
+        />
+        <TipRoundCard data={data} />
+        <AccuracyCard data={data} />
+      </div>
+    </section>
+  );
+}
+
+// ── Landing page (signed-out) ────────────────────────────────────────────────
+
+function LandingPage() {
+  return (
+    <section>
+      <h1>Fantasy Coach</h1>
+      <p>NRL match predictions powered by machine learning.</p>
+      <ul className="landing-features">
+        <li className="landing-feature">Round-by-round win predictions</li>
+        <li className="landing-feature">Per-team form and Elo progression</li>
+        <li className="landing-feature">Model accuracy tracking</li>
+        <li className="landing-feature">Key absence impact analysis</li>
+      </ul>
+      <SignInRequired message="Sign in to view predictions and your personalised dashboard." />
+    </section>
+  );
+}
+
+// ── Route component ──────────────────────────────────────────────────────────
 
 export default function Home() {
   const { user, loading } = useAuth();
 
   if (loading) return <p role="status">Loading…</p>;
 
-  return (
-    <section>
-      <h1>Predictions</h1>
-      <p>
-        Pick a round to see predicted winners and home-win probabilities for every match.
-      </p>
-      {user ? (
-        <RoundSelector />
-      ) : (
-        <SignInRequired message="Sign in to pick a round and view predictions." />
-      )}
-    </section>
-  );
+  return user ? <PersonalisedDashboard /> : <LandingPage />;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1118,3 +1118,143 @@ a:focus-visible {
 .match-card .consensus-badge {
   margin-top: 0.25rem;
 }
+
+/* ── Dashboard (#148) ──────────────────────────────────────────────────── */
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+@media (min-width: 600px) {
+  .dashboard-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 900px) {
+  .dashboard-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.dashboard-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.dashboard-card-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.dashboard-card-subtitle {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.dashboard-team-picker-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dashboard-team-picker-form label {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+}
+
+.dashboard-team-picker-form input {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.dashboard-team-picker-form button {
+  align-self: flex-start;
+  padding: 0.35rem 0.9rem;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.dashboard-team-picker-form button:hover {
+  background: var(--color-primary-hover);
+}
+
+.dashboard-change-team {
+  align-self: flex-start;
+  padding: 0.25rem 0.7rem;
+  background: none;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 4px;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  margin-top: auto;
+}
+
+.dashboard-change-team:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.dashboard-round-complete {
+  font-size: 0.9375rem;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+
+.dashboard-view-round-link {
+  display: inline-block;
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.dashboard-accuracy-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--color-text);
+  margin: 0;
+}
+
+/* ── Landing page (signed-out, #148) ──────────────────────────────────── */
+
+.landing-features {
+  list-style: none;
+  padding: 0;
+  margin: 1.25rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.landing-feature {
+  padding-left: 1.25rem;
+  position: relative;
+  font-size: 0.9375rem;
+  color: var(--color-text-secondary);
+}
+
+.landing-feature::before {
+  content: "–";
+  position: absolute;
+  left: 0;
+  color: var(--color-text-muted);
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -105,3 +105,25 @@ export type AccuracyOut = {
   venues: string[];
   modelVersions: string[];
 };
+
+// Returned by GET /me/dashboard (#148).
+export type DashboardOut = {
+  season: number;
+  currentRound: number | null;
+  favouriteTeamId: number | null;
+  nextFixture: {
+    matchId: number;
+    round: number;
+    opponent: string;
+    opponentId: number;
+    isHome: boolean;
+    kickoff: string;
+    predWinner: "home" | "away" | null;
+    predProb: number | null;
+    season: number;
+  } | null;
+  untippedMatchIds: number[];
+  seasonAccuracy: number | null;
+  totalTips: number;
+  correctTips: number;
+};


### PR DESCRIPTION
Closing — #148 was already implemented and merged in e772606 by another agent. The `/me/dashboard` endpoint, personalised Home dashboard, `DashboardOut` type, `getDashboard()` API function, and 13 tests are all already on `main`.

The backfill-readiness documentation for #158 (added to `docs/deploy.md`) is also superseded — the main issue requires actually running the 2023 scrape and updating `test_baseline_metrics.py`, not just documenting the command.

https://claude.ai/code/session_012A6Hy5H3tdqEFcndNh8EVK