### PR TITLE
docs(model): referee features ablation revisit — 2023-2026 data (#161)

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -317,24 +317,53 @@ XGBoost via the same feature vector. See `test_baseline_metrics.py` for the
 pinned metrics; the multi-metric XGBoost win tightens the case for issue
 #25's revisit once the third season lands.
 
-### Ablation notes — referee features (#57)
+### Ablation notes — referee features (#57, revisited #161)
 
-Walk-forward evaluation on the 2024–2025 baseline DB (424 predictions) after
-adding `ref_avg_total_points`, `ref_home_penalty_diff`, and `missing_referee`:
+**Original (#57) ablation — 2024–2025 only, 424 predictions, referee_id = NULL for all rows:**
 
-| Metric   | Before #57 | After #57 | Δ      |
-|----------|------------|-----------|--------|
+| Metric   | Before #57 | After #57 | Δ       |
+|----------|------------|-----------|---------|
 | accuracy | 0.5637     | 0.5660    | +0.23pp |
 | log_loss | 0.7636     | 0.7640    | −0.0004 |
 | brier    | 0.2655     | 0.2654    | +0.0001 |
 
-**Result: no meaningful signal** — the change is within noise. The root cause is
-that the 2024–2025 baseline DB was built at schema v1 (before referee IDs were
-extracted), so `referee_id = NULL` for every historical match; all predictions
-fall back to `missing_referee = 1.0` and the league-mean prior for
-`ref_avg_total_points`. The features are structurally correct and will accumulate
-signal as new rounds are ingested with referee data. They remain active in the
-feature vector; revisit with at least one full season of referee-annotated matches.
+Inconclusive: all `referee_id = NULL` in that DB snapshot — every match fell
+back to the league-mean prior so the features carried no information.
+
+**Revisit (#161) — 2023–2026 baseline, 692 predictions, referee data populated:**
+
+Fixture coverage at time of ablation: 2023 100%, 2024 100%, 2025 99%, 2026 31%.
+Ablation method: `scripts/ablate_referee_features.py`. "Without" condition forces
+`_referee_features` to return the `referee_id = None` fallback for every match
+(league-mean total-points, `ref_home_penalty_diff = 0`, `missing_referee = 1`).
+
+| Model    | Metric   | With refs | Without refs | Δ       |
+|----------|----------|-----------|--------------|---------|
+| Logistic | accuracy | 0.5694    | 0.5679       | +0.15pp |
+| Logistic | log_loss | 0.8906    | 0.8825       | +0.0081 ↑ (worse) |
+| Logistic | brier    | 0.2831    | 0.2814       | +0.0017 ↑ (worse) |
+| XGBoost  | accuracy | 0.6055    | 0.5838       | +2.17pp |
+| XGBoost  | log_loss | 0.6938    | 0.6854       | +0.0084 ↑ (worse) |
+| XGBoost  | brier    | 0.2476    | 0.2438       | +0.0038 ↑ (worse) |
+
+**Result: accuracy signal exists (especially XGBoost +2.17pp), but proper
+scoring rules worsen for both models.** The features are teaching the model
+referee-specific correlations that flip some borderline predictions correctly
+while widening probability estimates beyond what the data supports — a
+calibration cost that log_loss and brier both capture.
+
+The most likely cause is data sparsity per referee: even with referee IDs
+populated for 2023–2025, the rolling-20 window per referee hits the
+`REF_SHRINKAGE_N` threshold for many referees, so the shrinkage toward league
+mean is aggressive. As referee-annotated data accumulates (2+ full seasons of
+refs with ≥ 20 observed matches each), calibration should improve.
+
+**Decision (post #161):** features remain active. The XGBoost accuracy signal
+is non-trivial; removing the features now would cost 2.17pp on the evaluation
+pool. Revisit calibration specifically for referee-driven predictions once at
+least 2 full seasons (2024 + 2025 complete) have ≥ 20 obs per active referee.
+Track via the `missing_referee` rate in production predictions — when it drops
+below 20%, the calibration concern diminishes.
 
 ## MOV-weighted Elo (EloMOV) — #106
 

--- a/scripts/ablate_referee_features.py
+++ b/scripts/ablate_referee_features.py
@@ -1,0 +1,65 @@
+"""Ablation: referee features with populated referee data.
+
+Usage: uv run python scripts/ablate_referee_features.py
+
+Compares walk-forward metrics (logistic + XGBoost) on the baseline fixture DB
+with referee features enabled (current state) vs disabled (forced to the
+"referee unknown" fallback — equivalent to referee_id = NULL for every match).
+
+Fixture coverage: 2023 213/213, 2024 213/213, 2025 210/213, 2026 64/204.
+This is a substantial improvement over the #57 ablation where all rows had
+referee_id = NULL.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from fantasy_coach import feature_engineering as fe
+from fantasy_coach.evaluation import LogisticPredictor, XGBoostPredictor
+from fantasy_coach.evaluation.harness import walk_forward_from_repo
+from fantasy_coach.storage import SQLiteRepository
+
+BASELINE_DB = Path(__file__).parent.parent / "tests" / "fixtures" / "baseline-nrl.db"
+SEASONS = (2023, 2024, 2025, 2026)
+PREDICTORS = [LogisticPredictor, XGBoostPredictor]
+
+
+def run(label: str, patch_ctx=None) -> None:
+    print(f"\n=== {label} ===")
+    print(f"{'Predictor':<12} {'n':>4} {'accuracy':>10} {'log_loss':>10} {'brier':>8}")
+    print("-" * 50)
+    for cls in PREDICTORS:
+        repo = SQLiteRepository(BASELINE_DB)
+        try:
+            if patch_ctx is not None:
+                with patch_ctx:
+                    result = walk_forward_from_repo(repo, SEASONS, cls)
+            else:
+                result = walk_forward_from_repo(repo, SEASONS, cls)
+        finally:
+            repo.close()
+        m = result.metrics()
+        print(
+            f"{cls.__name__:<12} {result.n:>4} {m['accuracy']:>10.4f} "
+            f"{m['log_loss']:>10.4f} {m['brier']:>8.4f}"
+        )
+
+
+def _no_ref(self, referee_id):  # noqa: ANN001
+    """Force referee_id = None path for every match."""
+    league_mean = fe._avg(self._league_total) if self._league_total else 0.0
+    return league_mean, 0.0, 1.0
+
+
+if __name__ == "__main__":
+    run("WITH referee features (populated: 2023-100%, 2024-100%, 2025-99%)")
+    run(
+        "WITHOUT referee features (forced missing_referee=1.0 for all matches)",
+        patch.object(fe.FeatureBuilder, "_referee_features", _no_ref),
+    )
+    print()


### PR DESCRIPTION
## Summary

Closes #161

Re-runs the referee features ablation (#57) now that referee IDs are populated across 2023–2026:

- 2023: 213/213 matches (100%)
- 2024: 213/213 (100%)
- 2025: 210/213 (99%)
- 2026: 64/204 (31%, in-season)

## Ablation results

Fixture: `tests/fixtures/baseline-nrl.db`, 692 non-draw predictions (seasons 2023–2026).
Script: `scripts/ablate_referee_features.py` (new, reproducible).

| Model    | Metric   | With refs | Without refs | Δ |
|----------|----------|-----------|--------------|---|
| Logistic | accuracy | 0.5694 | 0.5679 | **+0.15pp** |
| Logistic | log_loss | 0.8906 | 0.8825 | +0.0081 ↑ (worse) |
| Logistic | brier    | 0.2831 | 0.2814 | +0.0017 ↑ (worse) |
| XGBoost  | accuracy | 0.6055 | 0.5838 | **+2.17pp** |
| XGBoost  | log_loss | 0.6938 | 0.6854 | +0.0084 ↑ (worse) |
| XGBoost  | brier    | 0.2476 | 0.2438 | +0.0038 ↑ (worse) |

## Decision

**Features remain active.** XGBoost shows a non-trivial +2.17pp accuracy gain when referee features are present. However, proper scoring rules (log_loss, brier) worsen for both models, indicating a calibration cost from limited per-referee samples (shrinkage toward league mean is still aggressive at this data volume).

This is the "signal is meaningful" branch of the #161 AC — features are kept, with the calibration caveat documented in `docs/model.md`.

## Files changed

- `docs/model.md` — replaces the stale "no signal due to NULL referee_ids" ablation with the full 2023-2026 results and a clear decision rationale.
- `scripts/ablate_referee_features.py` — new standalone ablation script so future revisits don't require reconstructing the methodology.

## Test evidence

```
769 passed, 3 skipped, 10 warnings
```

Baseline metrics unchanged (no feature-engineering or model code was modified).

https://claude.ai/code/session_01CdoriVNkVjK9QEGJr66xqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdoriVNkVjK9QEGJr66xqY)_