### PR TITLE
fix(web): single-column NRL-style match grid

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -364,21 +364,12 @@ a:focus-visible {
 /* ── Match grid ────────────────────────────────────────────────────────── */
 
 .match-grid {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
-  grid-template-columns: 1fr;
-}
-
-@media (min-width: 640px) {
-  .match-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-@media (min-width: 960px) {
-  .match-grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
+  max-width: 720px;
+  margin-inline: auto;
+  width: 100%;
 }
 
 /* ── Match card skeleton ───────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

The new round layout was still rendering through the legacy \`.match-grid\` rule, which was \`grid-template-columns: repeat(3, 1fr)\` at ≥960px and \`repeat(2, 1fr)\` at ≥640px. Each day-group element became one grid cell, so multi-day rounds put each day in its own column and cards stayed narrow.

Per the [NRL.com draw layout](https://www.nrl.com/draw/?competition=111&round=9&season=2026), it should be a **single vertical column** of full-width-ish cards.

## Change

Replace \`.match-grid\` rules with a vertical flex column, capped at 720px and centred with \`margin-inline: auto\` so the cards don't sprawl on wide screens.

## Test plan

- [x] \`npm run build\` clean
- [ ] Refresh \`/round/2026/9\` and confirm cards stack vertically with day headings between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)