### PR TITLE
feat(web): permanent Predictions nav link with smart redirect

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -70,6 +70,9 @@ export default function App() {
           </Link>
           <div className="header-controls">
             <SearchBar />
+            <Link to="/predictions" className="nav-link">
+              Predictions
+            </Link>
             <Link to="/ladder" className="nav-link">
               Ladder
             </Link>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -10,6 +10,7 @@ import Home from "./routes/Home";
 import Ladder from "./routes/Ladder";
 import Leaderboard from "./routes/Leaderboard";
 import MatchDetail from "./routes/MatchDetail";
+import Predictions from "./routes/Predictions";
 import Round from "./routes/Round";
 import Scoreboard from "./routes/Scoreboard";
 import Team from "./routes/Team";
@@ -21,6 +22,7 @@ const router = createBrowserRouter([
     element: <App />,
     children: [
       { index: true, element: <Home /> },
+      { path: "predictions", element: <Predictions /> },
       { path: "round/:season/:round", element: <Round /> },
       { path: "round/:season/:round/:matchId", element: <MatchDetail /> },
       { path: "scoreboard", element: <Scoreboard /> },

--- a/web/src/routes/Predictions.tsx
+++ b/web/src/routes/Predictions.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { getDashboard, NotSignedInError } from "../api";
+import { useAuth } from "../auth";
+
+const CURRENT_SEASON = 2026;
+const FALLBACK_ROUND = 1;
+
+/**
+ * Index route for /predictions — there's no single "predictions" page, so this
+ * resolves the active round and redirects to /round/{season}/{round}.
+ *
+ * - Signed-in users: hits /me/dashboard to read currentRound (lowest round
+ *   with at least one non-FullTime match, or highest round otherwise).
+ * - Signed-out / dashboard error: falls back to round 1 so the page still
+ *   renders (the Round component handles 503/empty cache itself).
+ */
+export default function Predictions() {
+  const { user, loading } = useAuth();
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (loading) return;
+
+    const goTo = (round: number) => {
+      navigate(`/round/${CURRENT_SEASON}/${round}`, { replace: true });
+    };
+
+    if (!user) {
+      goTo(FALLBACK_ROUND);
+      return;
+    }
+
+    let cancelled = false;
+    getDashboard(CURRENT_SEASON, null)
+      .then((d) => {
+        if (cancelled) return;
+        goTo(d.currentRound ?? FALLBACK_ROUND);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof NotSignedInError) {
+          goTo(FALLBACK_ROUND);
+          return;
+        }
+        // Soft-fail to a default round so the user still gets somewhere.
+        setError("Couldn't detect the current round; showing Round 1.");
+        goTo(FALLBACK_ROUND);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user, loading, navigate]);
+
+  return (
+    <section>
+      <p role="status">Loading predictions…</p>
+      {error && <p className="muted">{error}</p>}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

The Round predictions page (\`/round/:season/:round\`) had no entry point in the chrome. The Dashboard's \"Tip Round\" card has a \"View predictions →\" link, but it disappears once the user has tipped every match — leaving no way to revisit Round X's predictions.

This PR adds a permanent **Predictions** link to the top nav that resolves the active round and redirects to \`/round/{season}/{round}\`.

## Changes

- **\`web/src/routes/Predictions.tsx\`** — index route at \`/predictions\`. Reads \`currentRound\` from \`/me/dashboard\` (dashboard already auto-detects: lowest round with at least one non-FullTime match, fallback to highest seen). \`history.replace\` to \`/round/{season}/{round}\` so back-button doesn't loop. Soft-fails to round 1 for signed-out users or any dashboard error.
- **\`web/src/main.tsx\`** — wire the new route.
- **\`web/src/App.tsx\`** — add \"Predictions\" link in the header, first nav item.

## Test plan

- Signed-in user: click Predictions → lands on the current round (e.g. \`/round/2026/9\`).
- Signed-out user: click Predictions → falls back to \`/round/2026/1\`.
- Tipped every match: link still works (Dashboard's TipRoundCard would have hidden it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)