### PR TITLE
feat: scraper HTTP caching + prediction uncertainty fields

### DIFF
--- a/src/fantasy_coach/predictions.py
+++ b/src/fantasy_coach/predictions.py
@@ -610,7 +610,7 @@ _CONFIDENCE_MEDIUM_THRESHOLD = 0.20
 def _compute_uncertainty(
     prob: float,
     alternatives: AlternativeModels | None,
-) -> tuple[Literal['low', 'medium', 'high'] | None, tuple[float, float] | None, float | None]:
+) -> tuple[Literal["low", "medium", "high"] | None, tuple[float, float] | None, float | None]:
     """Return (confidence_band, win_probability_80ci, base_model_spread).
 
     base_model_spread is the range of home-win probabilities across all

--- a/src/fantasy_coach/predictions.py
+++ b/src/fantasy_coach/predictions.py
@@ -21,7 +21,7 @@ import sqlite3
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel
 
@@ -143,6 +143,14 @@ class PredictionOut(BaseModel):
     # Three-way consensus (#140): logistic + bookmaker picks alongside the
     # primary XGBoost pick. Absent on predictions cached before #140 shipped.
     alternatives: AlternativeModels | None = None
+    # Uncertainty / confidence (#146): additive fields — absent on predictions
+    # cached before this shipped; existing SPA clients ignore unknown fields.
+    confidenceBand: Literal["low", "medium", "high"] | None = None
+    winProbability80ci: tuple[float, float] | None = None
+    baseModelSpread: float | None = None
+    # trainingDataSimilarity requires a training-set centroid stored in the
+    # model artifact; populated once that metadata lands.
+    trainingDataSimilarity: float | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +178,8 @@ class PredictionStore:
             self._conn.execute("ALTER TABLE predictions ADD COLUMN contributions TEXT")
         with contextlib.suppress(sqlite3.OperationalError):
             self._conn.execute("ALTER TABLE predictions ADD COLUMN alternatives TEXT")
+        with contextlib.suppress(sqlite3.OperationalError):
+            self._conn.execute("ALTER TABLE predictions ADD COLUMN uncertainty TEXT")
 
     def close(self) -> None:
         self._conn.close()
@@ -193,6 +203,7 @@ class PredictionStore:
                 alts_json = (
                     json.dumps(p.alternatives.model_dump()) if p.alternatives is not None else None
                 )
+                uncertainty_json = _uncertainty_to_json(p)
                 self._conn.execute(
                     """
                     INSERT OR REPLACE INTO predictions
@@ -200,8 +211,8 @@ class PredictionStore:
                          home_id, home_name, away_id, away_name,
                          kickoff, predicted_winner, home_win_prob,
                          model_version, feature_hash, created_at,
-                         contributions, alternatives)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                         contributions, alternatives, uncertainty)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         season,
@@ -219,6 +230,7 @@ class PredictionStore:
                         now,
                         contribs_json,
                         alts_json,
+                        uncertainty_json,
                     ),
                 )
 
@@ -232,6 +244,8 @@ def _row_to_out(r: sqlite3.Row) -> PredictionOut:
     )
     alts_raw = r["alternatives"] if "alternatives" in cols else None
     alternatives = AlternativeModels(**json.loads(alts_raw)) if alts_raw else None
+    uncertainty_raw = r["uncertainty"] if "uncertainty" in cols else None
+    uncertainty = json.loads(uncertainty_raw) if uncertainty_raw else {}
     return PredictionOut(
         matchId=r["match_id"],
         home=TeamInfo(id=r["home_id"], name=r["home_name"]),
@@ -243,6 +257,12 @@ def _row_to_out(r: sqlite3.Row) -> PredictionOut:
         featureHash=r["feature_hash"],
         contributions=contribs,
         alternatives=alternatives,
+        confidenceBand=uncertainty.get("confidenceBand"),
+        winProbability80ci=tuple(uncertainty["winProbability80ci"])  # type: ignore[arg-type]
+        if uncertainty.get("winProbability80ci")
+        else None,
+        baseModelSpread=uncertainty.get("baseModelSpread"),
+        trainingDataSimilarity=uncertainty.get("trainingDataSimilarity"),
     )
 
 
@@ -556,6 +576,77 @@ def _xgboost_raw_contribs(loaded: Any, x: Any) -> Any | None:
     return shap_contributions(loaded, x)
 
 
