### PR TITLE
feat(predictions): add uncertainty fields to prediction API (#146)

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -949,3 +949,45 @@ report with mean CLV per model and a cumulative CLV curve table.
 equal positive PnL on a small sample — both are reported side by side.
 Statistical significance requires ≥ 400 predictions; Wald-test p < 0.05
 is the criterion used to declare a model "statistically edge-positive".
+
+## Prediction uncertainty (#146)
+
+Every prediction from `compute_predictions` now carries four optional fields
+that expose the model's confidence in the output:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `baseModelSpread` | `float` | `max − min` probability across XGBoost + logistic + bookmaker for this match. Higher = more model disagreement. |
+| `winProbability80ci` | `[float, float]` | Proxy 80% interval `[prob − spread/2, prob + spread/2]` clipped to `[0, 1]`. Not a Bayesian credible interval — use it as a rough disagreement band pending calibration. |
+| `trainingDataSimilarity` | `float` | Cosine similarity between this match's feature vector and the mean training-set feature vector. Values close to 1.0 indicate an in-distribution matchup; values below ~0.5 flag unusual team/context combinations. |
+| `confidenceBand` | `"low"` \| `"medium"` \| `"high"` | 3-level label derived from `baseModelSpread` and `trainingDataSimilarity`. |
+
+### Confidence band thresholds
+
+These are heuristic — pending held-out calibration against realised outcomes.
+
+| Band | Condition |
+|------|-----------|
+| `"high"` | `spread ≤ 0.10` **and** `ood_similarity ≥ 0.80` |
+| `"medium"` | `spread ≤ 0.20` **and** `ood_similarity ≥ 0.50` |
+| `"low"` | any other case |
+
+### Storage
+
+The four fields are serialised together as a single `uncertainty` JSON column
+in the SQLite `predictions` table (Firestore stores the full `model_dump()`).
+Predictions written before this feature shipped deserialise with all four
+fields as `None` — the response schema is additive.
+
+### Known limitations
+
+- The 80% CI is a proxy (disagreement band), not a calibrated interval. A
+  proper Bayesian or bootstrap interval would require re-running the model
+  many times or holding out a calibration set by season.
+- `trainingDataSimilarity` uses cosine similarity in raw feature space (no
+  whitening). Features with large absolute magnitudes (e.g. Elo ratings in
+  the hundreds) dominate the dot product. A PCA-whitened space or
+  Mahalanobis distance would be more principled.
+- `baseModelSpread` reflects the number of secondary models available: a
+  single-model deployment (no logistic + no odds) always has spread = 0 and
+  will appear `"high"` confidence regardless of the true uncertainty.

--- a/src/fantasy_coach/predictions.py
+++ b/src/fantasy_coach/predictions.py
@@ -143,6 +143,20 @@ class PredictionOut(BaseModel):
     # Three-way consensus (#140): logistic + bookmaker picks alongside the
     # primary XGBoost pick. Absent on predictions cached before #140 shipped.
     alternatives: AlternativeModels | None = None
+    # Prediction uncertainty fields (#146). All optional so predictions
+    # written before this feature shipped still deserialise correctly.
+    # `baseModelSpread` is max − min probability across available base models
+    # (XGBoost + logistic + bookmaker). `winProbability80ci` is a proxy 80%
+    # interval derived from the spread (clipped to [0, 1]).
+    # `trainingDataSimilarity` is cosine similarity between this match's
+    # feature vector and the training-set centroid — low values flag
+    # out-of-distribution matchups. `confidenceBand` is a 3-level label
+    # derived from spread + OOD similarity; thresholds are heuristic
+    # pending held-out calibration (see docs/model.md).
+    baseModelSpread: float | None = None
+    winProbability80ci: tuple[float, float] | None = None
+    trainingDataSimilarity: float | None = None
+    confidenceBand: str | None = None  # "low" | "medium" | "high"
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +184,8 @@ class PredictionStore:
             self._conn.execute("ALTER TABLE predictions ADD COLUMN contributions TEXT")
         with contextlib.suppress(sqlite3.OperationalError):
             self._conn.execute("ALTER TABLE predictions ADD COLUMN alternatives TEXT")
+        with contextlib.suppress(sqlite3.OperationalError):
+            self._conn.execute("ALTER TABLE predictions ADD COLUMN uncertainty TEXT")
 
     def close(self) -> None:
         self._conn.close()
@@ -193,6 +209,7 @@ class PredictionStore:
                 alts_json = (
                     json.dumps(p.alternatives.model_dump()) if p.alternatives is not None else None
                 )
+                uncertainty_json = _uncertainty_json(p)
                 self._conn.execute(
                     """
                     INSERT OR REPLACE INTO predictions
@@ -200,8 +217,8 @@ class PredictionStore:
                          home_id, home_name, away_id, away_name,
                          kickoff, predicted_winner, home_win_prob,
                          model_version, feature_hash, created_at,
-                         contributions, alternatives)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                         contributions, alternatives, uncertainty)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         season,
@@ -219,6 +236,7 @@ class PredictionStore:
                         now,
                         contribs_json,
                         alts_json,
+                        uncertainty_json,
                     ),
                 )
 
@@ -232,6 +250,9 @@ def _row_to_out(r: sqlite3.Row) -> PredictionOut:
     )
     alts_raw = r["alternatives"] if "alternatives" in cols else None
     alternatives = AlternativeModels(**json.loads(alts_raw)) if alts_raw else None
+    unc_raw = r["uncertainty"] if "uncertainty" in cols else None
+    unc = json.loads(unc_raw) if unc_raw else {}
+    ci = unc.get("winProbability80ci")
     return PredictionOut(
         matchId=r["match_id"],
         home=TeamInfo(id=r["home_id"], name=r["home_name"]),
@@ -243,6 +264,10 @@ def _row_to_out(r: sqlite3.Row) -> PredictionOut:
         featureHash=r["feature_hash"],
         contributions=contribs,
         alternatives=alternatives,
+        baseModelSpread=unc.get("baseModelSpread"),
+        winProbability80ci=tuple(ci) if ci else None,
+        trainingDataSimilarity=unc.get("trainingDataSimilarity"),
+        confidenceBand=unc.get("confidenceBand"),
     )
 
 
@@ -661,6 +686,83 @@ def _try_load_secondary_model(path: Path, gcs_uri_env: str) -> Any | None:
         return None
 
 
+def _uncertainty_json(p: PredictionOut) -> str | None:
+    """Serialise uncertainty fields to a JSON string for SQLite storage."""
+    if all(
+        v is None
+        for v in (
+            p.baseModelSpread,
+            p.winProbability80ci,
+            p.trainingDataSimilarity,
+            p.confidenceBand,
+        )
+    ):
+        return None
+    return json.dumps(
+        {
+            "baseModelSpread": p.baseModelSpread,
+            "winProbability80ci": list(p.winProbability80ci) if p.winProbability80ci else None,
+            "trainingDataSimilarity": p.trainingDataSimilarity,
+            "confidenceBand": p.confidenceBand,
+        }
+    )
+
+
+def _compute_training_centroid(history: list[MatchRow]) -> Any:
+    """Return the mean feature vector across completed historical matches.
+
+    Used as the reference point for training-data similarity (OOD detection).
+    Returns None when history is empty. Re-processes history via
+    ``build_training_frame`` — acceptable because history is already in memory
+    and the walk is O(n) with no I/O.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    from fantasy_coach.feature_engineering import build_training_frame  # noqa: PLC0415
+
+    frame = build_training_frame(history)
+    if frame.X.shape[0] == 0:
+        return None
+    return np.mean(frame.X, axis=0)
+
+
+def _cosine_similarity(x: Any, centroid: Any) -> float:
+    """Cosine similarity between a 1-d feature vector and the training centroid.
+
+    Returns 1.0 when vectors are identical, 0.0 when orthogonal. Clipped to
+    [0, 1] since feature vectors are mostly non-negative and near-orthogonal
+    vectors are rare in practice.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    v = np.asarray(x, dtype=float).flatten()
+    c = np.asarray(centroid, dtype=float).flatten()
+    norm_v = np.linalg.norm(v)
+    norm_c = np.linalg.norm(c)
+    if norm_v == 0 or norm_c == 0:
+        return 0.0
+    return float(np.clip(np.dot(v, c) / (norm_v * norm_c), 0.0, 1.0))
+
+
+# Uncertainty thresholds — heuristic pending held-out calibration.
+# At `high`: spread ≤ 0.10 and OOD similarity ≥ 0.80 → model is confident
+#            and the matchup is in-distribution.
+# At `low`: spread > 0.20 or OOD similarity < 0.50 → either base models
+#           strongly disagree or the matchup is unusual.
+_SPREAD_HIGH = 0.10
+_SPREAD_MEDIUM = 0.20
+_OOD_HIGH = 0.80
+_OOD_MEDIUM = 0.50
+
+
+def _confidence_band(spread: float, ood_similarity: float) -> str:
+    if spread <= _SPREAD_HIGH and ood_similarity >= _OOD_HIGH:
+        return "high"
+    if spread <= _SPREAD_MEDIUM and ood_similarity >= _OOD_MEDIUM:
+        return "medium"
+    return "low"
+
+
 def _build_inference_state(history: list[MatchRow]) -> Any:
     from fantasy_coach.feature_engineering import FeatureBuilder  # noqa: PLC0415
 
@@ -783,6 +885,12 @@ def compute_predictions(
 
     _fn = getattr(loaded, "feature_names", None)
     feature_names: tuple[str, ...] = _fn if isinstance(_fn, tuple) else FEATURE_NAMES
+
+    # Training centroid for OOD / uncertainty estimation (#146).
+    # Computed from the same history used for the inference builder so there
+    # is no leakage — the centroid only sees completed pre-round matches.
+    training_centroid = _compute_training_centroid(history)
+
     predictions: list[PredictionOut] = []
     for match in sorted(round_matches, key=lambda m: (m.start_time, m.match_id)):
         x = np.asarray([builder.feature_row(match)], dtype=float)
@@ -804,6 +912,22 @@ def compute_predictions(
             else None
         )
 
+        # Uncertainty estimation (#146).
+        all_probs = [prob]
+        if logistic_pick is not None:
+            all_probs.append(logistic_pick.homeWinProbability)
+        if bm_pick is not None:
+            all_probs.append(bm_pick.homeWinProbability)
+        spread = round(float(max(all_probs) - min(all_probs)), 4)
+        ci_lo = round(max(0.0, prob - spread / 2), 4)
+        ci_hi = round(min(1.0, prob + spread / 2), 4)
+        ood_sim = (
+            round(_cosine_similarity(x[0], training_centroid), 4)
+            if training_centroid is not None
+            else 1.0
+        )
+        band = _confidence_band(spread, ood_sim)
+
         predictions.append(
             PredictionOut(
                 matchId=match.match_id,
@@ -816,6 +940,10 @@ def compute_predictions(
                 featureHash=fh,
                 contributions=_compute_contributions(loaded, x, builder=builder, match=match),
                 alternatives=alternatives,
+                baseModelSpread=spread,
+                winProbability80ci=(ci_lo, ci_hi),
+                trainingDataSimilarity=ood_sim,
+                confidenceBand=band,
             )
         )
 

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -1259,3 +1259,140 @@ def test_compute_alternatives_absent_when_same_path(
     pred = result[0]
     if pred.alternatives is not None:
         assert pred.alternatives.logistic is None
+
+
+# ---------------------------------------------------------------------------
+# Prediction uncertainty (#146)
+# ---------------------------------------------------------------------------
+
+
+from fantasy_coach.predictions import (  # noqa: E402
+    _confidence_band,
+    _cosine_similarity,
+)
+
+
+def test_confidence_band_high_when_low_spread_and_in_distribution() -> None:
+    assert _confidence_band(0.05, 0.90) == "high"
+
+
+def test_confidence_band_medium_when_moderate_spread() -> None:
+    assert _confidence_band(0.15, 0.70) == "medium"
+
+
+def test_confidence_band_low_when_high_spread() -> None:
+    assert _confidence_band(0.25, 0.90) == "low"
+
+
+def test_confidence_band_low_when_ood() -> None:
+    # Tight spread but OOD → low confidence.
+    assert _confidence_band(0.05, 0.30) == "low"
+
+
+def test_confidence_band_boundary_spread_high() -> None:
+    # Exactly at the high-spread threshold (≤ 0.10).
+    assert _confidence_band(0.10, 0.80) == "high"
+
+
+def test_confidence_band_boundary_spread_medium() -> None:
+    # Just above high threshold → at most medium.
+    assert _confidence_band(0.11, 0.80) == "medium"
+
+
+def test_cosine_similarity_identical_vectors() -> None:
+    v = np.array([1.0, 2.0, 3.0])
+    assert _cosine_similarity(v, v) == pytest.approx(1.0)
+
+
+def test_cosine_similarity_orthogonal_vectors() -> None:
+    v1 = np.array([1.0, 0.0])
+    v2 = np.array([0.0, 1.0])
+    assert _cosine_similarity(v1, v2) == pytest.approx(0.0)
+
+
+def test_cosine_similarity_zero_vector_returns_zero() -> None:
+    assert _cosine_similarity(np.zeros(3), np.array([1.0, 2.0, 3.0])) == 0.0
+
+
+def test_store_roundtrips_uncertainty_fields(store: PredictionStore) -> None:
+    pred = PredictionOut(
+        matchId=77,
+        home=TeamInfo(id=1, name="A"),
+        away=TeamInfo(id=2, name="B"),
+        kickoff="2026-05-01T08:00:00+00:00",
+        predictedWinner="home",
+        homeWinProbability=0.65,
+        modelVersion="mv",
+        featureHash="fh",
+        baseModelSpread=0.08,
+        winProbability80ci=(0.61, 0.69),
+        trainingDataSimilarity=0.87,
+        confidenceBand="high",
+    )
+    store.put(2026, 8, [pred])
+    loaded = store.get(2026, 8)
+    assert len(loaded) == 1
+    out = loaded[0]
+    assert out.baseModelSpread == pytest.approx(0.08)
+    assert out.winProbability80ci is not None
+    assert out.winProbability80ci[0] == pytest.approx(0.61)
+    assert out.winProbability80ci[1] == pytest.approx(0.69)
+    assert out.trainingDataSimilarity == pytest.approx(0.87)
+    assert out.confidenceBand == "high"
+
+
+def test_store_roundtrips_null_uncertainty(store: PredictionStore) -> None:
+    pred = PredictionOut(
+        matchId=78,
+        home=TeamInfo(id=1, name="A"),
+        away=TeamInfo(id=2, name="B"),
+        kickoff="2026-05-01T08:00:00+00:00",
+        predictedWinner="away",
+        homeWinProbability=0.38,
+        modelVersion="mv",
+        featureHash="fh",
+        # no uncertainty fields
+    )
+    store.put(2026, 8, [pred])
+    loaded = store.get(2026, 8)
+    out = loaded[0]
+    assert out.baseModelSpread is None
+    assert out.winProbability80ci is None
+    assert out.trainingDataSimilarity is None
+    assert out.confidenceBand is None
+
+
+def test_compute_populates_uncertainty_fields(
+    store: PredictionStore, sqlite_repo: SQLiteRepository, tmp_path: Path
+) -> None:
+    """compute_predictions populates all four uncertainty fields on every result."""
+    raw_match = _load_fixture(UPCOMING_FIXTURE)
+    mock_round = MagicMock(return_value=_sample_round_payload("/match/url"))
+    mock_match = MagicMock(return_value=raw_match)
+    mock_model = _make_mock_model(0.68)
+    model_path = tmp_path / "model.joblib"
+    model_path.write_bytes(b"bytes")
+
+    with patch("fantasy_coach.models.loader.load_model", return_value=mock_model):
+        result = compute_predictions(
+            2026,
+            8,
+            sqlite_repo,
+            store,
+            model_path=model_path,
+            logistic_path=model_path,  # same path → no secondary model
+            fetch_round_fn=mock_round,
+            fetch_match_fn=mock_match,
+        )
+
+    assert len(result) == 1
+    pred = result[0]
+    # All four uncertainty fields must be populated.
+    assert pred.baseModelSpread is not None
+    assert 0.0 <= pred.baseModelSpread <= 1.0
+    assert pred.winProbability80ci is not None
+    ci_lo, ci_hi = pred.winProbability80ci
+    assert 0.0 <= ci_lo <= ci_hi <= 1.0
+    # OOD similarity — no history so centroid is None → default 1.0.
+    assert pred.trainingDataSimilarity == pytest.approx(1.0)
+    assert pred.confidenceBand in ("low", "medium", "high")


### PR DESCRIPTION
## Summary

- Adds four optional fields to `PredictionOut`: `baseModelSpread`, `winProbability80ci`, `trainingDataSimilarity`, `confidenceBand`
- Uncertainty is serialised to a new `uncertainty` JSON column in SQLite; backwards-compatible with cached predictions written before this ships (all four fields deserialise as `None`)
- `confidenceBand` is a 3-level label (`"high"` / `"medium"` / `"low"`) derived from ensemble spread + cosine OOD similarity to the training centroid
- Documents thresholds and known limitations in `docs/model.md`

## What each field is

| Field | Description |
|---|---|
| `baseModelSpread` | `max − min` home-win probability across XGBoost + logistic + bookmaker |
| `winProbability80ci` | Proxy disagreement band `[p − spread/2, p + spread/2]` clipped to `[0,1]` |
| `trainingDataSimilarity` | Cosine similarity of this match's feature vector to the training-set centroid (OOD detector) |
| `confidenceBand` | `"high"` when spread ≤ 0.10 and OOD sim ≥ 0.80; `"medium"` when spread ≤ 0.20 and OOD sim ≥ 0.50; `"low"` otherwise |

## Test plan

- [x] `_confidence_band` boundary tests for all three levels
- [x] `_cosine_similarity` identical, orthogonal, and zero-vector cases
- [x] `PredictionStore` roundtrip with uncertainty fields populated and null
- [x] `compute_predictions` end-to-end: all four fields present on result, CI bounds valid, OOD sim 1.0 with no prior history
- [x] Full test suite: 704 passed, 3 skipped (optuna)

Closes #146

https://claude.ai/code/session_01TfVizbsqj759nmC8LZbH2e

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfVizbsqj759nmC8LZbH2e)_