### PR TITLE
fix(web): activate new SW on first reload after deploy

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -35,6 +35,12 @@ export default defineConfig({
         ],
       },
       workbox: {
+        // Activate the new SW on first reload after deploy. Without these the
+        // SW installs but stays "waiting" until every tab of the origin closes,
+        // which surfaces as users seeing the previous build for hours/days
+        // after a deploy.
+        skipWaiting: true,
+        clientsClaim: true,
         // Precache all built JS, CSS, HTML, and image assets.
         globPatterns: ["**/*.{js,css,html,svg,png,ico,woff2}"],
         runtimeCaching: [


### PR DESCRIPTION
## Summary

Adds `workbox.skipWaiting: true` + `clientsClaim: true` to the vite-plugin-pwa config. Without these, every SPA deploy installs into the SW "waiting" state and only activates once every tab of the origin is closed and reopened — which surfaces as "I deployed but I still see the old UI" (most recently with PR #247's sidebar nav, where users had to close all tabs to see the new layout).

## Test plan
- [x] `npm run build` — clean (PWA SW + workbox manifest still generate).
- [ ] After deploy, visit https://fantasy.lopezcloud.dev with a stale tab open, hard reload — should pick up the new build immediately rather than waiting on all tabs to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)