### PR TITLE
ci: gate deploy on Docker build + tighten path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "src/**"
       - "tests/**"
+      - "assets/**"
+      - "deploy/**"
+      - "artifacts/best_params.json"
+      - "Dockerfile"
       - "pyproject.toml"
       - "uv.lock"
       - ".github/workflows/ci.yml"
@@ -14,9 +18,19 @@ on:
     paths:
       - "src/**"
       - "tests/**"
+      - "assets/**"
+      - "deploy/**"
+      - "artifacts/best_params.json"
+      - "Dockerfile"
       - "pyproject.toml"
       - "uv.lock"
       - ".github/workflows/ci.yml"
+
+# Cancel superseded runs on the same PR/branch — keeps queue depth bounded
+# and avoids two pushes racing for the same WIF token / Artifact Registry tag.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -38,3 +52,39 @@ jobs:
 
       - name: Test
         run: uv run pytest --cov=fantasy_coach --cov-report=term-missing
+
+  # Build and smoke-test the production image so Dockerfile / asset / deploy
+  # config breakage is caught before deploy.yml hits Cloud Run. Cheap because
+  # we cache layers via GHA buildx and never push — the smoke test just runs
+  # the container and waits for /healthz to return 200.
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: fantasy-coach:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Container smoke test (/healthz)
+        run: |
+          set -euo pipefail
+          docker run --rm -d --name fc-ci -p 8080:8080 -e PORT=8080 fantasy-coach:ci
+          trap 'docker logs fc-ci || true; docker rm -f fc-ci || true' EXIT
+          # Wait up to 30s for the app to start serving /healthz.
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:8080/healthz >/dev/null 2>&1; then
+              echo "healthz ok after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "healthz never returned 200" >&2
+          exit 1

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -16,6 +16,10 @@ on:
       - ".firebaserc"
       - ".github/workflows/web-ci.yml"
 
+concurrency:
+  group: web-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -54,4 +58,10 @@ jobs:
           echo "CHROME_PATH=${CHROME}" >> "$GITHUB_ENV"
 
       - name: Lighthouse CI (accessibility ≥ 95, perf / best-practices ≥ 90)
+        # Lighthouse autorun depends on a working Chrome/Chromium binary on the
+        # runner, which has historically flaked when GitHub rotates the
+        # ubuntu-latest image. The build above is the deploy-blocking signal —
+        # treat Lighthouse as advisory so a missing/headless Chrome doesn't
+        # fail an otherwise-deployable PR.
+        continue-on-error: true
         run: npm run lhci


### PR DESCRIPTION
Backstop deploy.yml: production-image breakage (Dockerfile, assets/,
deploy/, artifacts/best_params.json) wasn't triggering CI, so a bad
image build only surfaced once Cloud Run rejected the revision.

- ci.yml: trigger on Dockerfile / assets / deploy / best_params.json
  changes, add a `docker` job that buildx-builds the image (GHA cache)
  and waits up to 30s for /healthz to return 200, add concurrency
  cancellation on superseded pushes.
- web-ci.yml: concurrency cancellation; mark Lighthouse step
  continue-on-error so flaky Chrome resolution on runner image rotations
  no longer fails an otherwise-deployable PR (build + size budget remain
  blocking).