### PR TITLE
fix(api): dashboard untipped/accuracy read user tips, not model predictions

### DIFF
--- a/src/fantasy_coach/app.py
+++ b/src/fantasy_coach/app.py
@@ -844,43 +844,35 @@ def get_dashboard(
     else:
         current_round = None
 
-    # Untipped = current-round matches that have no stored prediction.
+    # User's own tips for this season — keyed by match_id so we can
+    # diff against the fixture list and against actual results.
+    # Empty when uid is the dev fallback or when STORAGE_BACKEND != firestore
+    # (tips are only persisted client-side via the Firebase JS SDK).
+    user_tips = _fetch_user_tips(uid, season)
+
+    # Untipped = current-round matches the *user* hasn't picked yet.
+    # (Earlier this was wired to the prediction cache, which silently
+    # collapsed once the precompute job populated predictions.)
     untipped_match_ids: list[int] = []
     if current_round is not None:
         current_round_matches = [m for m in matches if m.round == current_round]
-        try:
-            preds = _get_store().get(season, current_round)
-            tipped_ids = {p.matchId for p in preds}
-        except Exception:
-            tipped_ids = set()
         untipped_match_ids = [
-            m.match_id for m in current_round_matches if m.match_id not in tipped_ids
+            m.match_id for m in current_round_matches if m.match_id not in user_tips
         ]
 
-    # Season-to-date tipping accuracy: compare stored predictions to FullTime results.
-    total_tips = 0
-    correct_tips = 0
-    completed = [
-        m
+    # Season-to-date tipping accuracy: compare *user tips* to FullTime results.
+    result_map: dict[int, str] = {
+        m.match_id: ("home" if m.home.score > m.away.score else "away")  # type: ignore[operator]
         for m in matches
         if m.match_state == "FullTime" and m.home.score is not None and m.away.score is not None
-    ]
-    completed_rounds = {m.round for m in completed}
-    for rnd in completed_rounds:
-        try:
-            preds = _get_store().get(season, rnd)
-        except Exception:
-            continue
-        result_map = {
-            m.match_id: ("home" if m.home.score > m.away.score else "away")  # type: ignore[operator]
-            for m in completed
-            if m.round == rnd
-        }
-        for p in preds:
-            if p.matchId in result_map:
-                total_tips += 1
-                if p.predictedWinner == result_map[p.matchId]:
-                    correct_tips += 1
+    }
+    total_tips = 0
+    correct_tips = 0
+    for mid, choice in user_tips.items():
+        if mid in result_map:
+            total_tips += 1
+            if choice == result_map[mid]:
+                correct_tips += 1
 
     season_accuracy = correct_tips / total_tips if total_tips > 0 else None
 
@@ -1155,6 +1147,38 @@ def _make_invite_code() -> str:
     import string  # noqa: PLC0415
 
     return "".join(random.choices(string.ascii_uppercase + string.digits, k=6))
+
+
+def _fetch_user_tips(uid: str, season: int) -> dict[int, str]:
+    """Return ``{match_id: tip_choice}`` for this user/season from Firestore.
+
+    Tips live at ``users/{uid}/tips/{matchId}`` (written by the SPA via the
+    Firebase JS SDK). Returns ``{}`` when there's no real authenticated user,
+    when the storage backend isn't Firestore, or on any Firestore error —
+    callers should treat that as "no tips" rather than 5xx.
+    """
+    if uid == "__dev__":
+        return {}
+    if os.getenv("STORAGE_BACKEND", "sqlite").lower() != "firestore":
+        return {}
+    try:
+        db = _get_firestore_client()
+        tips_q = (
+            db.collection("users").document(uid).collection("tips").where("season", "==", season)
+        )
+        out: dict[int, str] = {}
+        for snap in tips_q.stream():
+            try:
+                mid = int(snap.id)
+            except (ValueError, TypeError):
+                continue
+            data = snap.to_dict() or {}
+            choice = data.get("tip")
+            if choice in ("home", "away"):
+                out[mid] = choice
+        return out
+    except Exception:
+        return {}
 
 
 @app.post(

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -389,3 +389,103 @@ def test_dashboard_current_round_none_when_no_matches(client: TestClient, tmp_pa
 
     assert resp.status_code == 200
     assert resp.json()["currentRound"] is None
+
+
+# ---------------------------------------------------------------------------
+# User-tip-driven untipped + accuracy (regression: previously read predictions)
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_untipped_excludes_user_tipped_matches(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Once the user tips match 100, untippedMatchIds should drop it.
+    The predictions cache being populated must NOT collapse the list."""
+    matches = [
+        _make_match(100, round_=9, match_state="Upcoming"),
+        _make_match(101, round_=9, match_state="Upcoming", offset_seconds=1),
+        _make_match(102, round_=9, match_state="Upcoming", offset_seconds=2),
+    ]
+    mock_repo = MagicMock()
+    mock_repo.list_matches.return_value = matches
+    store = PredictionStore(path=tmp_path / "p.db")
+    # Predictions exist for all three — earlier this would have collapsed
+    # untippedMatchIds to []. The fix makes us read user tips instead.
+    store.put(2026, 9, [_make_pred(100), _make_pred(101), _make_pred(102)])
+
+    with (
+        patch("fantasy_coach.app._get_repo", return_value=mock_repo),
+        patch("fantasy_coach.app._get_store", return_value=store),
+        patch("fantasy_coach.app._fetch_user_tips", return_value={100: "home"}),
+    ):
+        resp = client.get("/me/dashboard?season=2026")
+
+    body = resp.json()
+    assert set(body["untippedMatchIds"]) == {101, 102}
+
+
+def test_dashboard_season_accuracy_uses_user_tips(client: TestClient, tmp_path: Path) -> None:
+    """Accuracy/correct/total must reflect the user's own tips, not the model's."""
+    matches = [
+        _make_match(1, round_=1, match_state="FullTime", home_score=20, away_score=10),
+        _make_match(
+            2, round_=1, match_state="FullTime", home_score=12, away_score=18, offset_seconds=1
+        ),
+        _make_match(
+            3, round_=2, match_state="FullTime", home_score=24, away_score=22, offset_seconds=2
+        ),
+        _make_match(4, round_=3, match_state="Upcoming", offset_seconds=3),
+    ]
+    mock_repo = MagicMock()
+    mock_repo.list_matches.return_value = matches
+    store = PredictionStore(path=tmp_path / "p.db")
+    # Model predicted home wins for everything — irrelevant to user accuracy.
+    store.put(2026, 1, [_make_pred(1, "home"), _make_pred(2, "home")])
+    store.put(2026, 2, [_make_pred(3, "home")])
+
+    user_tips = {
+        1: "home",  # correct (home won 20-10)
+        2: "home",  # wrong (away won 18-12)
+        3: "home",  # correct (home won 24-22)
+        # match 4 not yet tipped (and it's still Upcoming anyway)
+    }
+
+    with (
+        patch("fantasy_coach.app._get_repo", return_value=mock_repo),
+        patch("fantasy_coach.app._get_store", return_value=store),
+        patch("fantasy_coach.app._fetch_user_tips", return_value=user_tips),
+    ):
+        resp = client.get("/me/dashboard?season=2026")
+
+    body = resp.json()
+    assert body["totalTips"] == 3
+    assert body["correctTips"] == 2
+    assert body["seasonAccuracy"] == pytest.approx(2 / 3)
+
+
+def test_dashboard_no_user_tips_means_all_current_round_untipped(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Previous bug: predictions populated → untippedMatchIds = []. Fix: every match untipped."""
+    matches = [
+        _make_match(50, round_=9, match_state="Upcoming"),
+        _make_match(51, round_=9, match_state="Upcoming", offset_seconds=1),
+    ]
+    mock_repo = MagicMock()
+    mock_repo.list_matches.return_value = matches
+    store = PredictionStore(path=tmp_path / "p.db")
+    # Predictions are populated for the whole round.
+    store.put(2026, 9, [_make_pred(50), _make_pred(51)])
+
+    with (
+        patch("fantasy_coach.app._get_repo", return_value=mock_repo),
+        patch("fantasy_coach.app._get_store", return_value=store),
+        patch("fantasy_coach.app._fetch_user_tips", return_value={}),
+    ):
+        resp = client.get("/me/dashboard?season=2026")
+
+    body = resp.json()
+    assert set(body["untippedMatchIds"]) == {50, 51}
+    assert body["totalTips"] == 0
+    assert body["correctTips"] == 0
+    assert body["seasonAccuracy"] is None


### PR DESCRIPTION
## Summary

\`/me/dashboard\` was conflating **model predictions** with **user tips**. Both \`untippedMatchIds\` and \`seasonAccuracy\` were derived from the \`PredictionStore\` (the cache the Cloud Run precompute job writes to). User tips actually live in Firestore at \`users/{uid}/tips/{matchId}\`.

Symptoms users hit:

1. As soon as the precompute job populated Round 9 predictions today, the Dashboard's "Tip Round" card collapsed to **\"Round 9 complete ✓\"** with no \"View predictions →\" link — even though the user hadn't tipped a single match.
2. The \"Your Accuracy\" card was reporting the **model's** accuracy, not the user's.

## Fix

- New \`_fetch_user_tips(uid, season)\` helper queries \`users/{uid}/tips\` where \`season == N\` and returns \`{match_id: choice}\`. Returns \`{}\` when storage isn't Firestore, when \`uid\` is the dev fallback, or on any Firestore error — degrades to \"no tips\" rather than 5xx.
- \`untippedMatchIds\` = current-round matches not in \`user_tips\`.
- \`totalTips\` / \`correctTips\` / \`seasonAccuracy\` walk \`user_tips\` against the FullTime result map.

## Tests

3 new regression tests:
- \`test_dashboard_untipped_excludes_user_tipped_matches\` — even when predictions cover the round, untipped includes only the matches the user hasn't picked.
- \`test_dashboard_season_accuracy_uses_user_tips\` — accuracy reflects the user's picks vs results, not the model's predictions.
- \`test_dashboard_no_user_tips_means_all_current_round_untipped\` — the original bug, locked in.

All 16 existing dashboard tests still pass (they use SQLite, where \`_fetch_user_tips\` short-circuits to \`{}\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)