### PR TITLE
feat(web): NRL-draw-style round view — day grouping + new card layout

### DIFF
--- a/src/fantasy_coach/predictions.py
+++ b/src/fantasy_coach/predictions.py
@@ -81,6 +81,11 @@ CREATE TABLE IF NOT EXISTS predictions (
 class TeamInfo(BaseModel):
     id: int
     name: str
+    # Decimal bookmaker odds at scrape time (e.g. 1.74). Optional — absent
+    # when the NRL feed didn't carry odds for this fixture, or for cached
+    # predictions written before this field shipped. Powers the NRL-draw-style
+    # odds pills in the SPA round view.
+    odds: float | None = None
 
 
 class ScorelineProb(BaseModel):
@@ -187,6 +192,10 @@ class PredictionOut(BaseModel):
     # FANTASY_COACH_BAYESIAN_MODEL_PATH. Absent on older cached predictions.
     bayesianMargin80ci: tuple[int, int] | None = None  # noqa: N815
     bayesianMargin95ci: tuple[int, int] | None = None  # noqa: N815
+    # Display metadata for the NRL-draw-style round view. Optional — older
+    # cached predictions don't carry these; the SPA falls back gracefully.
+    venue: str | None = None
+    venueCity: str | None = None  # noqa: N815
 
 
 # ---------------------------------------------------------------------------
@@ -970,8 +979,8 @@ def compute_predictions(
         predictions.append(
             PredictionOut(
                 matchId=match.match_id,
-                home=TeamInfo(id=match.home.team_id, name=match.home.name),
-                away=TeamInfo(id=match.away.team_id, name=match.away.name),
+                home=TeamInfo(id=match.home.team_id, name=match.home.name, odds=match.home.odds),
+                away=TeamInfo(id=match.away.team_id, name=match.away.name, odds=match.away.odds),
                 kickoff=match.start_time.isoformat(),
                 predictedWinner="home" if prob >= 0.5 else "away",
                 homeWinProbability=prob,
@@ -983,6 +992,8 @@ def compute_predictions(
                 winProbability80ci=(ci_lo, ci_hi),
                 trainingDataSimilarity=ood_sim,
                 confidenceBand=band,
+                venue=match.venue,
+                venueCity=match.venue_city,
             )
         )
 

--- a/web/src/components/MatchCard.tsx
+++ b/web/src/components/MatchCard.tsx
@@ -28,6 +28,24 @@ function formatKickoff(iso: string): string {
   });
 }
 
+/**
+ * Compact NRL-draw-style kickoff time, e.g. "6:00pm". Used in the centred
+ * column of the match card. Falls back to formatKickoff() for non-times.
+ */
+function formatKickoffTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d
+    .toLocaleString(undefined, { hour: "numeric", minute: "2-digit", hour12: true })
+    .replace(/\s/g, "")
+    .toLowerCase();
+}
+
+function formatOdds(odds: number | null | undefined): string {
+  if (odds == null || !Number.isFinite(odds)) return "—";
+  return `$${odds.toFixed(2)}`;
+}
+
 export function MatchCard({
   prediction,
   season,
@@ -57,6 +75,8 @@ export function MatchCard({
   const winnerPct = p.predictedWinner === "home" ? homePct : awayPct;
   const isKickedOff = new Date(p.kickoff) <= new Date();
 
+  const venueLine = [p.venue, p.venueCity].filter(Boolean).join(", ");
+
   return (
     <Link
       to={`/round/${season}/${round}/${p.matchId}`}
@@ -65,31 +85,43 @@ export function MatchCard({
     >
       <article className="match-card">
         <header className="match-card-head">
-          <div className="teams">
-            <span
-              className="team home team-link"
-              role="link"
-              tabIndex={0}
-              onClick={(e) => { e.preventDefault(); navigate(`/team/${p.home.id}`); }}
-              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); navigate(`/team/${p.home.id}`); } }}
-            >
-              {p.home.name}
-            </span>
-            <span className="muted"> vs </span>
-            <span
-              className="team away team-link"
-              role="link"
-              tabIndex={0}
-              onClick={(e) => { e.preventDefault(); navigate(`/team/${p.away.id}`); }}
-              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); navigate(`/team/${p.away.id}`); } }}
-            >
-              {p.away.name}
-            </span>
+          <div
+            className="match-team match-team--home"
+            role="link"
+            tabIndex={0}
+            onClick={(e) => { e.preventDefault(); navigate(`/team/${p.home.id}`); }}
+            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); navigate(`/team/${p.home.id}`); } }}
+          >
+            <span className="match-team-name">{p.home.name}</span>
           </div>
