### PR TITLE
feat(web): first-run onboarding tour

### DIFF
--- a/docs/spa.md
+++ b/docs/spa.md
@@ -101,6 +101,42 @@ token (see `src/fantasy_coach/auth.py`).
 6. Sign-out calls `firebase/auth.signOut()`; `onAuthStateChanged` then
    clears `user` in context, which flips the UI back to the signed-out state.
 
+### Auth providers
+
+- **Google** — `GoogleAuthProvider` with `signInWithPopup`. Enabled in Firebase
+  console → Authentication → Sign-in providers.
+- **Apple** — deferred until an Apple Developer account is provisioned.
+
+## First-run onboarding tour
+
+`<OnboardingTour>` (`web/src/components/OnboardingTour.tsx`) is a 4-step
+in-house overlay shown to signed-in users who have not yet completed it.
+
+**Trigger**: when `user` becomes non-null and `localStorage.getItem("fc:onboarding_v1")`
+is absent, `Home.tsx` renders the tour. On completion *or* skip,
+`setOnboardingCompleted()` (`src/prefs.ts`) writes `"1"` to
+`"fc:onboarding_v1"` and the tour is never shown again.
+
+**Steps**:
+
+| Step | Title | Content |
+|------|-------|---------|
+| 1 | This week's round | Predictions list + win probability |
+| 2 | Dig into the why | MatchDetail feature contributions |
+| 3 | Tip against the model | Tipping + accuracy tracking |
+| 4 | Set your favourite team | Team picker on Home |
+
+**Accessibility**:
+- `role="dialog" aria-modal="true"` on the backdrop.
+- `aria-live="assertive" aria-atomic="true"` on the step content so screen
+  readers announce each step on advance.
+- Focus trapped within the card; `Tab` wraps at both ends.
+- `Escape` skips the tour (same as clicking "Skip tour").
+- `prefers-reduced-motion: reduce` disables CSS transitions.
+
+**Reset for testing**: `localStorage.removeItem("fc:onboarding_v1")` then
+reload the page.
+
 ## CORS (SPA origin ≠ API origin)
 
 The SPA is served from `https://fantasy.lopezcloud.dev`; the API runs on a