+def _uncertainty_to_json(p: PredictionOut) -> str | None:
+    """Serialise the uncertainty fields to a JSON string for SQLite storage."""
+    if all(
+        f is None
+        for f in (
+            p.confidenceBand,
+            p.winProbability80ci,
+            p.baseModelSpread,
+            p.trainingDataSimilarity,
+        )
+    ):
+        return None
+    return json.dumps(
+        {
+            "confidenceBand": p.confidenceBand,
+            "winProbability80ci": list(p.winProbability80ci) if p.winProbability80ci else None,
+            "baseModelSpread": p.baseModelSpread,
+            "trainingDataSimilarity": p.trainingDataSimilarity,
+        }
+    )
+
+
+# Confidence-band thresholds (on base_model_spread). These are best-effort
+# defaults; tune with a held-out season once enough predictions are logged.
+# spread < LOW_THRESHOLD  → high confidence (models strongly agree)
+# spread < HIGH_THRESHOLD → medium confidence
+# spread ≥ HIGH_THRESHOLD → low confidence
+_CONFIDENCE_HIGH_THRESHOLD = 0.10
+_CONFIDENCE_MEDIUM_THRESHOLD = 0.20
+
+
+def _compute_uncertainty(
+    prob: float,
+    alternatives: AlternativeModels | None,
+) -> tuple[Literal['low', 'medium', 'high'] | None, tuple[float, float] | None, float | None]:
+    """Return (confidence_band, win_probability_80ci, base_model_spread).
+
+    base_model_spread is the range of home-win probabilities across all
+    available base models (XGBoost primary, logistic, bookmaker implied). The
+    80% CI is a heuristic: ±1.28 × (spread/2), treating the model spread as a
+    proxy for the predictive standard deviation.
+
+    Returns (None, None, None) when no alternatives are available — this keeps
+    the prediction backward-compatible.
+    """
+    probs: list[float] = [prob]
+    if alternatives is not None:
+        if alternatives.logistic is not None:
+            probs.append(alternatives.logistic.homeWinProbability)
+        if alternatives.bookmaker is not None:
+            probs.append(alternatives.bookmaker.homeWinProbability)
+
+    if len(probs) < 2:
+        return None, None, None
+
+    spread = round(max(probs) - min(probs), 4)
+
+    if spread < _CONFIDENCE_HIGH_THRESHOLD:
+        band: Literal["low", "medium", "high"] = "high"
+    elif spread < _CONFIDENCE_MEDIUM_THRESHOLD:
+        band = "medium"
+    else:
+        band = "low"
+
+    half_width = round(1.28 * spread / 2, 4)
+    lo = round(max(0.0, prob - half_width), 4)
+    hi = round(min(1.0, prob + half_width), 4)
+
+    return band, (lo, hi), spread
+
+
 def _contribution_detail(feature: str, builder: Any, match: Any) -> dict[str, Any] | None:
     """Return per-feature structured narrative detail, or None."""
     if builder is None or match is None:
@@ -804,6 +895,7 @@ def compute_predictions(
             else None
         )
 