-          <time className="kickoff muted" dateTime={p.kickoff}>
-            {formatKickoff(p.kickoff)}
-          </time>
+          <div className="match-time-cell">
+            <time className="match-kickoff-time" dateTime={p.kickoff}>
+              {formatKickoffTime(p.kickoff)}
+            </time>
+            <span className="match-kickoff-date muted">{formatKickoff(p.kickoff)}</span>
+          </div>
+          <div
+            className="match-team match-team--away"
+            role="link"
+            tabIndex={0}
+            onClick={(e) => { e.preventDefault(); navigate(`/team/${p.away.id}`); }}
+            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); navigate(`/team/${p.away.id}`); } }}
+          >
+            <span className="match-team-name">{p.away.name}</span>
+          </div>
         </header>
+
+        {(p.home.odds != null || p.away.odds != null) && (
+          <div className="match-odds-row" aria-label="Bookmaker odds">
+            <span className="match-odds-pill">{formatOdds(p.home.odds)}</span>
+            <span className="match-odds-source">odds</span>
+            <span className="match-odds-pill">{formatOdds(p.away.odds)}</span>
+          </div>
+        )}
+
+        {venueLine && (
+          <p className="match-venue muted">{venueLine}</p>
+        )}
 
         {(homeForm || awayForm) && (
           <div className="form-sparklines" aria-hidden="false">

--- a/web/src/routes/Round.tsx
+++ b/web/src/routes/Round.tsx
@@ -56,6 +56,33 @@ type Status =
   | { kind: "error"; message: string }
   | { kind: "ok"; predictions: Prediction[]; teamForm: Map<number, TeamFormHistory | null> };
 
+/**
+ * Group predictions by their kickoff day in the user's local timezone.
+ * Mimics the NRL draw page which renders one heading per match-day.
+ */
+function groupByDay(
+  predictions: Prediction[],
+): Array<{ dayKey: string; dayLabel: string; predictions: Prediction[] }> {
+  const fmt = new Intl.DateTimeFormat(undefined, {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
+  const groups = new Map<string, { dayKey: string; dayLabel: string; predictions: Prediction[] }>();
+  for (const p of predictions) {
+    const d = new Date(p.kickoff);
+    if (Number.isNaN(d.getTime())) continue;
+    // Bucket key by year-month-day in local time so DST and tz transitions
+    // don't split a single match-night across two groups.
+    const key = `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`;
+    if (!groups.has(key)) {
+      groups.set(key, { dayKey: key, dayLabel: fmt.format(d).toUpperCase(), predictions: [] });
+    }
+    groups.get(key)!.predictions.push(p);
+  }
+  return [...groups.values()].sort((a, b) => a.dayKey.localeCompare(b.dayKey));
+}
+
 const SKELETON_COUNT = 8;
 
 export default function Round() {
@@ -250,18 +277,23 @@ export default function Round() {
 
       {status.kind === "ok" && visiblePredictions.length > 0 && (
         <div className="match-grid">
-          {visiblePredictions.map((p) => (
-            <MatchCard
-              key={p.matchId}
-              prediction={p}
-              season={season}
-              round={round}
-              tip={tips.get(p.matchId) ?? null}
-              savingTip={savingTip === p.matchId}
-              onTip={(choice) => void handleTip(p.matchId, p.kickoff, choice)}
-              homeForm={status.teamForm.get(p.home.id)}
-              awayForm={status.teamForm.get(p.away.id)}
-            />
+          {groupByDay(visiblePredictions).map(({ dayLabel, predictions }) => (
+            <div key={dayLabel} className="match-day-group">
+              <h2 className="match-day-heading">{dayLabel}</h2>
+              {predictions.map((p) => (
+                <MatchCard
+                  key={p.matchId}
+                  prediction={p}
+                  season={season}
+                  round={round}
+                  tip={tips.get(p.matchId) ?? null}
+                  savingTip={savingTip === p.matchId}
+                  onTip={(choice) => void handleTip(p.matchId, p.kickoff, choice)}
+                  homeForm={status.teamForm.get(p.home.id)}
+                  awayForm={status.teamForm.get(p.away.id)}
+                />
+              ))}
+            </div>
           ))}
         </div>
       )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -414,24 +414,122 @@ a:focus-visible {
 }
 
 .match-card-head {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   gap: 0.75rem;
-  align-items: baseline;
-  flex-wrap: wrap;
+  align-items: center;
 }
 
-.teams {
-  font-size: 1.05rem;
+.match-team {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  cursor: pointer;
+  outline: none;
 }
 
-.team {
+.match-team--home {
+  align-items: flex-end;
+  text-align: right;
+}
+
+.match-team--away {
+  align-items: flex-start;
+  text-align: left;
+}
+
+.match-team:focus-visible {
+  outline: 2px solid var(--color-text);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm, 4px);
+}
+
+.match-team-name {
+  font-weight: 700;
+  font-size: 1.15rem;
+  line-height: 1.2;
+}
+
+.match-time-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  min-width: 5.5rem;
+}
+
+.match-kickoff-time {
+  font-weight: 700;
+  font-size: 1.15rem;
+  line-height: 1.2;
+}
+
+.match-kickoff-date {
+  font-size: 0.75rem;
+}
+
+/* Bookmaker-odds row — three columns mirroring the team layout above. */
+.match-odds-row {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  margin: 0.25rem 0;
+}
+
+.match-odds-pill {
+  background: var(--color-primary);
+  color: white;
+  padding: 0.4rem 0.75rem;
+  border-radius: var(--radius-md, 6px);
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-align: center;
+  min-width: 4rem;
+}
+
+.match-odds-pill:first-child {
+  justify-self: end;
+  width: min(100%, 8rem);
+}
+
+.match-odds-pill:last-child {
+  justify-self: start;
+  width: min(100%, 8rem);
+}
+
+.match-odds-source {
+  font-size: 0.75rem;
+  text-transform: lowercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.match-venue {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+/* Day grouping heading above each set of matches. */
+.match-day-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.match-day-heading {
+  margin: 1.25rem 0 0.25rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary);
+  text-align: center;
   font-weight: 600;
 }
 
-.kickoff {
-  font-size: 0.85rem;
-  white-space: nowrap;
+.match-day-group:first-child .match-day-heading {
+  margin-top: 0.25rem;
 }
 
 .prob-bar {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,6 +1,9 @@
 export type Team = {
   id: number;
   name: string;
+  // Decimal bookmaker odds (e.g. 1.74). Optional — older cached predictions
+  // and predictions for fixtures without odds data don't carry this.
+  odds?: number | null;
 };
 
 // One entry in a starting-XIII "missing regulars" list — carried as
@@ -54,6 +57,10 @@ export type Prediction = {
   actualWinner?: "home" | "away" | null;
   // Three-way consensus (#140): absent on predictions cached before #140 shipped.
   alternatives?: AlternativeModels | null;
+  // NRL-draw-style display fields (optional — older cached predictions
+  // don't carry these; the SPA falls back gracefully).
+  venue?: string | null;
+  venueCity?: string | null;
 };
 
 export type RoundAccuracy = {


### PR DESCRIPTION
## Summary

Reshapes the round predictions page to match the [NRL.com draw layout](https://www.nrl.com/draw/?competition=111&round=9&season=2026). Each match becomes a card with:

- **3-column header**: home team name (right-aligned) ▸ centred kickoff time + date ▸ away team name (left-aligned)
- **Odds row**: decimal-odds pill for each side, separated by a small \"odds\" label
- **Venue line**: \`Venue, City\`
- **Day grouping**: cards bucket under a \`FRIDAY 1 MAY\`-style heading by their local kickoff date

Existing prob bar, pick callout, and tip controls remain underneath so the screen still does its predictions job.

## Backend

- \`TeamInfo\` gets a new \`odds: float | None\` field (decimal odds from the NRL feed, e.g. \`1.74\`). \`compute_predictions\` copies it from \`MatchRow.home/away.odds\`.
- \`PredictionOut\` gets \`venue\` and \`venueCity\` (also from MatchRow).
- All three fields are **optional** — older cached predictions still deserialise; the SPA falls back gracefully when missing. Newest cached predictions get the data the next time the Cloud Run precompute job runs.

## SPA

- \`Prediction\` / \`Team\` types extended to mirror the new fields.
- \`Round.tsx\` groups visible predictions by local-date kickoff and renders each group under a \`match-day-heading\`. Filters and sort still apply within each day.
- \`MatchCard.tsx\` rewritten to the new 3-column layout, with the odds row only rendering when at least one side has odds.
- New \`.match-team\`, \`.match-time-cell\`, \`.match-odds-row\`, \`.match-venue\`, \`.match-day-*\` styles in \`styles.css\`.

## Out of scope (for now)

- Team logos / theme colors — needs an asset / licensing story before pulling from NRL CDN. Easy follow-up once decided.
- Ladder positions — needs a \`/standings\` endpoint or in-line accuracy compute.
- Broadcaster pills — needs \`videoProviders\` plumbed through MatchRow → PredictionOut.

## Test plan

- [x] \`uv run pytest --ignore=tests/test_baseline_metrics.py\` — 777 passed
- [x] \`npm run build\` — clean build, 787 KB main chunk (unchanged size)
- [ ] Open \`/round/2026/9\` after deploy, confirm card layout + day heading + odds + venue render. The next precompute will populate venue/odds for cached entries; pre-existing cached predictions will show name + time only until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)