### PR TITLE
feat(#244 PR A): job_runs schema + writer in precompute

### DIFF
--- a/src/fantasy_coach/__main__.py
+++ b/src/fantasy_coach/__main__.py
@@ -767,6 +767,15 @@ def _run_precompute(args: argparse.Namespace) -> int:
         _profiler.enable()
         print("[profile] cProfile + RSS sampler started")
 
+    started_at = datetime.now(UTC)
+    # Snapshot prev predictions BEFORE compute_predictions overwrites them, so
+    # the job_runs writer (#244) can diff prev → new. Single Firestore read.
+    prev_predictions: list[Any] = []
+    try:
+        prev_predictions = list(store.get(season, round_) or [])
+    except Exception as _e:  # noqa: BLE001
+        print(f"job_runs: prev predictions snapshot skipped ({_e})")
+
     try:
         # Fetch pre-kickoff weather forecasts for upcoming matches (#207).
         # Failures are non-fatal — missing_weather=1.0 falls back gracefully.
@@ -821,6 +830,62 @@ def _run_precompute(args: argparse.Namespace) -> int:
                 print(f"Persisted season simulation to Firestore for season {season}")
         except Exception as _sim_exc:  # noqa: BLE001
             print(f"Season simulation failed (non-fatal): {_sim_exc}")
+
+        # Write the job-run audit log (#244). Firestore-only — local SQLite
+        # dev runs skip this path. Failures are non-fatal: the SPA's /jobs
+        # page just won't see this run.
+        if os.getenv("STORAGE_BACKEND", "sqlite").lower() == "firestore":
+            try:
+                from fantasy_coach.job_runs import (  # noqa: PLC0415
+                    JobRunRecord,
+                    JobRunStore,
+                    aggregate_summary,
+                    build_change_entries,
+                    hash_team_lists,
+                    weather_fetched_at_iso,
+                )
+
+                jr_store = JobRunStore(project=os.getenv("FIREBASE_PROJECT_ID"))
+                prev_changes_by_match = jr_store.latest_changes_by_match(season, round_)
+                prev_predictions_by_match = {p.matchId: p for p in prev_predictions}
+
+                team_list_hashes = {
+                    p.matchId: hash_team_lists(team_list_repo, p.matchId) for p in predictions
+                }
+                weather_at = {
+                    p.matchId: weather_fetched_at_iso(weather_forecasts.get(p.matchId))
+                    for p in predictions
+                }
+
+                changes = build_change_entries(
+                    new_predictions=predictions,
+                    prev_predictions_by_match=prev_predictions_by_match,
+                    prev_changes_by_match=prev_changes_by_match,
+                    new_team_list_hashes=team_list_hashes,
+                    new_weather_fetched_at=weather_at,
+                )
+                model_version = predictions[0].modelVersion if predictions else ""
+                record = JobRunRecord(
+                    started_at=started_at,
+                    finished_at=datetime.now(UTC),
+                    trigger=os.getenv("FANTASY_COACH_JOB_TRIGGER", "scheduled"),
+                    status="success",
+                    season=season,
+                    round=round_,
+                    matches_processed=len(predictions),
+                    model_version=model_version,
+                    error=None,
+                    summary=aggregate_summary(changes),
+                    changes=changes,
+                )
+                run_id = jr_store.add(record)
+                print(
+                    f"job_runs: wrote {run_id} "
+                    f"(flips={record.summary['flips']}, "
+                    f"max_abs_delta={record.summary['max_abs_delta']:.3f})"
+                )
+            except Exception as _jr_exc:  # noqa: BLE001
+                print(f"job_runs: write failed (non-fatal): {_jr_exc}")
     finally:
         if _profiler is not None:
             import pstats  # noqa: PLC0415

--- a/src/fantasy_coach/job_runs.py
+++ b/src/fantasy_coach/job_runs.py
@@ -1,0 +1,420 @@
+"""Audit log for the precompute Job.
+
+Each precompute invocation writes one doc to the ``job_runs`` Firestore
+collection: started/finished/status/round, an aggregate ``summary`` of how
+predictions moved, and an inline ``changes[]`` of per-match diffs with a
+human-readable one-line ``summary`` string. The SPA's /jobs page reads this
+to surface "what changed since Tuesday" without users digging through Cloud
+Logging.
+
+``predictions`` stays single-version — there is no prediction history
+collection. The diff is captured by snapshotting the prev predictions doc
+immediately before ``compute_predictions`` overwrites it.
+
+Trigger-signal detection (``team_list`` / ``weather`` / ``retrain`` / null)
+compares this run's per-match metadata to the most recent prior ``job_runs``
+doc for the same (season, round). The very first time the writer runs there
+is no prior doc, so signals are null on that one round; from then on every
+subsequent run can label its drivers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from .predictions import PredictionOut
+
+_logger = logging.getLogger(__name__)
+
+_COLLECTION = "job_runs"
+
+_SIGNAL_CLAUSE = {
+    "team_list": " — team list update",
+    "weather": " — weather update",
+    "retrain": " — model retrained",
+}
+
+
+# ---------------------------------------------------------------------------
+# Records
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class JobRunChange:
+    match_id: int
+    home_team: str
+    away_team: str
+    prev_home_prob: float | None
+    new_home_prob: float
+    delta: float  # new - prev (0.0 when no prev)
+    flipped: bool
+    trigger_signal: str | None  # team_list | weather | retrain | None
+    summary: str
+    # Tracked so the next run can detect signals by comparing.
+    model_version: str
+    team_list_hash: str | None
+    weather_fetched_at: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "match_id": self.match_id,
+            "home_team": self.home_team,
+            "away_team": self.away_team,
+            "prev_home_prob": self.prev_home_prob,
+            "new_home_prob": self.new_home_prob,
+            "delta": self.delta,
+            "flipped": self.flipped,
+            "trigger_signal": self.trigger_signal,
+            "summary": self.summary,
+            "model_version": self.model_version,
+            "team_list_hash": self.team_list_hash,
+            "weather_fetched_at": self.weather_fetched_at,
+        }
+
+
+@dataclass
+class JobRunRecord:
+    started_at: datetime
+    finished_at: datetime | None
+    trigger: str  # "scheduled" | "manual"
+    status: str  # "success" | "partial" | "failed"
+    season: int
+    round: int
+    matches_processed: int
+    model_version: str
+    error: str | None
+    summary: dict[str, Any]  # flips, mean_abs_delta, max_abs_delta
+    changes: list[JobRunChange]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "started_at": self.started_at.isoformat(),
+            "finished_at": self.finished_at.isoformat() if self.finished_at else None,
+            "trigger": self.trigger,
+            "status": self.status,
+            "season": self.season,
+            "round": self.round,
+            "matches_processed": self.matches_processed,
+            "model_version": self.model_version,
+            "error": self.error,
+            "summary": self.summary,
+            "changes": [c.to_dict() for c in self.changes],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Pure logic
+# ---------------------------------------------------------------------------
+
+
+def render_summary(
+    *,
+    home_team: str,
+    away_team: str,
+    prev_home_prob: float | None,
+    new_home_prob: float,
+    flipped: bool,
+    trigger_signal: str | None,
+) -> str:
+    """Deterministic one-line summary of how a single match's prediction moved."""
+    new_pct = round(new_home_prob * 100)
+
+    if prev_home_prob is None:
+        fav = home_team if new_home_prob >= 0.5 else away_team
+        fav_pct = new_pct if new_home_prob >= 0.5 else 100 - new_pct
+        return f"Initial prediction: {fav} {fav_pct}%."
+
+    prev_pct = round(prev_home_prob * 100)
+    delta_pct = new_pct - prev_pct
+    abs_delta_pct = abs(delta_pct)
+    sign = "+" if delta_pct >= 0 else "-"
+    signal_clause = _SIGNAL_CLAUSE.get(trigger_signal or "", "")
+    abs_delta = abs(new_home_prob - prev_home_prob)
+
+    if flipped:
+        new_fav = home_team if new_home_prob >= 0.5 else away_team
+        return (
+            f"Predicted winner flipped to {new_fav} "
+            f"({prev_pct}% → {new_pct}% home, {sign}{abs_delta_pct}pt){signal_clause}."
+        )
+    if abs_delta >= 0.05:
+        verb = "firmed" if delta_pct > 0 else "drifted"
+        return (
+            f"{home_team} {verb}: {prev_pct}% → {new_pct}% home "
+            f"({sign}{abs_delta_pct}pt){signal_clause}."
+        )
+    if abs_delta >= 0.01:
+        return (
+            f"Small drift: {prev_pct}% → {new_pct}% home ({sign}{abs_delta_pct}pt){signal_clause}."
+        )
+    return f"No material change (~{new_pct}% home)."
+
+
+def detect_trigger_signal(
+    *,
+    prev_model_version: str | None,
+    new_model_version: str,
+    prev_team_list_hash: str | None,
+    new_team_list_hash: str | None,
+    prev_weather_fetched_at: str | None,
+    new_weather_fetched_at: str | None,
+) -> str | None:
+    """Pick the most likely driver of a prediction change.
+
+    Priority retrain > team_list > weather. None means no detectable change
+    in tracked inputs (model_version, team list, weather). Signals require
+    *both* sides — first-ever observation can't be a "change".
+    """
+    if prev_model_version is not None and prev_model_version != new_model_version:
+        return "retrain"
+    if (
+        prev_team_list_hash is not None
+        and new_team_list_hash is not None
+        and prev_team_list_hash != new_team_list_hash
+    ):
+        return "team_list"
+    if (
+        prev_weather_fetched_at is not None
+        and new_weather_fetched_at is not None
+        and prev_weather_fetched_at != new_weather_fetched_at
+    ):
+        return "weather"
+    return None
+
+
+def build_change_entries(
+    *,
+    new_predictions: list[PredictionOut],
+    prev_predictions_by_match: dict[int, PredictionOut],
+    prev_changes_by_match: dict[int, dict[str, Any]],
+    new_team_list_hashes: dict[int, str | None],
+    new_weather_fetched_at: dict[int, str | None],
+) -> list[JobRunChange]:
+    """Build one JobRunChange per new prediction.
+
+    ``prev_predictions_by_match`` is the prior ``predictions`` doc, indexed by
+    match_id — the source of truth for prev_home_prob and prev_model_version.
+    ``prev_changes_by_match`` is the prior ``job_runs`` doc's changes[] indexed
+    by match_id — the only place we have prev team_list_hash / weather_fetched_at
+    for signal detection.
+    """
+    out: list[JobRunChange] = []
+    for p in new_predictions:
+        prev_pred = prev_predictions_by_match.get(p.matchId)
+        prev_change = prev_changes_by_match.get(p.matchId)
+
+        prev_home_prob = prev_pred.homeWinProbability if prev_pred is not None else None
+        prev_model_version = prev_pred.modelVersion if prev_pred is not None else None
+        prev_team_list_hash = prev_change.get("team_list_hash") if prev_change else None
+        prev_weather_fetched_at = prev_change.get("weather_fetched_at") if prev_change else None
+
+        new_team_list_hash = new_team_list_hashes.get(p.matchId)
+        new_weather = new_weather_fetched_at.get(p.matchId)
+
+        if prev_home_prob is None:
+            delta = 0.0
+            flipped = False
+        else:
+            delta = p.homeWinProbability - prev_home_prob
+            prev_winner = "home" if prev_home_prob >= 0.5 else "away"
+            flipped = prev_winner != p.predictedWinner
+
+        signal = detect_trigger_signal(
+            prev_model_version=prev_model_version,
+            new_model_version=p.modelVersion,
+            prev_team_list_hash=prev_team_list_hash,
+            new_team_list_hash=new_team_list_hash,
+            prev_weather_fetched_at=prev_weather_fetched_at,
+            new_weather_fetched_at=new_weather,
+        )
+
+        summary = render_summary(
+            home_team=p.home.name,
+            away_team=p.away.name,
+            prev_home_prob=prev_home_prob,
+            new_home_prob=p.homeWinProbability,
+            flipped=flipped,
+            trigger_signal=signal,
+        )
+
+        out.append(
+            JobRunChange(
+                match_id=p.matchId,
+                home_team=p.home.name,
+                away_team=p.away.name,
+                prev_home_prob=prev_home_prob,
+                new_home_prob=p.homeWinProbability,
+                delta=round(delta, 4),
+                flipped=flipped,
+                trigger_signal=signal,
+                summary=summary,
+                model_version=p.modelVersion,
+                team_list_hash=new_team_list_hash,
+                weather_fetched_at=new_weather,
+            )
+        )
+    return out
+
+
+def aggregate_summary(changes: list[JobRunChange]) -> dict[str, Any]:
+    """Top-level run summary — drives the list-view row."""
+    deltas = [abs(c.delta) for c in changes if c.prev_home_prob is not None]
+    flips = sum(1 for c in changes if c.flipped)
+    return {
+        "flips": flips,
+        "mean_abs_delta": round(sum(deltas) / len(deltas), 4) if deltas else 0.0,
+        "max_abs_delta": round(max(deltas), 4) if deltas else 0.0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers used by the writer in _run_precompute
+# ---------------------------------------------------------------------------
+
+
+def hash_team_lists(team_list_repo: Any, match_id: int) -> str | None:
+    """Best-effort short hash of all team-list snapshots for *match_id*.
+
+    Concatenates each snapshot's ``(team_id, scraped_at, players_json)`` tuple
+    and hashes — order-stable because ``list_snapshots`` returns rows ordered
+    by scraped_at. None on any error or when the repo doesn't expose the
+    expected method, so trigger detection gracefully degrades to null.
+    """
+    if team_list_repo is None or not hasattr(team_list_repo, "list_snapshots"):
+        return None
+    try:
+        snaps = team_list_repo.list_snapshots(match_id)
+    except Exception:  # noqa: BLE001
+        return None
+    if not snaps:
+        return None
+    h = hashlib.sha256()
+    for s in snaps:
+        try:
+            payload = (
+                f"{s.team_id}|{s.scraped_at.isoformat()}|"
+                f"{sorted((p.player_id, p.position) for p in s.players)}"
+            )
+        except Exception:  # noqa: BLE001
+            continue
+        h.update(payload.encode())
+    return h.hexdigest()[:16]
+
+
+def weather_fetched_at_iso(weather_forecast: Any) -> str | None:
+    """Pull a stable timestamp off the WeatherForecast object for diffing.
+
+    None on missing attribute; we treat that as "no weather signal", which is
+    equivalent to "not changed" for trigger-signal purposes.
+    """
+    if weather_forecast is None:
+        return None
+    fa = getattr(weather_forecast, "fetched_at", None)
+    if fa is None:
+        return None
+    if isinstance(fa, datetime):
+        return fa.isoformat()
+    return str(fa)
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+class JobRunStore:
+    """Firestore-backed audit log for precompute runs."""
+
+    def __init__(
+        self,
+        client: Any = None,
+        project: str | None = None,
+        database: str = "(default)",
+    ) -> None:
+        if client is not None:
+            self._db = client
+        else:
+            from google.cloud import firestore  # noqa: PLC0415
+
+            self._db = firestore.Client(project=project, database=database)
+
+    def add(self, record: JobRunRecord) -> str:
+        """Write a new run record. Returns the auto-generated doc id."""
+        ref = self._db.collection(_COLLECTION).document()
+        ref.set(record.to_dict())
+        return ref.id
+
+    def latest_changes_by_match(self, season: int, round_: int) -> dict[int, dict[str, Any]]:
+        """Return the most recent run's changes[] for *(season, round_)*,
+        indexed by match_id, so the next run can compute trigger signals.
+
+        Returns an empty dict on miss or any Firestore error. The diff still
+        works without it — only signal detection degrades to null.
+        """
+        col = self._db.collection(_COLLECTION)
+        try:
+            from google.cloud.firestore_v1 import Query  # noqa: PLC0415
+
+            direction: Any = Query.DESCENDING
+        except Exception:  # noqa: BLE001
+            direction = "DESCENDING"
+        try:
+            query = (
+                col.where("season", "==", season)
+                .where("round", "==", round_)
+                .order_by("started_at", direction=direction)
+                .limit(1)
+            )
+            docs = list(query.stream())
+        except Exception:  # noqa: BLE001
+            _logger.warning("job_runs latest lookup failed; signals will be null", exc_info=True)
+            return {}
+        if not docs:
+            return {}
+        doc = docs[0].to_dict() or {}
+        return {c["match_id"]: c for c in doc.get("changes", [])}
+
+    def list_recent(self, limit: int = 20) -> list[dict[str, Any]]:
+        """Return the most recent run docs (without changes[]) for the list view.
+
+        Strips the ``changes`` array to keep the API payload small — detail
+        callers go through :meth:`get` to load the full doc.
+        """
+        col = self._db.collection(_COLLECTION)
+        try:
+            from google.cloud.firestore_v1 import Query  # noqa: PLC0415
+
+            direction: Any = Query.DESCENDING
+        except Exception:  # noqa: BLE001
+            direction = "DESCENDING"
+        try:
+            query = col.order_by("started_at", direction=direction).limit(limit)
+            docs = list(query.stream())
+        except Exception:  # noqa: BLE001
+            _logger.warning("job_runs list_recent failed", exc_info=True)
+            return []
+        out: list[dict[str, Any]] = []
+        for d in docs:
+            data = d.to_dict() or {}
+            data["id"] = d.id
+            data.pop("changes", None)
+            out.append(data)
+        return out
+
+    def get(self, run_id: str) -> dict[str, Any] | None:
+        """Return the full run doc by id (including changes[])."""
+        try:
+            snap = self._db.collection(_COLLECTION).document(run_id).get()
+        except Exception:  # noqa: BLE001
+            _logger.warning("job_runs get failed for %s", run_id, exc_info=True)
+            return None
+        if not snap.exists:
+            return None
+        data = snap.to_dict() or {}
+        data["id"] = run_id
+        return data

--- a/tests/test_job_runs.py
+++ b/tests/test_job_runs.py
@@ -1,0 +1,531 @@
+"""Tests for the precompute job-run audit log (#244)."""
+
+from __future__ import annotations
+
+import itertools
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from fantasy_coach.job_runs import (
+    JobRunChange,
+    JobRunRecord,
+    JobRunStore,
+    aggregate_summary,
+    build_change_entries,
+    detect_trigger_signal,
+    render_summary,
+)
+from fantasy_coach.predictions import PredictionOut, TeamInfo
+
+
+def _pred(
+    *,
+    match_id: int = 1,
+    home_name: str = "Broncos",
+    away_name: str = "Storm",
+    home_prob: float = 0.6,
+    winner: str = "home",
+    model_version: str = "mv1",
+) -> PredictionOut:
+    return PredictionOut(
+        matchId=match_id,
+        home=TeamInfo(id=10, name=home_name),
+        away=TeamInfo(id=20, name=away_name),
+        kickoff="2026-05-01T08:00:00+00:00",
+        predictedWinner=winner,
+        homeWinProbability=home_prob,
+        modelVersion=model_version,
+        featureHash="fh1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# render_summary
+# ---------------------------------------------------------------------------
+
+
+def test_render_summary_initial_prediction_no_prev() -> None:
+    out = render_summary(
+        home_team="Broncos",
+        away_team="Storm",
+        prev_home_prob=None,
+        new_home_prob=0.62,
+        flipped=False,
+        trigger_signal=None,
+    )
+    assert out == "Initial prediction: Broncos 62%."
+
+
+def test_render_summary_initial_prediction_picks_away_when_underdog() -> None:
+    out = render_summary(
+        home_team="Broncos",
+        away_team="Storm",
+        prev_home_prob=None,
+        new_home_prob=0.30,
+        flipped=False,
+        trigger_signal=None,
+    )
+    assert out == "Initial prediction: Storm 70%."
+
+
+def test_render_summary_flip_with_signal() -> None:
+    out = render_summary(
+        home_team="Broncos",
+        away_team="Storm",
+        prev_home_prob=0.48,
+        new_home_prob=0.61,
+        flipped=True,
+        trigger_signal="team_list",
+    )
+    assert out == "Predicted winner flipped to Broncos (48% → 61% home, +13pt) — team list update."
+
+
+def test_render_summary_flip_to_away() -> None:
+    out = render_summary(
+        home_team="Broncos",
+        away_team="Storm",
+        prev_home_prob=0.55,
+        new_home_prob=0.40,
+        flipped=True,
+        trigger_signal=None,
+    )
+    assert out == "Predicted winner flipped to Storm (55% → 40% home, -15pt)."
+
+
+def test_render_summary_significant_firmed_with_retrain_signal() -> None:
+    out = render_summary(
+        home_team="Broncos",
+        away_team="Storm",
+        prev_home_prob=0.55,
+        new_home_prob=0.61,
+        flipped=False,
+        trigger_signal="retrain",
+    )
+    assert out == "Broncos firmed: 55% → 61% home (+6pt) — model retrained."
+
+
+def test_render_summary_significant_drifted() -> None:
+    out = render_summary(
+        home_team="Broncos",
+        away_team="Storm",
+        prev_home_prob=0.65,
+        new_home_prob=0.58,
+        flipped=False,
+        trigger_signal=None,
+    )
+    assert out == "Broncos drifted: 65% → 58% home (-7pt)."
+
+
+def test_render_summary_small_drift_with_weather_signal() -> None:
+    out = render_summary(
+        home_team="Broncos",
+        away_team="Storm",
+        prev_home_prob=0.62,
+        new_home_prob=0.65,
+        flipped=False,
+        trigger_signal="weather",
+    )
+    assert out == "Small drift: 62% → 65% home (+3pt) — weather update."
+
+
+def test_render_summary_no_material_change_below_threshold() -> None:
+    out = render_summary(
+        home_team="Broncos",
+        away_team="Storm",
+        prev_home_prob=0.605,
+        new_home_prob=0.610,
+        flipped=False,
+        trigger_signal=None,
+    )
+    assert out == "No material change (~61% home)."
+
+
+# ---------------------------------------------------------------------------
+# detect_trigger_signal
+# ---------------------------------------------------------------------------
+
+
+def test_detect_trigger_signal_retrain_wins_priority() -> None:
+    assert (
+        detect_trigger_signal(
+            prev_model_version="mv1",
+            new_model_version="mv2",
+            prev_team_list_hash="abc",
+            new_team_list_hash="def",
+            prev_weather_fetched_at="t0",
+            new_weather_fetched_at="t1",
+        )
+        == "retrain"
+    )
+
+
+def test_detect_trigger_signal_team_list_when_only_lineup_changed() -> None:
+    assert (
+        detect_trigger_signal(
+            prev_model_version="mv1",
+            new_model_version="mv1",
+            prev_team_list_hash="abc",
+            new_team_list_hash="def",
+            prev_weather_fetched_at="t0",
+            new_weather_fetched_at="t0",
+        )
+        == "team_list"
+    )
+
+
+def test_detect_trigger_signal_weather_when_only_forecast_changed() -> None:
+    assert (
+        detect_trigger_signal(
+            prev_model_version="mv1",
+            new_model_version="mv1",
+            prev_team_list_hash="abc",
+            new_team_list_hash="abc",
+            prev_weather_fetched_at="t0",
+            new_weather_fetched_at="t1",
+        )
+        == "weather"
+    )
+
+
+def test_detect_trigger_signal_null_when_first_observation() -> None:
+    """No prev side means we can't call it a 'change' — degrade to null."""
+    assert (
+        detect_trigger_signal(
+            prev_model_version=None,
+            new_model_version="mv1",
+            prev_team_list_hash=None,
+            new_team_list_hash="abc",
+            prev_weather_fetched_at=None,
+            new_weather_fetched_at="t0",
+        )
+        is None
+    )
+
+
+def test_detect_trigger_signal_null_when_nothing_changed() -> None:
+    assert (
+        detect_trigger_signal(
+            prev_model_version="mv1",
+            new_model_version="mv1",
+            prev_team_list_hash="abc",
+            new_team_list_hash="abc",
+            prev_weather_fetched_at="t0",
+            new_weather_fetched_at="t0",
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_change_entries
+# ---------------------------------------------------------------------------
+
+
+def test_build_change_entries_no_prev_emits_initial_summary() -> None:
+    new = [_pred(match_id=1, home_prob=0.6)]
+    changes = build_change_entries(
+        new_predictions=new,
+        prev_predictions_by_match={},
+        prev_changes_by_match={},
+        new_team_list_hashes={1: "tlh1"},
+        new_weather_fetched_at={1: None},
+    )
+    assert len(changes) == 1
+    c = changes[0]
+    assert c.prev_home_prob is None
+    assert c.delta == 0.0
+    assert c.flipped is False
+    assert c.trigger_signal is None
+    assert c.summary.startswith("Initial prediction:")
+    # Metadata stored for the next run's signal detection
+    assert c.team_list_hash == "tlh1"
+
+
+def test_build_change_entries_flip_detection() -> None:
+    prev = _pred(match_id=1, home_prob=0.48, winner="away")
+    new = _pred(match_id=1, home_prob=0.61, winner="home")
+    changes = build_change_entries(
+        new_predictions=[new],
+        prev_predictions_by_match={1: prev},
+        prev_changes_by_match={
+            1: {
+                "model_version": "mv1",
+                "team_list_hash": "tlh_old",
+                "weather_fetched_at": None,
+            }
+        },
+        new_team_list_hashes={1: "tlh_new"},
+        new_weather_fetched_at={1: None},
+    )
+    c = changes[0]
+    assert c.flipped is True
+    assert c.delta == pytest.approx(0.13)
+    assert c.trigger_signal == "team_list"
+    assert "flipped to Broncos" in c.summary
+    assert "team list update" in c.summary
+
+
+def test_build_change_entries_retrain_signal_takes_priority() -> None:
+    prev = _pred(match_id=1, home_prob=0.55, model_version="mv1")
+    new = _pred(match_id=1, home_prob=0.62, model_version="mv2")
+    changes = build_change_entries(
+        new_predictions=[new],
+        prev_predictions_by_match={1: prev},
+        prev_changes_by_match={
+            1: {
+                "model_version": "mv1",
+                "team_list_hash": "tlh_old",
+                "weather_fetched_at": "t0",
+            }
+        },
+        new_team_list_hashes={1: "tlh_new"},
+        new_weather_fetched_at={1: "t1"},
+    )
+    assert changes[0].trigger_signal == "retrain"
+    assert "model retrained" in changes[0].summary
+
+
+# ---------------------------------------------------------------------------
+# aggregate_summary
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_summary_counts_flips_and_max_delta() -> None:
+    changes = [
+        JobRunChange(
+            match_id=1,
+            home_team="A",
+            away_team="B",
+            prev_home_prob=0.50,
+            new_home_prob=0.62,
+            delta=0.12,
+            flipped=True,
+            trigger_signal=None,
+            summary="x",
+            model_version="mv1",
+            team_list_hash=None,
+            weather_fetched_at=None,
+        ),
+        JobRunChange(
+            match_id=2,
+            home_team="C",
+            away_team="D",
+            prev_home_prob=0.40,
+            new_home_prob=0.43,
+            delta=0.03,
+            flipped=False,
+            trigger_signal=None,
+            summary="x",
+            model_version="mv1",
+            team_list_hash=None,
+            weather_fetched_at=None,
+        ),
+        # Initial prediction — excluded from delta stats.
+        JobRunChange(
+            match_id=3,
+            home_team="E",
+            away_team="F",
+            prev_home_prob=None,
+            new_home_prob=0.55,
+            delta=0.0,
+            flipped=False,
+            trigger_signal=None,
+            summary="x",
+            model_version="mv1",
+            team_list_hash=None,
+            weather_fetched_at=None,
+        ),
+    ]
+    summary = aggregate_summary(changes)
+    assert summary["flips"] == 1
+    assert summary["max_abs_delta"] == 0.12
+    # mean over the two non-initial entries
+    assert summary["mean_abs_delta"] == pytest.approx(0.075)
+
+
+def test_aggregate_summary_empty_changes() -> None:
+    summary = aggregate_summary([])
+    assert summary == {"flips": 0, "mean_abs_delta": 0.0, "max_abs_delta": 0.0}
+
+
+# ---------------------------------------------------------------------------
+# JobRunStore round-trip via in-memory fake Firestore
+# ---------------------------------------------------------------------------
+
+
+class _FakeSnap:
+    def __init__(self, doc_id: str, data: dict[str, Any] | None) -> None:
+        self.id = doc_id
+        self._data = data
+
+    @property
+    def exists(self) -> bool:
+        return self._data is not None
+
+    def to_dict(self) -> dict[str, Any] | None:
+        return self._data
+
+
+class _FakeDocRef:
+    def __init__(self, collection: _FakeCollection, doc_id: str) -> None:
+        self._collection = collection
+        self.id = doc_id
+
+    def set(self, data: dict[str, Any]) -> None:
+        self._collection._docs[self.id] = dict(data)
+
+    def get(self) -> _FakeSnap:
+        return _FakeSnap(self.id, self._collection._docs.get(self.id))
+
+
+class _FakeQuery:
+    def __init__(self, collection: _FakeCollection) -> None:
+        self._collection = collection
+        self._filters: list[tuple[str, str, Any]] = []
+        self._order_by: tuple[str, str] | None = None
+        self._limit: int | None = None
+
+    def where(self, field: str, op: str, value: Any) -> _FakeQuery:
+        q = _FakeQuery(self._collection)
+        q._filters = [*self._filters, (field, op, value)]
+        q._order_by = self._order_by
+        q._limit = self._limit
+        return q
+
+    def order_by(self, field: str, direction: Any = "ASCENDING") -> _FakeQuery:
+        q = _FakeQuery(self._collection)
+        q._filters = list(self._filters)
+        q._order_by = (field, str(direction))
+        q._limit = self._limit
+        return q
+
+    def limit(self, n: int) -> _FakeQuery:
+        q = _FakeQuery(self._collection)
+        q._filters = list(self._filters)
+        q._order_by = self._order_by
+        q._limit = n
+        return q
+
+    def stream(self):
+        rows = [
+            (doc_id, data)
+            for doc_id, data in self._collection._docs.items()
+            if all(self._eval_filter(data, f) for f in self._filters)
+        ]
+        if self._order_by is not None:
+            field, direction = self._order_by
+            reverse = "DESC" in direction.upper()
+            rows.sort(key=lambda row: row[1].get(field, ""), reverse=reverse)
+        if self._limit is not None:
+            rows = rows[: self._limit]
+        return iter([_FakeSnap(doc_id, data) for doc_id, data in rows])
+
+    @staticmethod
+    def _eval_filter(data: dict[str, Any], f: tuple[str, str, Any]) -> bool:
+        field, op, value = f
+        if op == "==":
+            return data.get(field) == value
+        raise NotImplementedError(op)
+
+
+class _FakeCollection:
+    def __init__(self) -> None:
+        self._docs: dict[str, dict[str, Any]] = {}
+        self._ids = (f"doc_{i}" for i in itertools.count())
+
+    def document(self, doc_id: str | None = None) -> _FakeDocRef:
+        if doc_id is None:
+            doc_id = next(self._ids)
+        return _FakeDocRef(self, doc_id)
+
+    def where(self, field: str, op: str, value: Any) -> _FakeQuery:
+        return _FakeQuery(self).where(field, op, value)
+
+    def order_by(self, field: str, direction: Any = "ASCENDING") -> _FakeQuery:
+        return _FakeQuery(self).order_by(field, direction)
+
+
+class _FakeFirestore:
+    def __init__(self) -> None:
+        self._collections: dict[str, _FakeCollection] = {}
+
+    def collection(self, name: str) -> _FakeCollection:
+        return self._collections.setdefault(name, _FakeCollection())
+
+
+def _record(
+    season: int = 2026, round_: int = 9, started_at: datetime | None = None
+) -> JobRunRecord:
+    return JobRunRecord(
+        started_at=started_at or datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
+        finished_at=datetime(2026, 5, 1, 9, 5, tzinfo=UTC),
+        trigger="scheduled",
+        status="success",
+        season=season,
+        round=round_,
+        matches_processed=1,
+        model_version="mv1",
+        error=None,
+        summary={"flips": 0, "mean_abs_delta": 0.0, "max_abs_delta": 0.0},
+        changes=[
+            JobRunChange(
+                match_id=1,
+                home_team="Broncos",
+                away_team="Storm",
+                prev_home_prob=None,
+                new_home_prob=0.6,
+                delta=0.0,
+                flipped=False,
+                trigger_signal=None,
+                summary="Initial prediction: Broncos 60%.",
+                model_version="mv1",
+                team_list_hash="tlh1",
+                weather_fetched_at=None,
+            )
+        ],
+    )
+
+
+def test_job_run_store_add_and_get_round_trip() -> None:
+    store = JobRunStore(client=_FakeFirestore())
+    run_id = store.add(_record())
+    fetched = store.get(run_id)
+    assert fetched is not None
+    assert fetched["id"] == run_id
+    assert fetched["season"] == 2026
+    assert fetched["changes"][0]["summary"] == "Initial prediction: Broncos 60%."
+
+
+def test_job_run_store_list_recent_strips_changes_and_orders_desc() -> None:
+    store = JobRunStore(client=_FakeFirestore())
+    earlier = _record(started_at=datetime(2026, 5, 1, 9, 0, tzinfo=UTC))
+    later = _record(started_at=datetime(2026, 5, 3, 6, 0, tzinfo=UTC))
+    store.add(earlier)
+    later_id = store.add(later)
+    rows = store.list_recent(limit=10)
+    assert len(rows) == 2
+    assert rows[0]["id"] == later_id  # ordered by started_at desc
+    assert "changes" not in rows[0]
+    assert "summary" in rows[0]
+
+
+def test_job_run_store_latest_changes_by_match_filters_by_round() -> None:
+    store = JobRunStore(client=_FakeFirestore())
+    older = _record(round_=8, started_at=datetime(2026, 5, 1, 9, 0, tzinfo=UTC))
+    target_round = _record(round_=9, started_at=datetime(2026, 5, 1, 9, 0, tzinfo=UTC))
+    newer_target = _record(round_=9, started_at=datetime(2026, 5, 3, 6, 0, tzinfo=UTC))
+    store.add(older)
+    store.add(target_round)
+    store.add(newer_target)
+    out = store.latest_changes_by_match(2026, 9)
+    assert set(out.keys()) == {1}
+    # Returns the most recent — round-9 entries are identical here, but the
+    # function picks the latest started_at and indexes by match_id.
+    assert out[1]["team_list_hash"] == "tlh1"
+
+
+def test_job_run_store_latest_changes_by_match_returns_empty_on_miss() -> None:
+    store = JobRunStore(client=_FakeFirestore())
+    assert store.latest_changes_by_match(2026, 9) == {}


### PR DESCRIPTION
## Summary

- New `fantasy_coach.job_runs` module: records each precompute invocation in a `job_runs` Firestore collection with an aggregate `summary` + per-match `changes[]` carrying prev/new probs, delta, flipped flag, deterministic one-line `summary`, and a `trigger_signal` label.
- Writer wired into `_run_precompute` after the season-simulation block. Snapshots prev predictions before `compute_predictions` overwrites them; failures are non-fatal.
- Firestore-only (gated on `STORAGE_BACKEND=firestore`); local SQLite dev runs skip the writer.

Stack of #244:
- **PR A (this)** — schema + writer.
- PR B — `GET /job-runs` and `GET /job-runs/{run_id}` endpoints.
- PR C — SPA `/jobs` route + sidebar entry.

## Test plan
- [x] `uv run pytest tests/test_job_runs.py` — 22 new tests covering `render_summary`, `detect_trigger_signal`, `build_change_entries`, `aggregate_summary`, and the in-memory `JobRunStore` round-trip / `latest_changes_by_match` ordering.
- [x] `uv run pytest` — full suite (806 passed, 1 skipped).
- [x] `uv run ruff format` + `ruff check` clean on touched files.
- [ ] First scheduled precompute after merge writes a `job_runs` doc with all-null trigger signals (bootstrap run); subsequent runs label drivers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)