### PR TITLE
feat(#244 PR C): SPA /jobs route + sidebar nav

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, Outlet } from "react-router-dom";
+import { Link, NavLink, Outlet, useLocation } from "react-router-dom";
 
 import { AuthProvider, useAuth } from "./auth";
 import { AuthButton } from "./components/AuthButton";
@@ -10,6 +10,16 @@ import { ThemeToggle } from "./components/ThemeToggle";
 import { onForegroundMessage, acquireAndRegisterToken, getPermissionState, isRegistered } from "./notifications";
 
 type Toast = { title: string; body: string; href?: string };
+
+const NAV_ITEMS: { to: string; label: string }[] = [
+  { to: "/predictions", label: "Predictions" },
+  { to: "/ladder", label: "Ladder" },
+  { to: "/leaderboard", label: "Leaderboard" },
+  { to: "/groups", label: "Groups" },
+  { to: "/scoreboard", label: "Scoreboard" },
+  { to: "/accuracy", label: "Accuracy" },
+  { to: "/jobs", label: "Job runs" },
+];
 
 function ForegroundToast({ toast, onClose }: { toast: Toast; onClose: () => void }) {
   useEffect(() => {
@@ -60,41 +70,64 @@ function NotificationManager() {
 }
 
 export default function App() {
+  const [navOpen, setNavOpen] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    setNavOpen(false);
+  }, [location.pathname]);
+
   return (
     <AuthProvider>
       <div className="app">
-        <OfflineBanner />
-        <header className="app-header">
-          <Link to="/" className="brand">
+        <aside
+          className={`app-sidebar${navOpen ? " is-open" : ""}`}
+          aria-label="Primary navigation"
+        >
+          <Link to="/" className="brand" onClick={() => setNavOpen(false)}>
             Fantasy Coach
           </Link>
-          <div className="header-controls">
-            <SearchBar />
-            <Link to="/predictions" className="nav-link">
-              Predictions
-            </Link>
-            <Link to="/ladder" className="nav-link">
-              Ladder
-            </Link>
-            <Link to="/leaderboard" className="nav-link">
-              Leaderboard
-            </Link>
-            <Link to="/groups" className="nav-link">
-              Groups
-            </Link>
-            <Link to="/scoreboard" className="nav-link">
-              Scoreboard
-            </Link>
-            <Link to="/accuracy" className="nav-link">
-              Accuracy
-            </Link>
-            <ThemeToggle />
-            <AuthButton />
-          </div>
-        </header>
-        <main className="app-main">
-          <Outlet />
-        </main>
+          <nav className="sidebar-nav">
+            {NAV_ITEMS.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) => `nav-link${isActive ? " is-active" : ""}`}
+              >
+                {item.label}
+              </NavLink>
+            ))}
+          </nav>
+        </aside>
+        <button
+          type="button"
+          className={`sidebar-backdrop${navOpen ? " is-open" : ""}`}
+          aria-label="Close menu"
+          tabIndex={navOpen ? 0 : -1}
+          onClick={() => setNavOpen(false)}
+        />
+        <div className="app-body">
+          <OfflineBanner />
+          <header className="app-header">
+            <button
+              type="button"
+              className="nav-toggle"
+              aria-label={navOpen ? "Close menu" : "Open menu"}
+              aria-expanded={navOpen}
+              onClick={() => setNavOpen((o) => !o)}
+            >
+              ☰
+            </button>
+            <div className="header-controls">
+              <SearchBar />
+              <ThemeToggle />
+              <AuthButton />
+            </div>
+          </header>
+          <main className="app-main">
+            <Outlet />
+          </main>
+        </div>
         <InstallPrompt />
         <NotificationManager />
       </div>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,5 +1,11 @@
 import { getFirebaseAuth, API_BASE_URL } from "./firebase";
