### PR TITLE
feat(scraper): HTTP caching with ETag + content-hash fallback (#155)

### DIFF
--- a/docs/nrl-endpoints.md
+++ b/docs/nrl-endpoints.md
@@ -99,3 +99,19 @@ No documented rate limit. No `robots.txt` permission statement for these endpoin
 ## Samples
 
 - [`samples/draw-round-8-2026.json`](samples/draw-round-8-2026.json) — trimmed fixtures-endpoint response
+
+
+## HTTP caching behaviour (#155)
+
+Observed caching headers per endpoint (update as new data arrives):
+
+| Endpoint | ETag | Last-Modified | Cache-Control |
+|---|---|---|---|
+| `/draw/data` (fixtures) | Unknown | Unknown | Unknown |
+| `/draw/nrl-premiership/…/data` (match detail) | Unknown | Unknown | Unknown |
+
+Until live observations are recorded here, `InMemoryScraperCache` falls back to
+SHA-256 content-hash dedup for all endpoints. Pass the cache instance to
+`fetch_match` / `fetch_round` / `fetch_match_from_url` to enable it.
+
+Update this table after observing real `curl -I` responses from the endpoints.

--- a/src/fantasy_coach/scraper.py
+++ b/src/fantasy_coach/scraper.py
@@ -4,17 +4,26 @@ Thin wrappers around the two `nrl.com` JSON endpoints documented in
 `docs/nrl-endpoints.md`. Throttled to be polite and retrying on transient
 failures; 404s return None because a wrong slug order (away-v-home vs
 home-v-away) is a common caller bug, not a server error worth crashing on.
+
+HTTP caching (#155): pass a ``ScraperCache`` instance to the fetch functions
+to enable ETag / If-None-Match conditional requests and content-hash dedup.
+On 304 Not Modified the function returns ``None`` — same as "no new data",
+which callers can treat as "skip processing". ``InMemoryScraperCache`` is
+the default for local dev and testing; the Cloud Run Job can swap in a
+Firestore-backed implementation for durability across cold starts.
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import random
 import threading
 import time
+from dataclasses import dataclass, field
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 
 import httpx
 
@@ -61,6 +70,81 @@ class _Throttle:
 _throttle = _Throttle()
 
 
+# ---------------------------------------------------------------------------
+# HTTP cache types (#155)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CacheEntry:
+    """Metadata persisted between requests for a single URL."""
+
+    url: str
+    etag: str | None = None
+    last_modified: str | None = None
+    # SHA-256 of the response body — used when the endpoint doesn't send
+    # ETag or Last-Modified so we can still skip identical payloads.
+    content_hash: str | None = None
+    last_fetched_at: float = 0.0
+
+
+@dataclass
+class InMemoryScraperCache:
+    """In-memory scraper cache. Suitable for single-run dedup and testing.
+
+    Swap for a Firestore-backed implementation in the Cloud Run Job so the
+    cache survives across cold starts. Any object with ``get`` / ``put``
+    matching the signatures below satisfies the implicit protocol.
+
+    ``stats`` tracks fetch outcomes for the per-run log summary.
+    """
+
+    _store: dict[str, CacheEntry] = field(default_factory=dict)
+    # Counters incremented by _fetch_json for the per-run summary log.
+    new: int = 0
+    unchanged: int = 0
+    errors: int = 0
+
+    def get(self, url_hash: str) -> CacheEntry | None:
+        return self._store.get(url_hash)
+
+    def put(self, url_hash: str, entry: CacheEntry) -> None:
+        self._store[url_hash] = entry
+
+    def log_summary(self) -> None:
+        total = self.new + self.unchanged + self.errors
+        logger.info(
+            "scraped %d urls: %d new (200), %d unchanged (304/hash), %d error",
+            total,
+            self.new,
+            self.unchanged,
+            self.errors,
+        )
+
+
+def _url_hash(url: str) -> str:
+    return hashlib.sha1(url.encode()).hexdigest()  # noqa: S324
+
+
+def _body_hash(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _is_no_store(response: httpx.Response) -> bool:
+    return "no-store" in response.headers.get("cache-control", "").lower()
+
+
+def _build_cache_key(path: str, params: dict[str, Any] | None) -> str:
+    """Canonical URL string used as cache-key input."""
+    qs = ("?" + urlencode(sorted((params or {}).items()))) if params else ""
+    return BASE_URL + path + qs
+
+
+# ---------------------------------------------------------------------------
+# Public fetch functions
+# ---------------------------------------------------------------------------
+
+
 def _match_path(year: int, round_: int, home_slug: str, away_slug: str) -> str:
     return f"/draw/nrl-premiership/{year}/round-{round_}/{home_slug}-v-{away_slug}/data"
 
@@ -73,18 +157,19 @@ def fetch_match(
     *,
     client: httpx.Client | None = None,
     max_retries: int = DEFAULT_MAX_RETRIES,
+    cache: InMemoryScraperCache | None = None,
 ) -> dict[str, Any] | None:
     """Fetch a single regular-season match's per-match JSON.
 
     For finals matches use `fetch_match_from_url(matchCentreUrl)` — finals
     slugs (`finals-week-{n}/game-{m}`) don't fit this signature.
 
-    Returns the parsed JSON body on 200, or None on 404. Raises
-    `httpx.HTTPError` after exhausting retries on 5xx / network errors.
+    Returns the parsed JSON body on 200, or None on 404 / 304 Not Modified.
+    Raises `httpx.HTTPError` after exhausting retries on 5xx / network errors.
     """
 
     path = _match_path(year, round_, home_slug, away_slug)
-    return _fetch_json(path, client=client, max_retries=max_retries)
+    return _fetch_json(path, client=client, max_retries=max_retries, cache=cache)
 
 
 def fetch_match_from_url(
@@ -92,6 +177,7 @@ def fetch_match_from_url(
     *,
     client: httpx.Client | None = None,
     max_retries: int = DEFAULT_MAX_RETRIES,
+    cache: InMemoryScraperCache | None = None,
 ) -> dict[str, Any] | None:
     """Fetch a per-match payload using a `matchCentreUrl` from the fixtures list.
 
@@ -101,7 +187,7 @@ def fetch_match_from_url(
     """
 
     path = _normalize_match_path(match_centre_url)
-    return _fetch_json(path, client=client, max_retries=max_retries)
+    return _fetch_json(path, client=client, max_retries=max_retries, cache=cache)
 
 
 def fetch_round(
@@ -111,6 +197,7 @@ def fetch_round(
     competition: int = 111,
     client: httpx.Client | None = None,
     max_retries: int = DEFAULT_MAX_RETRIES,
+    cache: InMemoryScraperCache | None = None,
 ) -> dict[str, Any] | None:
     """Fetch the fixtures-list payload for a given round.
 
@@ -120,7 +207,7 @@ def fetch_round(
 
     path = "/draw/data"
     params = {"competition": competition, "round": round_, "season": year}
-    return _fetch_json(path, params=params, client=client, max_retries=max_retries)
+    return _fetch_json(path, params=params, client=client, max_retries=max_retries, cache=cache)
 
 
 def _normalize_match_path(match_centre_url: str) -> str:
@@ -139,9 +226,21 @@ def _fetch_json(
     params: dict[str, Any] | None = None,
     client: httpx.Client | None = None,
     max_retries: int = DEFAULT_MAX_RETRIES,
+    cache: InMemoryScraperCache | None = None,
 ) -> dict[str, Any] | None:
     headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
     interval = _min_interval_seconds()
+
+    # Compute cache key and load any stored validators before building the
+    # request — etag / last-modified go into request headers.
+    cache_key = _build_cache_key(path, params)
+    url_hash = _url_hash(cache_key)
+    cached = cache.get(url_hash) if cache is not None else None
+    if cached is not None:
+        if cached.etag:
+            headers["If-None-Match"] = cached.etag
+        if cached.last_modified:
+            headers["If-Modified-Since"] = cached.last_modified
 
     owns_client = client is None
     http = client or httpx.Client(base_url=BASE_URL, timeout=DEFAULT_TIMEOUT)
@@ -158,6 +257,8 @@ def _fetch_json(
                         attempt,
                         exc,
                     )
+                    if cache is not None:
+                        cache.errors += 1
                     raise
                 delay = _backoff_delay(attempt)
                 logger.warning(
@@ -171,11 +272,30 @@ def _fetch_json(
                 time.sleep(delay)
                 continue
 
+            if response.status_code == 304:
+                logger.debug("304 Not Modified for %s; skipping downstream processing", path)
+                # Touch last_fetched_at so we can audit cache freshness.
+                if cache is not None and cached is not None:
+                    cache.put(
+                        url_hash,
+                        CacheEntry(
+                            url=cache_key,
+                            etag=cached.etag,
+                            last_modified=cached.last_modified,
+                            content_hash=cached.content_hash,
+                            last_fetched_at=time.time(),
+                        ),
+                    )
+                    cache.unchanged += 1
+                return None
+
             if response.status_code == 404:
                 logger.warning("404 for %s", path)
                 return None
             if 500 <= response.status_code < 600:
                 if attempt == max_retries:
+                    if cache is not None:
+                        cache.errors += 1
                     response.raise_for_status()
                 delay = _backoff_delay(attempt)
                 logger.warning(
@@ -190,7 +310,49 @@ def _fetch_json(
                 continue
 
             response.raise_for_status()
-            return response.json()
+            data = response.json()
+
+            # Update cache unless the server asked us not to.
+            if cache is not None and not _is_no_store(response):
+                etag = response.headers.get("etag") or None
+                last_mod = response.headers.get("last-modified") or None
+                body_hash: str | None = None
+                if not etag and not last_mod:
+                    # Content-hash fallback: compute SHA-256 of the raw body
+                    # and skip downstream if unchanged. Warn once so we notice
+                    # if NRL ever starts sending validators.
+                    logger.debug(
+                        "No ETag or Last-Modified from %s; falling back to content-hash dedup",
+                        path,
+                    )
+                    body_hash = _body_hash(response.content)
+                    if cached is not None and cached.content_hash == body_hash:
+                        logger.debug("Content-hash unchanged for %s; skipping", path)
+                        cache.put(
+                            url_hash,
+                            CacheEntry(
+                                url=cache_key,
+                                etag=None,
+                                last_modified=None,
+                                content_hash=body_hash,
+                                last_fetched_at=time.time(),
+                            ),
+                        )
+                        cache.unchanged += 1
+                        return None
+                cache.put(
+                    url_hash,
+                    CacheEntry(
+                        url=cache_key,
+                        etag=etag,
+                        last_modified=last_mod,
+                        content_hash=body_hash,
+                        last_fetched_at=time.time(),
+                    ),
+                )
+                cache.new += 1
+
+            return data
 
         raise RuntimeError(f"fetch retry loop exited without resolution for {path}")
     finally:

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -186,3 +186,99 @@ def test_fetch_match_from_url_accepts_full_url() -> None:
     respx.get(full + "data").mock(return_value=httpx.Response(200, json={"ok": True}))
 
     assert scraper.fetch_match_from_url(full) == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# HTTP caching tests (#155)
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_cache_stores_etag_on_200() -> None:
+    payload = {"matchId": 999}
+    respx.get(MATCH_URL).mock(
+        return_value=httpx.Response(200, json=payload, headers={"ETag": '"abc123"'})
+    )
+    cache = scraper.InMemoryScraperCache()
+    result = scraper.fetch_match(2026, 8, "wests-tigers", "raiders", cache=cache)
+
+    assert result == payload
+    # One entry stored, keyed by url-hash.
+    assert len(cache._store) == 1
+    entry = next(iter(cache._store.values()))
+    assert entry.etag == '"abc123"'
+    assert cache.new == 1
+
+
+@respx.mock
+def test_cache_sends_if_none_match_on_second_fetch() -> None:
+    payload = {"matchId": 999}
+    route = respx.get(MATCH_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=payload, headers={"ETag": '"abc123"'}),
+            httpx.Response(304),
+        ]
+    )
+    cache = scraper.InMemoryScraperCache()
+
+    # First fetch: populates cache.
+    first = scraper.fetch_match(2026, 8, "wests-tigers", "raiders", cache=cache)
+    assert first == payload
+
+    # Second fetch: sends If-None-Match, receives 304, returns None.
+    second = scraper.fetch_match(2026, 8, "wests-tigers", "raiders", cache=cache)
+    assert second is None
+    assert route.call_count == 2
+    second_request = route.calls[1].request
+    assert second_request.headers.get("if-none-match") == '"abc123"'
+    assert cache.unchanged == 1
+
+
+@respx.mock
+def test_cache_no_store_header_prevents_caching() -> None:
+    payload = {"matchId": 7}
+    respx.get(MATCH_URL).mock(
+        return_value=httpx.Response(
+            200, json=payload, headers={"Cache-Control": "no-store", "ETag": '"xyz"'}
+        )
+    )
+    cache = scraper.InMemoryScraperCache()
+    result = scraper.fetch_match(2026, 8, "wests-tigers", "raiders", cache=cache)
+
+    assert result == payload
+    assert len(cache._store) == 0  # no-store → nothing cached
+
+
+@respx.mock
+def test_cache_content_hash_fallback_skips_unchanged_body() -> None:
+    payload = {"matchId": 5}
+    body_bytes = b'{"matchId": 5}'
+    # No ETag or Last-Modified on either response.
+    route = respx.get(MATCH_URL).mock(
+        side_effect=[
+            httpx.Response(200, content=body_bytes, headers={"Content-Type": "application/json"}),
+            httpx.Response(200, content=body_bytes, headers={"Content-Type": "application/json"}),
+        ]
+    )
+    cache = scraper.InMemoryScraperCache()
+
+    first = scraper.fetch_match(2026, 8, "wests-tigers", "raiders", cache=cache)
+    assert first == payload
+    assert cache.new == 1
+
+    # Same body → content-hash dedup → returns None.
+    second = scraper.fetch_match(2026, 8, "wests-tigers", "raiders", cache=cache)
+    assert second is None
+    assert route.call_count == 2
+    assert cache.unchanged == 1
+
+
+@respx.mock
+def test_cache_uncached_without_cache_arg() -> None:
+    """Callers that don't pass a cache get the normal response, unchanged."""
+    payload = {"matchId": 1}
+    respx.get(MATCH_URL).mock(
+        return_value=httpx.Response(200, json=payload, headers={"ETag": '"v1"'})
+    )
+    result = scraper.fetch_match(2026, 8, "wests-tigers", "raiders")
+    assert result == payload


### PR DESCRIPTION
## Summary

- Adds `CacheEntry` dataclass and `InMemoryScraperCache` to `scraper.py`
- All three public fetch functions (`fetch_match`, `fetch_round`, `fetch_match_from_url`) accept an optional `cache=` parameter
- On `200`: stores `ETag` / `Last-Modified`; falls back to SHA-256 content-hash when neither is present (warns at DEBUG level)
- On `304 Not Modified`: touches `last_fetched_at`, returns `None` to skip downstream processing
- `Cache-Control: no-store` responses are not persisted
- Per-run stats counters (`new`, `unchanged`, `errors`) on the cache object with `log_summary()` for one-line observability
- Cache is injectable: `InMemoryScraperCache` is the default; Firestore-backed implementation can be swapped in the Cloud Run Job for cross-cold-start durability
- `docs/nrl-endpoints.md`: adds HTTP caching section with a table stub for observed validator headers (to be filled after live `curl -I` reconnaissance)

## Test plan

- [ ] 5 new tests in `test_scraper.py` using `respx`:
  - First fetch (200 with ETag) → cache entry written
  - Second fetch same URL (sends `If-None-Match`, receives 304, returns `None`)
  - `Cache-Control: no-store` → nothing cached
  - Content-hash fallback: same body on second 200 → returns `None`
  - No-cache-arg path: normal 200 response, no side effects
- [ ] `653 passed, 3 skipped` on full suite

Closes #155

https://claude.ai/code/session_01TfVizbsqj759nmC8LZbH2e

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfVizbsqj759nmC8LZbH2e)_