+        confidence_band, ci_80, spread = _compute_uncertainty(prob, alternatives)
         predictions.append(
             PredictionOut(
                 matchId=match.match_id,
@@ -816,6 +908,9 @@ def compute_predictions(
                 featureHash=fh,
                 contributions=_compute_contributions(loaded, x, builder=builder, match=match),
                 alternatives=alternatives,
+                confidenceBand=confidence_band,
+                winProbability80ci=ci_80,
+                baseModelSpread=spread,
             )
         )
 

--- a/src/fantasy_coach/scraper.py
+++ b/src/fantasy_coach/scraper.py
@@ -4,19 +4,29 @@ Thin wrappers around the two `nrl.com` JSON endpoints documented in
 `docs/nrl-endpoints.md`. Throttled to be polite and retrying on transient
 failures; 404s return None because a wrong slug order (away-v-home vs
 home-v-away) is a common caller bug, not a server error worth crashing on.
+
+HTTP caching via conditional requests (ETag / If-None-Match and
+Last-Modified / If-Modified-Since) is supported when a ``ScraperCache``
+is passed to the public fetch functions. On 304 Not Modified, functions
+return ``None`` and downstream processing is skipped. See
+``src/fantasy_coach/scraper_cache.py`` for backend implementations.
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import random
 import threading
 import time
-from typing import Any
-from urllib.parse import urlparse
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlencode, urlparse
 
 import httpx
+
+if TYPE_CHECKING:
+    from fantasy_coach.scraper_cache import ScraperCache
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +83,7 @@ def fetch_match(
     *,
     client: httpx.Client | None = None,
     max_retries: int = DEFAULT_MAX_RETRIES,
+    cache: ScraperCache | None = None,
 ) -> dict[str, Any] | None:
     """Fetch a single regular-season match's per-match JSON.
 
@@ -84,7 +95,7 @@ def fetch_match(
     """
 
     path = _match_path(year, round_, home_slug, away_slug)
-    return _fetch_json(path, client=client, max_retries=max_retries)
+    return _fetch_json(path, client=client, max_retries=max_retries, cache=cache)
 
 
 def fetch_match_from_url(
@@ -92,6 +103,7 @@ def fetch_match_from_url(
     *,
     client: httpx.Client | None = None,
     max_retries: int = DEFAULT_MAX_RETRIES,
+    cache: ScraperCache | None = None,
 ) -> dict[str, Any] | None:
     """Fetch a per-match payload using a `matchCentreUrl` from the fixtures list.
 
@@ -101,7 +113,7 @@ def fetch_match_from_url(
     """
 
     path = _normalize_match_path(match_centre_url)
-    return _fetch_json(path, client=client, max_retries=max_retries)
+    return _fetch_json(path, client=client, max_retries=max_retries, cache=cache)
 
 
 def fetch_round(
@@ -111,6 +123,7 @@ def fetch_round(
     competition: int = 111,
     client: httpx.Client | None = None,
     max_retries: int = DEFAULT_MAX_RETRIES,
+    cache: ScraperCache | None = None,
 ) -> dict[str, Any] | None:
     """Fetch the fixtures-list payload for a given round.
 
@@ -120,7 +133,7 @@ def fetch_round(
 
     path = "/draw/data"
     params = {"competition": competition, "round": round_, "season": year}
-    return _fetch_json(path, params=params, client=client, max_retries=max_retries)
+    return _fetch_json(path, params=params, client=client, max_retries=max_retries, cache=cache)
 
 
 def _normalize_match_path(match_centre_url: str) -> str:
@@ -133,15 +146,32 @@ def _normalize_match_path(match_centre_url: str) -> str:
     return path + "data"
 
 
+def _cache_url(path: str, params: dict[str, Any] | None) -> str:
+    """Build a stable string key for the cache from path + sorted query params."""
+    if params:
+        return path + "?" + urlencode(sorted((str(k), str(v)) for k, v in params.items()))
+    return path
+
+
 def _fetch_json(
     path: str,
     *,
     params: dict[str, Any] | None = None,
     client: httpx.Client | None = None,
     max_retries: int = DEFAULT_MAX_RETRIES,
+    cache: ScraperCache | None = None,
 ) -> dict[str, Any] | None:
     headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
     interval = _min_interval_seconds()
+
+    cache_url = _cache_url(path, params)
+    entry = cache.get(cache_url) if cache is not None else None
+
+    if entry is not None:
+        if entry.etag:
+            headers["If-None-Match"] = entry.etag
+        elif entry.last_modified:
+            headers["If-Modified-Since"] = entry.last_modified
 
     owns_client = client is None
     http = client or httpx.Client(base_url=BASE_URL, timeout=DEFAULT_TIMEOUT)
@@ -171,6 +201,18 @@ def _fetch_json(
                 time.sleep(delay)
                 continue
 
+            if response.status_code == 304:
+                logger.debug("304 Not Modified for %s — skipping downstream processing", path)
+                if cache is not None and entry is not None:
+                    cache.put(
+                        cache_url,
+                        etag=entry.etag,
+                        last_modified=entry.last_modified,
+                        content_hash=entry.content_hash,
+                        status=304,
+                    )
+                return None
+
             if response.status_code == 404:
                 logger.warning("404 for %s", path)
                 return None
@@ -190,7 +232,41 @@ def _fetch_json(
                 continue
 
             response.raise_for_status()
-            return response.json()
+            body = response.json()
+
+            if cache is not None:
+                cc = response.headers.get("Cache-Control", "")
+                if "no-store" not in cc:
+                    etag = response.headers.get("ETag")
+                    last_modified = response.headers.get("Last-Modified")
+                    content_hash: str | None = None
+                    if not etag and not last_modified:
+                        content_hash = hashlib.sha256(response.content).hexdigest()
+                        if entry is not None and entry.content_hash == content_hash:
+                            logger.debug(
+                                "Content hash unchanged for %s — skipping downstream processing",
+                                path,
+                            )
+                            cache.put(
+                                cache_url,
+                                etag=None,
+                                last_modified=None,
+                                content_hash=content_hash,
+                                status=200,
+                            )
+                            return None
+                        logger.warning(
+                            "No ETag or Last-Modified from %s; using content-hash fallback", path
+                        )
+                    cache.put(
+                        cache_url,
+                        etag=etag,
+                        last_modified=last_modified,
+                        content_hash=content_hash,
+                        status=200,
+                    )
+
+            return body
 
         raise RuntimeError(f"fetch retry loop exited without resolution for {path}")
     finally:

--- a/src/fantasy_coach/scraper_cache.py
+++ b/src/fantasy_coach/scraper_cache.py
@@ -1,0 +1,212 @@
+"""HTTP response cache for the NRL scraper.
+
+Stores ETag / Last-Modified validators per scraped URL so that subsequent
+requests can send conditional headers (``If-None-Match`` / ``If-Modified-
+Since``). On 304 Not Modified the scraper skips JSON parsing and downstream
+Firestore writes entirely — the only write is a timestamp bump on the cache
+entry.
+
+For endpoints that never send standard validators (``Cache-Control: no-store``
+excluded) a SHA-256 content-hash is stored as a fallback; if the body hash
+matches the previous scrape, the URL is treated as unchanged.
+
+Two backends, matching the rest of the system:
+- ``SQLiteScraperCache`` — local dev / tests; persists a ``scraper_cache``
+  table in the same SQLite file as the main DB.
+- ``FirestoreScraperCache`` — production (Cloud Run Job); durable across cold
+  starts, keyed by SHA-1 of the URL.
+
+TTL is 30 days; call ``prune()`` periodically to remove stale entries.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+TTL_DAYS = 30
+
+_CREATE_CACHE_TABLE = """
+CREATE TABLE IF NOT EXISTS scraper_cache (
+    url_key         TEXT PRIMARY KEY,
+    url             TEXT NOT NULL,
+    etag            TEXT,
+    last_modified   TEXT,
+    content_hash    TEXT,
+    last_fetched_at TEXT NOT NULL,
+    last_status     INTEGER NOT NULL
+);
+"""
+
+
+@dataclass
+class CacheEntry:
+    url: str
+    etag: str | None
+    last_modified: str | None
+    content_hash: str | None
+    last_fetched_at: datetime
+    last_status: int
+
+
+class ScraperCache(ABC):
+    """Abstract cache for per-URL HTTP validator metadata."""
+
+    @staticmethod
+    def url_key(url: str) -> str:
+        return hashlib.sha1(url.encode()).hexdigest()
+
+    @abstractmethod
+    def get(self, url: str) -> CacheEntry | None:
+        """Return the stored entry for ``url``, or None if not cached."""
+
+    @abstractmethod
+    def put(
+        self,
+        url: str,
+        *,
+        etag: str | None,
+        last_modified: str | None,
+        content_hash: str | None,
+        status: int,
+    ) -> None:
+        """Upsert a cache entry for ``url``."""
+
+    @abstractmethod
+    def prune(self) -> int:
+        """Delete entries older than TTL_DAYS. Returns row count removed."""
+
+
+class SQLiteScraperCache(ScraperCache):
+    """SQLite-backed scraper cache.
+
+    Pass the path to the existing ``nrl.db`` (or any SQLite file); the
+    ``scraper_cache`` table is created on first use.
+    """
+
+    def __init__(self, path: str) -> None:
+        self._conn = sqlite3.connect(path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(_CREATE_CACHE_TABLE)
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def get(self, url: str) -> CacheEntry | None:
+        row = self._conn.execute(
+            "SELECT * FROM scraper_cache WHERE url_key = ?",
+            (self.url_key(url),),
+        ).fetchone()
+        if row is None:
+            return None
+        return CacheEntry(
+            url=row["url"],
+            etag=row["etag"],
+            last_modified=row["last_modified"],
+            content_hash=row["content_hash"],
+            last_fetched_at=datetime.fromisoformat(row["last_fetched_at"]),
+            last_status=row["last_status"],
+        )
+
+    def put(
+        self,
+        url: str,
+        *,
+        etag: str | None,
+        last_modified: str | None,
+        content_hash: str | None,
+        status: int,
+    ) -> None:
+        now = datetime.now(UTC).isoformat()
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT OR REPLACE INTO scraper_cache
+                    (url_key, url, etag, last_modified, content_hash, last_fetched_at, last_status)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (self.url_key(url), url, etag, last_modified, content_hash, now, status),
+            )
+
+    def prune(self) -> int:
+        cutoff = (datetime.now(UTC) - timedelta(days=TTL_DAYS)).isoformat()
+        with self._conn:
+            result = self._conn.execute(
+                "DELETE FROM scraper_cache WHERE last_fetched_at < ?",
+                (cutoff,),
+            )
+        return result.rowcount
+
+
+class FirestoreScraperCache(ScraperCache):
+    """Firestore-backed scraper cache (production).
+
+    Collection: ``scraper_cache``. Each document is keyed by SHA-1 of the
+    scraped URL so Cloud Run Job cold starts share a persistent cache.
+    TTL enforcement relies on Firestore TTL policies (30 days on
+    ``last_fetched_at``) or manual ``prune()`` calls.
+    """
+
+    _COLLECTION = "scraper_cache"
+
+    def __init__(self, client: Any) -> None:
+        self._db = client
+
+    def get(self, url: str) -> CacheEntry | None:
+        snap = self._db.collection(self._COLLECTION).document(self.url_key(url)).get()
+        if not snap.exists:
+            return None
+        data = snap.to_dict() or {}
+        return CacheEntry(
+            url=data["url"],
+            etag=data.get("etag"),
+            last_modified=data.get("last_modified"),
+            content_hash=data.get("content_hash"),
+            last_fetched_at=datetime.fromisoformat(data["last_fetched_at"]),
+            last_status=data["last_status"],
+        )
+
+    def put(
+        self,
+        url: str,
+        *,
+        etag: str | None,
+        last_modified: str | None,
+        content_hash: str | None,
+        status: int,
+    ) -> None:
+        now = datetime.now(UTC).isoformat()
+        self._db.collection(self._COLLECTION).document(self.url_key(url)).set(
+            {
+                "url": url,
+                "etag": etag,
+                "last_modified": last_modified,
+                "content_hash": content_hash,
+                "last_fetched_at": now,
+                "last_status": status,
+            }
+        )
+
+    def prune(self) -> int:
+        cutoff = (datetime.now(UTC) - timedelta(days=TTL_DAYS)).isoformat()
+        batch_size = 500
+        deleted = 0
+        col = self._db.collection(self._COLLECTION)
+        while True:
+            docs = col.where("last_fetched_at", "<", cutoff).limit(batch_size).stream()
+            batch = self._db.batch()
+            count = 0
+            for doc in docs:
+                batch.delete(doc.reference)
+                count += 1
+            if count == 0:
+                break
+            batch.commit()
+            deleted += count
+            if count < batch_size:
+                break
+        return deleted

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -1259,3 +1259,173 @@ def test_compute_alternatives_absent_when_same_path(
     pred = result[0]
     if pred.alternatives is not None:
         assert pred.alternatives.logistic is None
+
+
+# ---------------------------------------------------------------------------
+# _compute_uncertainty — confidence-band and 80% CI derivation (#146)
+# ---------------------------------------------------------------------------
+
+
+from fantasy_coach.predictions import (  # noqa: E402
+    _compute_uncertainty,
+)
+
+
+def test_compute_uncertainty_high_confidence_when_models_agree() -> None:
+    """All models within 0.05 of each other → high confidence band."""
+    alts = AlternativeModels(
+        logistic=PickSummary(predictedWinner="home", homeWinProbability=0.68),
+        bookmaker=PickSummary(predictedWinner="home", homeWinProbability=0.70),
+    )
+    band, ci, spread = _compute_uncertainty(0.69, alts)
+    assert band == "high"
+    assert spread is not None and spread < 0.10
+    assert ci is not None
+    lo, hi = ci
+    assert lo < 0.69 < hi
+
+
+def test_compute_uncertainty_medium_confidence_moderate_spread() -> None:
+    alts = AlternativeModels(
+        logistic=PickSummary(predictedWinner="home", homeWinProbability=0.60),
+        bookmaker=PickSummary(predictedWinner="home", homeWinProbability=0.72),
+    )
+    band, ci, spread = _compute_uncertainty(0.65, alts)
+    assert band == "medium"
+    assert spread is not None and 0.10 <= spread < 0.20
+
+
+def test_compute_uncertainty_low_confidence_high_spread() -> None:
+    alts = AlternativeModels(
+        logistic=PickSummary(predictedWinner="away", homeWinProbability=0.42),
+        bookmaker=PickSummary(predictedWinner="home", homeWinProbability=0.71),
+    )
+    band, ci, spread = _compute_uncertainty(0.56, alts)
+    assert band == "low"
+    assert spread is not None and spread >= 0.20
+
+
+def test_compute_uncertainty_returns_none_when_no_alternatives() -> None:
+    band, ci, spread = _compute_uncertainty(0.65, None)
+    assert band is None
+    assert ci is None
+    assert spread is None
+
+
+def test_compute_uncertainty_returns_none_when_only_primary() -> None:
+    """Only XGBoost primary, no logistic or bookmaker → can't compute spread."""
+    alts = AlternativeModels(logistic=None, bookmaker=None)
+    band, ci, spread = _compute_uncertainty(0.65, alts)
+    assert band is None
+    assert ci is None
+    assert spread is None
+
+
+def test_compute_uncertainty_ci_clipped_to_unit_interval() -> None:
+    """Extreme probabilities near 0 or 1 should not produce CI below 0 or above 1."""
+    alts = AlternativeModels(
+        logistic=PickSummary(predictedWinner="home", homeWinProbability=0.95),
+        bookmaker=PickSummary(predictedWinner="home", homeWinProbability=0.98),
+    )
+    band, ci, spread = _compute_uncertainty(0.97, alts)
+    assert ci is not None
+    lo, hi = ci
+    assert lo >= 0.0
+    assert hi <= 1.0
+
+
+def test_store_roundtrips_uncertainty_fields(store: PredictionStore) -> None:
+    pred = PredictionOut(
+        matchId=77,
+        home=TeamInfo(id=1, name="A"),
+        away=TeamInfo(id=2, name="B"),
+        kickoff="2026-05-01T08:00:00+00:00",
+        predictedWinner="home",
+        homeWinProbability=0.68,
+        modelVersion="mv",
+        featureHash="fh",
+        confidenceBand="high",
+        winProbability80ci=(0.62, 0.74),
+        baseModelSpread=0.06,
+    )
+    store.put(2026, 8, [pred])
+    loaded = store.get(2026, 8)
+    assert len(loaded) == 1
+    out = loaded[0]
+    assert out.confidenceBand == "high"
+    assert out.winProbability80ci == pytest.approx((0.62, 0.74))
+    assert out.baseModelSpread == pytest.approx(0.06)
+    assert out.trainingDataSimilarity is None
+
+
+def test_store_roundtrips_null_uncertainty(store: PredictionStore) -> None:
+    pred = PredictionOut(
+        matchId=78,
+        home=TeamInfo(id=1, name="A"),
+        away=TeamInfo(id=2, name="B"),
+        kickoff="2026-05-01T08:00:00+00:00",
+        predictedWinner="away",
+        homeWinProbability=0.35,
+        modelVersion="mv",
+        featureHash="fh",
+        # no uncertainty fields
+    )
+    store.put(2026, 8, [pred])
+    loaded = store.get(2026, 8)
+    out = loaded[0]
+    assert out.confidenceBand is None
+    assert out.winProbability80ci is None
+    assert out.baseModelSpread is None
+
+
+def test_compute_populates_uncertainty_when_alternatives_present(
+    store: PredictionStore, sqlite_repo: SQLiteRepository, tmp_path: Path
+) -> None:
+    """When logistic + bookmaker alternatives are present, uncertainty fields are populated."""
+    from fantasy_coach.feature_engineering import FEATURE_NAMES, TrainingFrame
+    from fantasy_coach.models.logistic import save_model, train_logistic
+
+    raw_match = _load_fixture(UPCOMING_FIXTURE)
+    mock_round = MagicMock(return_value=_sample_round_payload("/match/url"))
+    mock_match = MagicMock(return_value=raw_match)
+
+    primary_model = _make_mock_model(0.72)
+    primary_path = tmp_path / "primary.joblib"
+    primary_path.write_bytes(b"primary-bytes")
+
+    rng = np.random.default_rng(2)
+    n = 60
+    X = rng.standard_normal((n, len(FEATURE_NAMES)))
+    y = (X[:, 0] > 0).astype(int)
+    frame = TrainingFrame(
+        X=X,
+        y=y,
+        match_ids=np.arange(n),
+        start_times=np.arange(n, dtype=float),
+        feature_names=FEATURE_NAMES,
+    )
+    logistic_result = train_logistic(frame, test_fraction=0.0)
+    logistic_path = tmp_path / "logistic.joblib"
+    save_model(logistic_result, logistic_path)
+
+    with patch("fantasy_coach.models.loader.load_model", return_value=primary_model):
+        result = compute_predictions(
+            2026,
+            8,
+            sqlite_repo,
+            store,
+            model_path=primary_path,
+            logistic_path=logistic_path,
+            fetch_round_fn=mock_round,
+            fetch_match_fn=mock_match,
+        )
+
+    assert len(result) == 1
+    pred = result[0]
+    # baseModelSpread is populated when logistic is available.
+    assert pred.baseModelSpread is not None
+    assert 0.0 <= pred.baseModelSpread <= 1.0
+    assert pred.confidenceBand in ("low", "medium", "high")
+    assert pred.winProbability80ci is not None
+    lo, hi = pred.winProbability80ci
+    assert 0.0 <= lo <= pred.homeWinProbability <= hi <= 1.0

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -5,6 +5,13 @@ import pytest
 import respx
 
 from fantasy_coach import scraper
+from fantasy_coach.scraper_cache import SQLiteScraperCache
+
+
+@pytest.fixture()
+def mem_cache() -> SQLiteScraperCache:
+    """In-memory SQLite scraper cache for tests."""
+    return SQLiteScraperCache(":memory:")
 
 
 @pytest.fixture(autouse=True)
@@ -186,3 +193,125 @@ def test_fetch_match_from_url_accepts_full_url() -> None:
     respx.get(full + "data").mock(return_value=httpx.Response(200, json={"ok": True}))
 
     assert scraper.fetch_match_from_url(full) == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# HTTP caching tests
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_cache_first_fetch_stores_etag(mem_cache: SQLiteScraperCache) -> None:
+    """First 200 with an ETag stores it in the cache for the next request."""
+    payload = {"matchId": 1}
+    respx.get(MATCH_URL).mock(
+        return_value=httpx.Response(200, json=payload, headers={"ETag": '"abc123"'})
+    )
+
+    result = scraper.fetch_match(2026, 8, "wests-tigers", "raiders", cache=mem_cache)
+
+    assert result == payload
+    entry = mem_cache.get("/draw/nrl-premiership/2026/round-8/wests-tigers-v-raiders/data")
+    assert entry is not None
+    assert entry.etag == '"abc123"'
+    assert entry.last_status == 200
+
+
+@respx.mock
+def test_cache_second_fetch_sends_if_none_match(mem_cache: SQLiteScraperCache) -> None:
+    """Second fetch for the same URL sends If-None-Match; 304 returns None."""
+    payload = {"matchId": 1}
+    route = respx.get(MATCH_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=payload, headers={"ETag": '"v1"'}),
+            httpx.Response(304),
+        ]
+    )
+
+    # First fetch — populates cache.
+    first = scraper.fetch_match(2026, 8, "wests-tigers", "raiders", cache=mem_cache)
+    assert first == payload
+
+    # Second fetch — should send If-None-Match and return None on 304.
+    second = scraper.fetch_match(2026, 8, "wests-tigers", "raiders", cache=mem_cache)
+    assert second is None
+
+    # The 304 request must have sent the conditional header.
+    second_request = route.calls[1].request
+    assert second_request.headers.get("if-none-match") == '"v1"'
+
+    # Cache entry must still be present (last_fetched_at updated).
+    entry = mem_cache.get("/draw/nrl-premiership/2026/round-8/wests-tigers-v-raiders/data")
+    assert entry is not None
+    assert entry.etag == '"v1"'
+    assert entry.last_status == 304
+
+
+@respx.mock
+def test_cache_content_hash_fallback_unchanged(mem_cache: SQLiteScraperCache) -> None:
+    """For endpoints without validators, content-hash dedup returns None on match."""
+    body = b'{"matchId": 99}'
+    respx.get(MATCH_URL).mock(
+        return_value=httpx.Response(200, content=body, headers={"Content-Type": "application/json"})
+    )
+
+    # First fetch — stores content hash.
+    first = scraper.fetch_match(2026, 8, "wests-tigers", "raiders", cache=mem_cache)
+    assert first == {"matchId": 99}
+
+    # Second fetch — same body, no ETag/Last-Modified → hash match → None.
+    second = scraper.fetch_match(2026, 8, "wests-tigers", "raiders", cache=mem_cache)
+    assert second is None
+
+
+@respx.mock
+def test_cache_etag_mismatch_returns_new_body(mem_cache: SQLiteScraperCache) -> None:
+    """When the server returns a new ETag + new body, cache is updated and body returned."""
+    route = respx.get(MATCH_URL).mock(
+        side_effect=[
+            httpx.Response(200, json={"version": 1}, headers={"ETag": '"v1"'}),
+            httpx.Response(200, json={"version": 2}, headers={"ETag": '"v2"'}),
+        ]
+    )
+
+    first = scraper.fetch_match(2026, 8, "wests-tigers", "raiders", cache=mem_cache)
+    assert first == {"version": 1}
+
+    second = scraper.fetch_match(2026, 8, "wests-tigers", "raiders", cache=mem_cache)
+    assert second == {"version": 2}
+
+    # Second request must have sent If-None-Match with old ETag.
+    assert route.calls[1].request.headers.get("if-none-match") == '"v1"'
+
+    # Cache entry must have the new ETag.
+    entry = mem_cache.get("/draw/nrl-premiership/2026/round-8/wests-tigers-v-raiders/data")
+    assert entry is not None
+    assert entry.etag == '"v2"'
+
+
+@respx.mock
+def test_cache_no_store_skips_caching(mem_cache: SQLiteScraperCache) -> None:
+    """Cache-Control: no-store responses are not cached (no conditional headers on retry)."""
+    route = respx.get(MATCH_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"live": True},
+            headers={"ETag": '"live"', "Cache-Control": "no-store"},
+        )
+    )
+
+    scraper.fetch_match(2026, 8, "wests-tigers", "raiders", cache=mem_cache)
+    scraper.fetch_match(2026, 8, "wests-tigers", "raiders", cache=mem_cache)
+
+    # Both requests must NOT have sent If-None-Match.
+    for call in route.calls:
+        assert "if-none-match" not in call.request.headers
+
+
+@respx.mock
+def test_cache_without_cache_param_behaves_as_before() -> None:
+    """Callers that don't pass cache= get the original behaviour (no cache interaction)."""
+    payload = {"matchId": 5}
+    respx.get(MATCH_URL).mock(return_value=httpx.Response(200, json=payload))
+
+    assert scraper.fetch_match(2026, 8, "wests-tigers", "raiders") == payload


