### PR TITLE
fix(api): leaderboard group filter — fetch stats by path, not by __name__ in

### DIFF
--- a/src/fantasy_coach/app.py
+++ b/src/fantasy_coach/app.py
@@ -1210,21 +1210,19 @@ def get_leaderboard(
     db = _get_firestore_client()
 
     if group_id:
-        # Collect UIDs in this group, then look up their stats.
+        # Collect UIDs in this group, then look up each member's stats doc by
+        # known path. The schema (match_sync._update_user_stats) writes stats
+        # to users/{uid}/stats/{season}, so a direct get_all is faster than a
+        # collection_group query and doesn't need a composite index.
         member_docs = db.collection("groups").document(group_id).collection("members").stream()
         member_uids = [d.id for d in member_docs]
         if not member_uids:
             return LeaderboardOut(season=season, groupId=group_id, entries=[])
-        stats_docs = []
-        # Firestore `in` operator supports up to 30 values; chunk if needed.
-        for i in range(0, len(member_uids), 30):
-            chunk = member_uids[i : i + 30]
-            q = (
-                db.collection_group("stats")
-                .where("season", "==", season)
-                .where("__name__", "in", chunk)
-            )
-            stats_docs.extend(q.stream())
+        refs = [
+            db.collection("users").document(uid).collection("stats").document(str(season))
+            for uid in member_uids
+        ]
+        stats_docs = [snap for snap in db.get_all(refs) if snap.exists]
     else:
         # Global top-50.
         stats_docs = list(

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -1,0 +1,100 @@
+"""Tests for GET /leaderboard, including the group-filtered branch (#173)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fantasy_coach.app import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _stat_snap(uid: str, *, accuracy: float, wins: int, losses: int) -> MagicMock:
+    """Build a DocumentSnapshot mock matching what `users/{uid}/stats/{season}` looks like."""
+    snap = MagicMock()
+    snap.exists = True
+    snap.to_dict.return_value = {
+        "wins": wins,
+        "losses": losses,
+        "total_tips": wins + losses,
+        "accuracy": accuracy,
+        "margin_points": 0.0,
+        "current_streak": 0,
+        "longest_streak": 0,
+        "display_name": f"User {uid}",
+    }
+    parent = MagicMock()
+    parent.parent.id = uid
+    snap.reference.parent = parent
+    return snap
+
+
+def _fake_db_with_group(member_uids: list[str], stats_by_uid: dict[str, MagicMock]) -> MagicMock:
+    """Build a fake firestore.Client where:
+    - `groups/{gid}/members` enumerates `member_uids` (each as a doc with id=uid)
+    - `db.get_all([users/{uid}/stats/{season} refs])` returns the matching stat snapshots
+    """
+    db = MagicMock()
+    member_doc_mocks = []
+    for uid in member_uids:
+        m = MagicMock()
+        m.id = uid
+        member_doc_mocks.append(m)
+    db.collection.return_value.document.return_value.collection.return_value.stream.return_value = (
+        iter(member_doc_mocks)
+    )
+
+    def fake_get_all(refs: list[Any]) -> list[MagicMock]:
+        # We can't introspect the chained MagicMock refs, but order doesn't matter
+        # because `_compute_leaderboard` re-sorts by accuracy.
+        return list(stats_by_uid.values())
+
+    db.get_all.side_effect = fake_get_all
+    return db
+
+
+def test_leaderboard_group_filter_returns_member_stats(client: TestClient) -> None:
+    """Group-filtered leaderboard fetches each member's stats by direct path,
+    not via collection_group + __name__ (which raises 'must be a Key')."""
+    stats = {
+        "uid_a": _stat_snap("uid_a", accuracy=0.7, wins=7, losses=3),
+        "uid_b": _stat_snap("uid_b", accuracy=0.5, wins=5, losses=5),
+    }
+    db = _fake_db_with_group(["uid_a", "uid_b"], stats)
+
+    with (
+        patch.dict("os.environ", {"STORAGE_BACKEND": "firestore"}),
+        patch("fantasy_coach.app._get_firestore_client", return_value=db),
+    ):
+        resp = client.get("/leaderboard?season=2026&group_id=g1")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["season"] == 2026
+    assert body["groupId"] == "g1"
+    # The endpoint sorts entries by accuracy DESC and assigns rank.
+    assert [e["rank"] for e in body["entries"]] == [1, 2]
+    assert body["entries"][0]["accuracy"] == pytest.approx(0.7)
+    # Verify get_all was used (the bug we're regression-testing was a
+    # collection_group + where('__name__', 'in', ...) call that raised
+    # "__key__ filter value must be a Key").
+    assert db.get_all.called
+
+
+def test_leaderboard_group_filter_empty_group(client: TestClient) -> None:
+    db = _fake_db_with_group([], {})
+    with (
+        patch.dict("os.environ", {"STORAGE_BACKEND": "firestore"}),
+        patch("fantasy_coach.app._get_firestore_client", return_value=db),
+    ):
+        resp = client.get("/leaderboard?season=2026&group_id=empty")
+    assert resp.status_code == 200
+    assert resp.json()["entries"] == []
+    db.get_all.assert_not_called()


### PR DESCRIPTION
## Summary

The group-filtered branch of \`/leaderboard\` was 500ing because it used \`collection_group('stats').where('__name__', 'in', uid_strings)\`. Firestore rejects that with \`__key__ filter value must be a Key\` — a collection-group \`__name__\` filter expects DocumentReference objects (and full document paths), not plain UIDs. Shipped with #173 because the group-filter path had no test coverage.

## Fix

\`match_sync._update_user_stats\` writes stats to a known path: \`users/{uid}/stats/{season}\`. We don't need a collection-group scan — we can build the refs directly and use \`db.get_all([refs...])\` for a single round trip with no composite index required.

## Changes

- **\`src/fantasy_coach/app.py\`** — replace the chunked \`where('__name__', 'in', ...)\` loop with a direct \`db.get_all\` over per-member \`users/{uid}/stats/{season}\` refs.
- **\`tests/test_leaderboard.py\` (new)** — regression test for the group-filter path plus an empty-group short-circuit. Mocks the firestore client.

## Verification

- ✅ \`pytest tests/test_leaderboard.py\` — 2 passed
- 🔄 The all-users \`/leaderboard?season=2026\` was already returning 200 (since the composite index in #236 finished building); the group-filter path is what this PR rescues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)