### PR TITLE
feat(#244 PR B): GET /job-runs endpoints

### DIFF
--- a/src/fantasy_coach/app.py
+++ b/src/fantasy_coach/app.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 
 from fantasy_coach import __version__
 from fantasy_coach.config import get_repository
+from fantasy_coach.job_runs import JobRunStore
 from fantasy_coach.predictions import (
     FirestorePredictionStore,
     PredictionOut,
@@ -110,6 +111,46 @@ class DashboardOut(BaseModel):
     correctTips: int
 
 
+class JobRunChangeOut(BaseModel):
+    matchId: int
+    homeTeam: str
+    awayTeam: str
+    prevHomeProb: float | None
+    newHomeProb: float
+    delta: float
+    flipped: bool
+    triggerSignal: str | None
+    summary: str
+
+
+class JobRunSummaryOut(BaseModel):
+    flips: int
+    meanAbsDelta: float
+    maxAbsDelta: float
+
+
+class JobRunListItem(BaseModel):
+    id: str
+    startedAt: str
+    finishedAt: str | None
+    trigger: str
+    status: str
+    season: int
+    round: int
+    matchesProcessed: int
+    modelVersion: str
+    error: str | None
+    summary: JobRunSummaryOut
+
+
+class JobRunListOut(BaseModel):
+    runs: list[JobRunListItem]
+
+
+class JobRunDetail(JobRunListItem):
+    changes: list[JobRunChangeOut]
+
+
 class UncertaintyOut(BaseModel):
     """Bayesian posterior predictive uncertainty for a single match (#144)."""
 
@@ -166,6 +207,7 @@ app.add_middleware(
 # Module-level singletons — created lazily on first use.
 _store: PredictionStore | FirestorePredictionStore | None = None
 _repo: Repository | None = None
+_job_run_store: JobRunStore | None = None
 
 # In-process cache for team profile responses: key=(team_id, season), value=(timestamp, data)
 _PROFILE_CACHE_TTL = 60  # seconds
@@ -192,6 +234,57 @@ def _get_repo() -> Repository:
     if _repo is None:
         _repo = get_repository()
     return _repo
+
+
+def _get_job_run_store() -> JobRunStore | None:
+    """Return the audit-log store, or None when running on SQLite (local dev).
+
+    The job_runs collection is Firestore-only (#244 PR A) so we can't surface
+    it from a local sqlite dev server — the endpoints respond with an empty
+    list / 404 in that case.
+    """
+    global _job_run_store
+    if os.getenv("STORAGE_BACKEND", "sqlite").lower() != "firestore":
+        return None
+    if _job_run_store is None:
+        _job_run_store = JobRunStore(project=os.getenv("FIREBASE_PROJECT_ID"))
+    return _job_run_store
+
+
+def _job_run_doc_to_list_item(doc: dict) -> dict:
+    """Map a Firestore doc (snake_case) to the camelCase API shape, no changes[]."""
+    summary = doc.get("summary") or {}
+    return {
+        "id": doc["id"],
+        "startedAt": doc.get("started_at", ""),
+        "finishedAt": doc.get("finished_at"),
+        "trigger": doc.get("trigger", "scheduled"),
+        "status": doc.get("status", "success"),
+        "season": doc.get("season", 0),
+        "round": doc.get("round", 0),
+        "matchesProcessed": doc.get("matches_processed", 0),
+        "modelVersion": doc.get("model_version", ""),
+        "error": doc.get("error"),
+        "summary": {
+            "flips": summary.get("flips", 0),
+            "meanAbsDelta": summary.get("mean_abs_delta", 0.0),
+            "maxAbsDelta": summary.get("max_abs_delta", 0.0),
+        },
+    }
+
+
+def _job_run_change_to_out(change: dict) -> dict:
+    return {
+        "matchId": change.get("match_id", 0),
+        "homeTeam": change.get("home_team", ""),
+        "awayTeam": change.get("away_team", ""),
+        "prevHomeProb": change.get("prev_home_prob"),
+        "newHomeProb": change.get("new_home_prob", 0.0),
+        "delta": change.get("delta", 0.0),
+        "flipped": bool(change.get("flipped", False)),
+        "triggerSignal": change.get("trigger_signal"),
+        "summary": change.get("summary", ""),
+    }
 
 
 def _annotate_results(
@@ -1021,6 +1114,53 @@ def get_season_simulation(season: int) -> dict:
     }
     _sim_cache[season] = (time.monotonic(), out)
     return out
+
+
+@app.get(
+    "/job-runs",
+    response_model=JobRunListOut,
+    summary="List recent precompute job runs",
+    description=(
+        "Returns the most recent precompute Job invocations with their aggregate "
+        "summary (flips, mean/max absolute delta) but without the per-match "
+        "changes[] array. Use GET /job-runs/{run_id} for the detail view. "
+        "Empty list when running on local SQLite — the audit log is Firestore-only."
+    ),
+)
+def list_job_runs(
+    limit: int = Query(20, ge=1, le=100, description="Max number of runs to return."),
+) -> JobRunListOut:
+    store = _get_job_run_store()
+    if store is None:
+        return JobRunListOut(runs=[])
+    rows = store.list_recent(limit=limit)
+    return JobRunListOut(runs=[JobRunListItem(**_job_run_doc_to_list_item(r)) for r in rows])
+
+
+@app.get(
+    "/job-runs/{run_id}",
+    response_model=JobRunDetail,
+    summary="Get a single precompute job run with per-match change diffs",
+    description=(
+        "Returns the full job_runs doc, including the inline changes[] array. "
+        "Each change carries prev/new home win probability, delta, a flipped "
+        "flag, an optional trigger_signal label, and a deterministic one-line "
+        "human-readable summary."
+    ),
+)
+def get_job_run(run_id: str) -> JobRunDetail:
+    store = _get_job_run_store()
+    if store is None:
+        raise HTTPException(
+            status_code=404,
+            detail="Job-run audit log is unavailable on this backend.",
+        )
+    doc = store.get(run_id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail=f"Job run {run_id} not found.")
+    list_item = _job_run_doc_to_list_item(doc)
+    changes = [JobRunChangeOut(**_job_run_change_to_out(c)) for c in doc.get("changes", [])]
+    return JobRunDetail(**list_item, changes=changes)
 
 
 _VENUES_CSV = pathlib.Path(__file__).parents[3] / "data" / "venues.csv"

--- a/tests/test_job_runs_api.py
+++ b/tests/test_job_runs_api.py
@@ -1,0 +1,140 @@
+"""Integration tests for /job-runs endpoints (#244 PR B)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fantasy_coach.app import app
+from fantasy_coach.job_runs import JobRunChange, JobRunRecord, JobRunStore
+
+# Reuse the in-memory Firestore stub from the unit tests for the store.
+from tests.test_job_runs import _FakeFirestore
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_app_singletons():
+    import fantasy_coach.app as app_module
+
+    app_module._store = None
+    app_module._job_run_store = None
+    yield
+    app_module._store = None
+    app_module._job_run_store = None
+
+
+def _record(
+    *,
+    season: int = 2026,
+    round_: int = 9,
+    started_at: datetime | None = None,
+    flips: int = 1,
+    summary_text: str = (
+        "Predicted winner flipped to Broncos (48% → 61% home, +13pt) — team list update."
+    ),
+) -> JobRunRecord:
+    return JobRunRecord(
+        started_at=started_at or datetime(2026, 5, 1, 9, 0, tzinfo=UTC),
+        finished_at=datetime(2026, 5, 1, 9, 5, tzinfo=UTC),
+        trigger="scheduled",
+        status="success",
+        season=season,
+        round=round_,
+        matches_processed=1,
+        model_version="mv1",
+        error=None,
+        summary={"flips": flips, "mean_abs_delta": 0.13, "max_abs_delta": 0.13},
+        changes=[
+            JobRunChange(
+                match_id=42,
+                home_team="Broncos",
+                away_team="Storm",
+                prev_home_prob=0.48,
+                new_home_prob=0.61,
+                delta=0.13,
+                flipped=True,
+                trigger_signal="team_list",
+                summary=summary_text,
+                model_version="mv1",
+                team_list_hash="tlh1",
+                weather_fetched_at=None,
+            )
+        ],
+    )
+
+
+def _populated_store() -> tuple[JobRunStore, str]:
+    store = JobRunStore(client=_FakeFirestore())
+    earlier_id = store.add(_record(started_at=datetime(2026, 5, 1, 9, 0, tzinfo=UTC), flips=0))
+    later_id = store.add(_record(started_at=datetime(2026, 5, 3, 6, 0, tzinfo=UTC), flips=1))
+    assert earlier_id != later_id
+    return store, later_id
+
+
+def test_list_job_runs_returns_recent_runs_in_camel_case(client: TestClient) -> None:
+    store, latest_id = _populated_store()
+    with patch("fantasy_coach.app._get_job_run_store", return_value=store):
+        response = client.get("/job-runs?limit=5")
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body["runs"], list)
+    assert len(body["runs"]) == 2
+    # Most recent first
+    first = body["runs"][0]
+    assert first["id"] == latest_id
+    assert first["startedAt"] == "2026-05-03T06:00:00+00:00"
+    assert first["matchesProcessed"] == 1
+    assert first["modelVersion"] == "mv1"
+    # Aggregate summary is camelCase
+    assert first["summary"] == {"flips": 1, "meanAbsDelta": 0.13, "maxAbsDelta": 0.13}
+    # changes[] is intentionally absent in the list view
+    assert "changes" not in first
+
+
+def test_list_job_runs_empty_when_backend_unavailable(client: TestClient) -> None:
+    """Local SQLite dev returns an empty list, not 500."""
+    with patch("fantasy_coach.app._get_job_run_store", return_value=None):
+        response = client.get("/job-runs")
+    assert response.status_code == 200
+    assert response.json() == {"runs": []}
+
+
+def test_get_job_run_returns_full_doc_with_changes(client: TestClient) -> None:
+    store, latest_id = _populated_store()
+    with patch("fantasy_coach.app._get_job_run_store", return_value=store):
+        response = client.get(f"/job-runs/{latest_id}")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == latest_id
+    assert body["summary"]["flips"] == 1
+    assert len(body["changes"]) == 1
+    change = body["changes"][0]
+    assert change["matchId"] == 42
+    assert change["homeTeam"] == "Broncos"
+    assert change["prevHomeProb"] == 0.48
+    assert change["newHomeProb"] == 0.61
+    assert change["flipped"] is True
+    assert change["triggerSignal"] == "team_list"
+    assert "team list update" in change["summary"]
+
+
+def test_get_job_run_returns_404_when_id_unknown(client: TestClient) -> None:
+    store, _ = _populated_store()
+    with patch("fantasy_coach.app._get_job_run_store", return_value=store):
+        response = client.get("/job-runs/does-not-exist")
+    assert response.status_code == 404
+
+
+def test_get_job_run_returns_404_when_backend_unavailable(client: TestClient) -> None:
+    """SQLite dev: detail endpoint 404s instead of returning a misleading shape."""
+    with patch("fantasy_coach.app._get_job_run_store", return_value=None):
+        response = client.get("/job-runs/anything")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

- Two new endpoints surfacing the `job_runs` audit log added in PR A:
  - `GET /job-runs?limit=20` returns recent run summaries (no `changes[]`).
  - `GET /job-runs/{run_id}` returns the full doc including per-match `changes[]` with the deterministic human-readable `summary` string.
- Maps Firestore's snake_case fields to the SPA's camelCase shape via Pydantic models (`JobRunListItem` / `JobRunDetail` / `JobRunChangeOut`).
- Singleton `_get_job_run_store()` returns None on local SQLite — endpoints respond with empty list / 404 instead of erroring.

Stacked on `feat/244-job-runs-writer`. Re-target this PR's base to `main` before merging PR A so it doesn't auto-close.

## Test plan
- [x] `uv run pytest tests/test_job_runs_api.py` — 5 new endpoint tests (camelCase shape, ordering, 404s, SQLite-disabled fallback).
- [x] `uv run pytest` — full suite (811 passed, 1 skipped).
- [x] `uv run ruff format` + `ruff check` clean.
- [ ] After PR A + this merge, `curl https://fantasy.lopezcloud.dev/job-runs?limit=5` returns the latest write from the next scheduled precompute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)