### PR DESCRIPTION
## Summary

Two independent improvements batched on one branch (no dependency between them):

### #155 — Scraper HTTP caching (ETag / If-None-Match + content-hash fallback)

- New `src/fantasy_coach/scraper_cache.py` — `ScraperCache` abstract base with `SQLiteScraperCache` and `FirestoreScraperCache` backends. TTL 30 days; `prune()` for cleanup.
- `fetch_round`, `fetch_match`, `fetch_match_from_url` accept `cache: ScraperCache | None = None`. When present, `_fetch_json` sends `If-None-Match` / `If-Modified-Since` on each request.
- **304 Not Modified** → returns `None` early, skipping JSON parse and downstream Firestore writes. Cache entry's `last_fetched_at` is bumped.
- **No validators** (no ETag / Last-Modified) → SHA-256 content-hash dedup; warns once per URL. `Cache-Control: no-store` responses bypass caching entirely.
- Tests: first-fetch ETag storage, 304 round-trip with conditional header assertion, content-hash dedup, ETag mismatch update, `no-store` bypass, no-cache-param backward compat.

### #146 — Prediction uncertainty & low-confidence warnings

- Four new additive fields on `PredictionOut` (backward-compatible — absent on predictions cached before this PR):
  - `confidenceBand`: `"low"` / `"medium"` / `"high"` — thresholded from ensemble spread
  - `winProbability80ci`: `[lo, hi]` — ≈ prob ± 1.28 × (spread/2), clipped to [0,1]
  - `baseModelSpread`: max − min across XGBoost primary, logistic, bookmaker alternatives
  - `trainingDataSimilarity`: wired to `None` pending training-set centroid metadata in the model artifact
- Thresholds: spread < 0.10 → high, 0.10–0.20 → medium, ≥ 0.20 → low.
- SQLite store gains an `uncertainty TEXT` column (JSON blob) via forward-compat `ALTER TABLE`.
- Firestore round-trip works automatically via `model_dump()`.
- Tests: high/medium/low band cases, None when no alternatives, CI clipped to [0,1], SQLite round-trip with and without fields, integration test that verifies fields are populated when logistic artefact is present.

## Test evidence

All 3 skipped tests are `optuna`-guarded (training-only extra, not installed in CI).

```
tests/test_scraper.py         19 passed
tests/test_predictions.py     57 passed
Full suite: all passed, 3 skipped (optuna not installed)
```

Closes #155
Closes #146

https://claude.ai/code/session_01QwpAbcY2BhK6Da645geKo5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QwpAbcY2BhK6Da645geKo5)_