-import type { DashboardOut, SeasonSimulation, TeamOption } from "./types";
+import type {
+  DashboardOut,
+  JobRunDetail,
+  JobRunListItem,
+  SeasonSimulation,
+  TeamOption,
+} from "./types";
 
 export class ApiError extends Error {
   constructor(
@@ -41,6 +47,15 @@ export async function getDashboard(
 
 export async function getSimulation(season: number): Promise<SeasonSimulation> {
   return apiFetch<SeasonSimulation>(`/season/${season}/simulation`);
+}
+
+export async function getJobRuns(limit = 20): Promise<JobRunListItem[]> {
+  const data = await apiFetch<{ runs: JobRunListItem[] }>(`/job-runs?limit=${limit}`);
+  return data.runs;
+}
+
+export async function getJobRun(runId: string): Promise<JobRunDetail> {
+  return apiFetch<JobRunDetail>(`/job-runs/${encodeURIComponent(runId)}`);
 }
 
 export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -7,6 +7,7 @@ import App from "./App";
 import GroupDetail from "./routes/GroupDetail";
 import Groups from "./routes/Groups";
 import Home from "./routes/Home";
+import { JobDetail, Jobs } from "./routes/Jobs";
 import Ladder from "./routes/Ladder";
 import Leaderboard from "./routes/Leaderboard";
 import MatchDetail from "./routes/MatchDetail";
@@ -32,6 +33,8 @@ const router = createBrowserRouter([
       { path: "leaderboard", element: <Leaderboard /> },
       { path: "groups", element: <Groups /> },
       { path: "groups/:gid", element: <GroupDetail /> },
+      { path: "jobs", element: <Jobs /> },
+      { path: "jobs/:runId", element: <JobDetail /> },
     ],
   },
 ]);

--- a/web/src/routes/Jobs.tsx
+++ b/web/src/routes/Jobs.tsx
@@ -1,0 +1,253 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { ApiError, getJobRun, getJobRuns, NotSignedInError } from "../api";
+import { useAuth } from "../auth";
+import { SignInRequired } from "../components/SignInRequired";
+import type { JobRunChange, JobRunDetail, JobRunListItem } from "../types";
+
+type ListStatus =
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "ok"; data: JobRunListItem[] };
+
+type DetailStatus =
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "ok"; data: JobRunDetail };
+
+function fmtDate(iso: string): string {
+  if (!iso) return "—";
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function fmtPct(n: number | null | undefined): string {
+  if (n === null || n === undefined) return "—";
+  return `${Math.round(n * 100)}%`;
+}
+
+function StatusPill({ status }: { status: string }) {
+  const cls =
+    status === "success"
+      ? "job-status-pill job-status-pill--ok"
+      : status === "failed"
+        ? "job-status-pill job-status-pill--err"
+        : "job-status-pill job-status-pill--warn";
+  return <span className={cls}>{status}</span>;
+}
+
+function SignalBadge({ signal }: { signal: JobRunChange["triggerSignal"] }) {
+  if (!signal) return null;
+  const label =
+    signal === "team_list"
+      ? "team list"
+      : signal === "weather"
+        ? "weather"
+        : "model retrained";
+  return <span className="job-signal-badge">{label}</span>;
+}
+
+export function Jobs() {
+  const { user, loading } = useAuth();
+  const [status, setStatus] = useState<ListStatus>({ kind: "loading" });
+
+  useEffect(() => {
+    if (loading || !user) return;
+    let cancelled = false;
+    setStatus({ kind: "loading" });
+    getJobRuns(50)
+      .then((data) => {
+        if (!cancelled) setStatus({ kind: "ok", data });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof NotSignedInError) {
+          setStatus({ kind: "error", message: "Sign in required" });
+          return;
+        }
+        const msg =
+          err instanceof ApiError
+            ? `API ${err.status}: ${err.message}`
+            : err instanceof Error
+              ? err.message
+              : String(err);
+        setStatus({ kind: "error", message: msg });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user, loading]);
+
+  if (loading) return <p>Loading…</p>;
+  if (!user) return <SignInRequired />;
+
+  return (
+    <div className="jobs-page">
+      <h1>Precompute runs</h1>
+      <p className="muted">
+        The precompute job runs Tue 09:00 and Thu 06:00 AEST. Each row shows how predictions
+        moved relative to the prior run — useful for spotting late team-list or weather
+        changes that might shift your tips.
+      </p>
+
+      {status.kind === "loading" && <p>Loading runs…</p>}
+      {status.kind === "error" && (
+        <div className="error-box">Failed to load runs: {status.message}</div>
+      )}
+      {status.kind === "ok" && status.data.length === 0 && (
+        <p className="muted">No runs recorded yet.</p>
+      )}
+      {status.kind === "ok" && status.data.length > 0 && (
+        <ul className="job-list">
+          {status.data.map((run) => (
+            <li key={run.id} className="job-list-item">
+              <Link to={`/jobs/${run.id}`} className="job-list-link">
+                <div className="job-list-row">
+                  <span className="job-list-time">{fmtDate(run.startedAt)}</span>
+                  <StatusPill status={run.status} />
+                  <span className="job-list-meta">
+                    Round {run.round} · {run.matchesProcessed} matches
+                  </span>
+                </div>
+                <div className="job-list-summary">
+                  <span>
+                    <strong>{run.summary.flips}</strong> flip
+                    {run.summary.flips === 1 ? "" : "s"}
+                  </span>
+                  <span>
+                    max Δ <strong>{Math.round(run.summary.maxAbsDelta * 100)}pt</strong>
+                  </span>
+                  <span>
+                    avg Δ <strong>{Math.round(run.summary.meanAbsDelta * 100)}pt</strong>
+                  </span>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export function JobDetail() {
+  const { runId } = useParams<{ runId: string }>();
+  const { user, loading } = useAuth();
+  const [status, setStatus] = useState<DetailStatus>({ kind: "loading" });
+
+  useEffect(() => {
+    if (loading || !user || !runId) return;
+    let cancelled = false;
+    setStatus({ kind: "loading" });
+    getJobRun(runId)
+      .then((data) => {
+        if (!cancelled) setStatus({ kind: "ok", data });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof NotSignedInError) {
+          setStatus({ kind: "error", message: "Sign in required" });
+          return;
+        }
+        const msg =
+          err instanceof ApiError
+            ? err.status === 404
+              ? "Run not found."
+              : `API ${err.status}: ${err.message}`
+            : err instanceof Error
+              ? err.message
+              : String(err);
+        setStatus({ kind: "error", message: msg });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user, loading, runId]);
+
+  if (loading) return <p>Loading…</p>;
+  if (!user) return <SignInRequired />;
+
+  return (
+    <div className="jobs-page">
+      <p>
+        <Link to="/jobs" className="back-link">
+          ← All runs
+        </Link>
+      </p>
+      {status.kind === "loading" && <p>Loading run…</p>}
+      {status.kind === "error" && (
+        <div className="error-box">Failed to load run: {status.message}</div>
+      )}
+      {status.kind === "ok" && (
+        <>
+          <h1>Run on {fmtDate(status.data.startedAt)}</h1>
+          <div className="job-detail-meta">
+            <StatusPill status={status.data.status} />
+            <span>Round {status.data.round}</span>
+            <span>{status.data.matchesProcessed} matches</span>
+            <span className="muted">model {status.data.modelVersion}</span>
+          </div>
+          <div className="job-detail-summary">
+            <span>
+              <strong>{status.data.summary.flips}</strong> flip
+              {status.data.summary.flips === 1 ? "" : "s"}
+            </span>
+            <span>
+              max Δ{" "}
+              <strong>{Math.round(status.data.summary.maxAbsDelta * 100)}pt</strong>
+            </span>
+            <span>
+              avg Δ{" "}
+              <strong>{Math.round(status.data.summary.meanAbsDelta * 100)}pt</strong>
+            </span>
+          </div>
+
+          {status.data.error && (
+            <div className="error-box">Error: {status.data.error}</div>
+          )}
+
+          <h2>Per-match changes</h2>
+          {status.data.changes.length === 0 ? (
+            <p className="muted">No matches in this run.</p>
+          ) : (
+            <ul className="job-change-list">
+              {status.data.changes.map((c) => (
+                <li
+                  key={c.matchId}
+                  className={`job-change-card${c.flipped ? " job-change-card--flipped" : ""}`}
+                >
+                  <div className="job-change-teams">
+                    <strong>{c.homeTeam}</strong> v <strong>{c.awayTeam}</strong>
+                    {c.flipped && <span className="job-flip-badge">flipped</span>}
+                    <SignalBadge signal={c.triggerSignal} />
+                  </div>
+                  <div className="job-change-probs">
+                    <span>{fmtPct(c.prevHomeProb)}</span>
+                    <span aria-hidden="true">→</span>
+                    <span>
+                      <strong>{fmtPct(c.newHomeProb)}</strong> home
+                    </span>
+                  </div>
+                  <p className="job-change-summary">{c.summary}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export default Jobs;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -87,10 +87,51 @@ body {
 
 /* ── Layout ────────────────────────────────────────────────────────────── */
 
+:root {
+  --sidebar-width: 220px;
+}
+
 .app {
-  max-width: 960px;
-  margin: 0 auto;
+  min-height: 100vh;
+}
+
+.app-sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: var(--sidebar-width);
   padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  z-index: 50;
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.sidebar-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  z-index: 40;
+}
+
+.app-body {
+  margin-left: var(--sidebar-width);
+  padding: 1rem;
+  max-width: calc(960px + var(--sidebar-width));
 }
 
 .app-header {
@@ -107,6 +148,7 @@ body {
   display: flex;
   align-items: center;
   gap: 1rem;
+  margin-left: auto;
 }
 
 .brand {
@@ -116,8 +158,49 @@ body {
   text-decoration: none;
 }
 
+.nav-toggle {
+  display: none;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  padding: 0.35rem 0.6rem;
+  font-size: 1.1rem;
+  line-height: 1;
+  border-radius: var(--radius-sm);
+}
+
+.nav-toggle:hover {
+  background: var(--color-border);
+  border-color: var(--color-border);
+}
+
 .app-main h1 {
   margin-top: 0;
+}
+
+@media (max-width: 768px) {
+  .app-sidebar {
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
+    box-shadow: var(--shadow-card);
+  }
+
+  .app-sidebar.is-open {
+    transform: translateX(0);
+  }
+
+  .sidebar-backdrop.is-open {
+    display: block;
+  }
+
+  .app-body {
+    margin-left: 0;
+    max-width: 100%;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+  }
 }
 
 /* ── Buttons ───────────────────────────────────────────────────────────── */
@@ -809,14 +892,24 @@ a:focus-visible {
 /* ── Nav link ──────────────────────────────────────────────────────────── */
 
 .nav-link {
-  font-size: 0.9rem;
+  display: block;
+  font-size: 0.95rem;
   color: var(--color-text-muted);
   text-decoration: none;
   white-space: nowrap;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-md);
 }
 
 .nav-link:hover {
   color: var(--color-text);
+  background: var(--color-border);
+}
+
+.nav-link.is-active {
+  color: var(--color-text);
+  background: var(--color-border);
+  font-weight: 600;
 }
 
 /* ── Tip entry ─────────────────────────────────────────────────────────── */
@@ -2025,4 +2118,194 @@ a:focus-visible {
   .onboarding-dot {
     transition: none;
   }
+}
+
+/* ── Jobs page (#244) ──────────────────────────────────────────────────── */
+
+.jobs-page h1 {
+  margin-bottom: 0.5rem;
+}
+
+.jobs-page > p.muted {
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+  max-width: 60ch;
+}
+
+.job-status-pill {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  border-radius: var(--radius-full);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--color-border);
+  color: var(--color-text-secondary);
+}
+
+.job-status-pill--ok {
+  background: #d4edda;
+  color: #155724;
+}
+
+.job-status-pill--warn {
+  background: #fff3cd;
+  color: #856404;
+}
+
+.job-status-pill--err {
+  background: var(--color-error-bg);
+  color: var(--color-error-text);
+}
+
+[data-theme="dark"] .job-status-pill--ok {
+  background: #1f3b25;
+  color: #b8e0c1;
+}
+
+[data-theme="dark"] .job-status-pill--warn {
+  background: #3a3008;
+  color: #f5d97a;
+}
+
+.job-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.job-list-item {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.job-list-link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.85rem 1rem;
+  color: inherit;
+  text-decoration: none;
+}
+
+.job-list-link:hover {
+  background: var(--color-bg);
+  border-radius: var(--radius-md);
+}
+
+.job-list-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.job-list-time {
+  font-weight: 600;
+}
+
+.job-list-meta {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.job-list-summary {
+  display: flex;
+  gap: 1.25rem;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.job-detail-meta {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 0.25rem 0 0.75rem;
+}
+
+.job-detail-summary {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+  font-size: 1rem;
+  color: var(--color-text-secondary);
+}
+
+.job-change-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.job-change-card {
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.job-change-card--flipped {
+  border-left-color: var(--color-error);
+}
+
+.job-change-teams {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.job-flip-badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--radius-full);
+  background: var(--color-error-bg);
+  color: var(--color-error-text);
+}
+
+.job-signal-badge {
+  font-size: 0.75rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: var(--radius-full);
+  background: var(--color-border);
+  color: var(--color-text-secondary);
+}
+
+.job-change-probs {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+}
+
+.job-change-summary {
+  margin: 0;
+  color: var(--color-text);
+}
+
+.back-link {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
+
+.back-link:hover {
+  color: var(--color-text);
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -189,6 +189,46 @@ export type SeasonSimulation = {
   teams: SeasonTeamOutcome[];
 };
 
+// ---------------------------------------------------------------------------
+// Precompute job-run audit log (#244)
+// ---------------------------------------------------------------------------
+
+export type JobRunSummary = {
+  flips: number;
+  meanAbsDelta: number;
+  maxAbsDelta: number;
+};
+
+export type JobRunListItem = {
+  id: string;
+  startedAt: string;
+  finishedAt: string | null;
+  trigger: string;
+  status: string;
+  season: number;
+  round: number;
+  matchesProcessed: number;
+  modelVersion: string;
+  error: string | null;
+  summary: JobRunSummary;
+};
+
+export type JobRunChange = {
+  matchId: number;
+  homeTeam: string;
+  awayTeam: string;
+  prevHomeProb: number | null;
+  newHomeProb: number;
+  delta: number;
+  flipped: boolean;
+  triggerSignal: "team_list" | "weather" | "retrain" | null;
+  summary: string;
+};
+
+export type JobRunDetail = JobRunListItem & {
+  changes: JobRunChange[];
+};
+
 export type DashboardOut = {
   season: number;
   currentRound: number | null;


### PR DESCRIPTION
## Summary

- **/jobs** — list view of recent precompute runs (timestamp, status pill, round, flip count, max/mean Δ).
- **/jobs/:runId** — detail view with per-match cards: prev → new home win prob, a flip badge when the winner switched, an optional trigger-signal badge (team list / weather / model retrained), and the deterministic one-line `summary` string written by PR A.
- New **"Job runs"** entry in the sidebar nav.
- This PR also brings in the **top-header → left sidebar** UX change requested earlier in the conversation (`NavLink` with active-state highlighting, hamburger toggle on mobile, route-change auto-close). Bundled because the new "Job runs" entry needs somewhere to live and the sidebar work is its natural home.

Stacked on `feat/244-job-runs-api` → `feat/244-job-runs-writer`. Re-target this PR's base to `main` before merging the bottom of the stack so it doesn't auto-close.

## Test plan
- [x] `npm run lint` (tsc --noEmit) — clean.
- [x] `npm run build` — clean (29.63 → 32.29 KB CSS, 789 → 794 KB JS gzip).
- [ ] Local `npm run dev` — eyeball: list view loads, status pill, click into detail, flipped + signal badges render correctly, back link works, sidebar active state highlights `/jobs`.
- [ ] After PR A + B + this merge, visit https://fantasy.lopezcloud.dev/jobs and confirm the next scheduled precompute appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)