--- a/web/src/components/OnboardingTour.tsx
+++ b/web/src/components/OnboardingTour.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef, useState } from "react";
+
+const STEPS = [
+  {
+    title: "This week's round",
+    body: "The model's best pick is highlighted for every match. Win probability shows how confident the model is.",
+    cta: "Next",
+  },
+  {
+    title: "Dig into the why",
+    body: "Tap any match to see which factors drove the prediction — form, Elo, rest days, weather, and more.",
+    cta: "Next",
+  },
+  {
+    title: "Tip against the model",
+    body: "Pick your own winner for every match and track your accuracy against the model over the season.",
+    cta: "Next",
+  },
+  {
+    title: "Set your favourite team",
+    body: "Pick a team to see their next fixture, the model's prediction, and personalise this screen.",
+    cta: "Done",
+  },
+] as const;
+
+type Props = {
+  onComplete: () => void;
+};
+
+export function OnboardingTour({ onComplete }: Props) {
+  const [step, setStep] = useState(0);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const current = STEPS[step];
+
+  useEffect(() => {
+    cardRef.current?.focus();
+  }, [step]);
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onComplete();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onComplete]);
+
+  function handleTabKey(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key !== "Tab") return;
+    const focusable = cardRef.current?.querySelectorAll<HTMLElement>(
+      "button, [href], input, [tabindex]:not([tabindex=\"-1\"])",
+    );
+    if (!focusable || focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  function handleNext() {
+    if (step >= STEPS.length - 1) {
+      onComplete();
+    } else {
+      setStep(step + 1);
+    }
+  }
+
+  return (
+    <div
+      className="onboarding-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="onboarding-title"
+      aria-describedby="onboarding-body"
+    >
+      <div
+        ref={cardRef}
+        className="onboarding-card"
+        tabIndex={-1}
+        onKeyDown={handleTabKey}
+      >
+        <div className="onboarding-progress" aria-hidden="true">
+          {STEPS.map((_, i) => (
+            <span
+              key={i}
+              className={`onboarding-dot${i === step ? " active" : i < step ? " done" : ""}`}
+            />
+          ))}
+        </div>
+        <p className="onboarding-step-label muted">
+          Step {step + 1} of {STEPS.length}
+        </p>
+        <div aria-live="assertive" aria-atomic="true">
+          <h2 id="onboarding-title" className="onboarding-title">
+            {current.title}
+          </h2>
+          <p id="onboarding-body" className="onboarding-body">
+            {current.body}
+          </p>
+        </div>
+        <div className="onboarding-actions">
+          <button type="button" className="onboarding-skip" onClick={onComplete}>
+            Skip tour
+          </button>
+          <button type="button" className="onboarding-next" onClick={handleNext}>
+            {current.cta}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/prefs.ts
+++ b/web/src/prefs.ts
@@ -1,4 +1,5 @@
 const FAV_TEAMS_KEY = "fc:fav_teams";
+const ONBOARDING_KEY = "fc:onboarding_v1";
 
 export function getFavouriteTeams(): Set<string> {
   try {
@@ -12,6 +13,22 @@ export function getFavouriteTeams(): Set<string> {
 export function setFavouriteTeams(teams: Set<string>): void {
   try {
     localStorage.setItem(FAV_TEAMS_KEY, JSON.stringify([...teams]));
+  } catch {
+    // storage full — ignore
+  }
+}
+
+export function getOnboardingCompleted(): boolean {
+  try {
+    return localStorage.getItem(ONBOARDING_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function setOnboardingCompleted(): void {
+  try {
+    localStorage.setItem(ONBOARDING_KEY, "1");
   } catch {
     // storage full — ignore
   }

--- a/web/src/routes/Home.tsx
+++ b/web/src/routes/Home.tsx
@@ -4,7 +4,9 @@ import { Link } from "react-router-dom";
 import { getDashboard, ApiError, NotSignedInError } from "../api";
 import { useAuth } from "../auth";
 import { NotificationPrompt } from "../components/NotificationPrompt";
+import { OnboardingTour } from "../components/OnboardingTour";
 import { SignInRequired } from "../components/SignInRequired";
+import { getOnboardingCompleted, setOnboardingCompleted } from "../prefs";
 import type { DashboardOut } from "../types";
 
 const CURRENT_SEASON = 2026;
@@ -337,10 +339,27 @@ function LandingPage() {
 
 export default function Home() {
   const { user, loading } = useAuth();
+  const [tourActive, setTourActive] = useState(false);
+
+  useEffect(() => {
+    if (user && !getOnboardingCompleted()) {
+      setTourActive(true);
+    }
+  }, [user]);
+
+  function handleTourComplete() {
+    setOnboardingCompleted();
+    setTourActive(false);
+  }
 
   if (loading) return <p role="status">Loading…</p>;
 
   if (!user) return <LandingPage />;
 
-  return <PersonalisedDashboard />;
+  return (
+    <>
+      {tourActive && <OnboardingTour onComplete={handleTourComplete} />}
+      <PersonalisedDashboard />
+    </>
+  );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1843,3 +1843,97 @@ a:focus-visible {
   font-size: 0.875rem;
   color: var(--color-text-muted);
 }
+
+/* ── Onboarding tour ───────────────────────────────────────────────────── */
+
+.onboarding-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.onboarding-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  padding: 2rem;
+  max-width: 400px;
+  width: 100%;
+  outline: none;
+  transition: opacity 0.15s ease;
+}
+
+.onboarding-progress {
+  display: flex;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.onboarding-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-border);
+  transition: background 0.15s ease;
+}
+
+.onboarding-dot.active {
+  background: var(--color-primary);
+}
+
+.onboarding-dot.done {
+  background: var(--color-border-subtle);
+}
+
+.onboarding-step-label {
+  font-size: 0.8rem;
+  margin: 0 0 0.5rem;
+}
+
+.onboarding-title {
+  font-size: 1.15rem;
+  margin: 0 0 0.6rem;
+}
+
+.onboarding-body {
+  color: var(--color-text-secondary);
+  margin: 0 0 1.5rem;
+  line-height: 1.6;
+}
+
+.onboarding-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.onboarding-skip {
+  background: transparent;
+  border-color: transparent;
+  color: var(--color-text-muted);
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.onboarding-skip:hover {
+  background: transparent;
+  border-color: transparent;
+  color: var(--color-text);
+}
+
+.onboarding-next {
+  margin-left: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .onboarding-card,
+  .onboarding-dot {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `OnboardingTour` component (`web/src/components/OnboardingTour.tsx`): a 4-step in-house overlay (~100 lines, no library dep) shown to signed-in users who have not completed the tour.
- Tracks completion in `localStorage` key `fc:onboarding_v1` via two new helpers in `web/src/prefs.ts`.
- Mounts the tour in `Home.tsx` on first sign-in; unmounts immediately on skip or "Done".
- Adds tour CSS to `styles.css` with `prefers-reduced-motion` support.
- Documents the onboarding flow + auth providers in `docs/spa.md`.

**Note on Google sign-in**: `GoogleAuthProvider` + `signInWithPopup` were already wired in `auth.tsx` before this PR. The `AuthButton` already says "Sign in with Google". This PR does not change auth.

**Note on Apple sign-in**: deferred — requires Apple Developer Program membership. Scoped ahead with Google only per issue recommendation.

**Note on `user_prefs/{uid}` Firestore**: issue spec called for Firestore persistence. Implemented with `localStorage` instead (consistent with the existing `prefs.ts` pattern; no Firestore write infrastructure exists for user prefs yet). This is the only deviation from spec; can be migrated to Firestore in a follow-up.

## Steps covered

| # | Title | Description |
|---|-------|-------------|
| 1 | This week's round | Model picks + win probability |
| 2 | Dig into the why | MatchDetail feature contributions |
| 3 | Tip against the model | Tipping + accuracy tracking |
| 4 | Set your favourite team | Team picker on Home |

## Accessibility

- `role="dialog" aria-modal="true"` on backdrop
- `aria-live="assertive" aria-atomic="true"` on step content
- Focus trapped within card; `Tab` wraps at both ends
- `Escape` skips tour
- `prefers-reduced-motion: reduce` disables CSS transitions

## Test plan

- [ ] Sign in — tour appears automatically on Home
- [ ] Click "Next" through all 4 steps; "Done" on step 4 dismisses the tour
- [ ] Reload — tour does not reappear
- [ ] `localStorage.removeItem("fc:onboarding_v1")` + reload — tour reappears
- [ ] Click "Skip tour" on any step — tour dismissed, does not reappear
- [ ] `Escape` key skips the tour
- [ ] `Tab` / `Shift+Tab` cycles only within the card
- [ ] No visual regression on Home dashboard after tour dismissal

Closes #151

https://claude.ai/code/session_018xmRRgCrRhJ6WawxUKy612

---
_Generated by [Claude Code](https://claude.ai/code/session_018xmRRgCrRhJ6WawxUKy612)_