### PR TITLE
feat(#208 PR B): late team-list watcher + watch-team-lists CLI

### DIFF
--- a/src/fantasy_coach/__main__.py
+++ b/src/fantasy_coach/__main__.py
@@ -427,6 +427,49 @@ def main(argv: list[str] | None = None) -> int:
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
     )
 
+    wtl = sub.add_parser(
+        "watch-team-lists",
+        help=(
+            "Snapshot starting-XIIIs for kickoff-imminent matches and emit "
+            "LateTeamChange rows for any starting-XIII diff vs the most recent "
+            "pre-window snapshot (#208). Designed to run on a third Cloud Run "
+            "schedule (every 15 min on match days)."
+        ),
+    )
+    wtl.add_argument(
+        "--season",
+        type=int,
+        default=None,
+        help="Season to watch. Omit to autodetect the current year.",
+    )
+    wtl.add_argument(
+        "--round",
+        type=int,
+        default=None,
+        help="Round to watch. Omit to autodetect the next upcoming round.",
+    )
+    wtl.add_argument(
+        "--lead-minutes",
+        type=int,
+        default=90,
+        help="Look at matches whose kickoff is inside the next N minutes (default 90).",
+    )
+    wtl.add_argument(
+        "--cutoff-minutes",
+        type=int,
+        default=60,
+        help=(
+            "A snapshot must be at least N minutes before kickoff to be eligible "
+            "as the diff reference (default 60). Filters out other intra-window "
+            "watcher snapshots so each emit compares to the named team list."
+        ),
+    )
+    wtl.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+
     args = parser.parse_args(argv)
     logging.basicConfig(
         level=args.log_level,
@@ -457,6 +500,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_notify_round_published(args)
     if args.command == "clear-commentary-cache":
         return _run_clear_commentary_cache(args)
+    if args.command == "watch-team-lists":
+        return _run_watch_team_lists(args)
     parser.error(f"unknown command {args.command!r}")
     return 2  # unreachable
 
@@ -1298,6 +1343,109 @@ def _run_notify_round_published(args: argparse.Namespace) -> int:
     from fantasy_coach.notifications import send_round_published  # noqa: PLC0415
 
     send_round_published(season=args.season, round_id=args.round_id)
+    return 0
+
+
+def _run_watch_team_lists(args: argparse.Namespace) -> int:
+    """Snapshot kickoff-imminent team lists + emit LateTeamChange rows (#208)."""
+    import os  # noqa: PLC0415
+    from datetime import UTC, datetime  # noqa: PLC0415
+
+    from fantasy_coach.config import get_repository  # noqa: PLC0415
+    from fantasy_coach.late_change_watcher import (  # noqa: PLC0415
+        find_matches_in_window,
+        watch_match,
+    )
+    from fantasy_coach.scraper import (  # noqa: PLC0415
+        InMemoryScraperCache,
+        fetch_match_from_url,
+    )
+    from fantasy_coach.storage.injury import (  # noqa: PLC0415
+        FirestoreLateTeamChangeRepository,
+        SQLiteLateTeamChangeRepository,
+    )
+    from fantasy_coach.storage.team_list import (  # noqa: PLC0415
+        FirestoreTeamListRepository,
+        SQLiteTeamListRepository,
+    )
+
+    season = args.season or datetime.now(UTC).year
+    round_ = args.round
+    if round_ is None:
+        round_ = _detect_upcoming_round(season)
+        if round_ is None:
+            print(f"No upcoming round found in season {season} — nothing to watch.")
+            return 0
+        print(f"Autodetected upcoming round: season={season} round={round_}")
+
+    repo = get_repository()
+    backend = os.getenv("STORAGE_BACKEND", "sqlite").lower()
+    if backend == "firestore":
+        team_list_repo: Any = FirestoreTeamListRepository()
+        late_repo: Any = FirestoreLateTeamChangeRepository()
+    else:
+        conn = getattr(repo, "_conn", None)
+        if conn is None:
+            print("watch-team-lists: SQLite repo has no `_conn`; aborting.")
+            return 1
+        team_list_repo = SQLiteTeamListRepository(conn)
+        late_repo = SQLiteLateTeamChangeRepository(conn)
+
+    matches = repo.list_matches(season, round_)
+    now = datetime.now(UTC)
+    in_window = find_matches_in_window(matches=matches, now=now, lead_minutes=args.lead_minutes)
+
+    if not in_window:
+        print(
+            f"No matches kicking off in the next {args.lead_minutes} min "
+            f"(season={season}, round={round_}); nothing to watch."
+        )
+        return 0
+
+    cache = InMemoryScraperCache()
+
+    def _fetcher(match: Any) -> dict[str, Any] | None:
+        # The Cloud Run Job stores match objects with a stable matchCentreUrl
+        # only on the upcoming-fixture endpoint, not the per-match payload.
+        # Fall back to a constructed path when that's missing.
+        url = getattr(match, "match_centre_url", None)
+        if url is None:
+            from fantasy_coach.scraper import _match_path  # noqa: PLC0415
+
+            home_slug = getattr(match.home, "slug", None)
+            away_slug = getattr(match.away, "slug", None)
+            if home_slug and away_slug:
+                url = _match_path(season, round_, home_slug, away_slug)
+        if url is None:
+            print(f"watch-team-lists: no match URL for match_id={match.match_id}; skipping")
+            return None
+        return fetch_match_from_url(url, cache=cache)
+
+    total_changes = 0
+    for match in in_window:
+        try:
+            written = watch_match(
+                match=match,
+                fetch_match=_fetcher,
+                team_list_repo=team_list_repo,
+                late_repo=late_repo,
+                now=now,
+                cutoff_minutes_before_kickoff=args.cutoff_minutes,
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(f"watch-team-lists: match_id={match.match_id} failed: {exc}")
+            continue
+        if written:
+            total_changes += len(written)
+            print(
+                f"watch-team-lists: match_id={match.match_id} -> "
+                f"{len(written)} late changes ({[c.change_type for c in written]})"
+            )
+
+    print(
+        f"watch-team-lists: {len(in_window)} matches in window, "
+        f"{total_changes} late changes recorded."
+    )
     return 0
 
 

--- a/src/fantasy_coach/late_change_watcher.py
+++ b/src/fantasy_coach/late_change_watcher.py
@@ -1,0 +1,282 @@
+"""Late team-list watcher (#208).
+
+Polls upcoming matches whose kickoff is inside a configurable lead-time
+window and snapshots their team list, then diffs against the most recent
+prior snapshot to detect late starting-XIII changes — the kind of move
+that bookmaker closing lines react to in 0.5–1.5 point swings but the
+Tue/Thu precompute Job misses entirely.
+
+The watcher is meant to run on a third Cloud Run schedule (every 15 min
+on match days). Each invocation:
+
+1. Lists upcoming matches with kickoff ≤ ``lead_minutes`` away.
+2. For each, re-fetches the per-match endpoint to get a fresh team list.
+3. Records the snapshot in ``team_list_snapshots`` (so the Tue/Thu diff
+   downstream picks it up too).
+4. Computes a starting-XIII diff vs the latest prior snapshot whose
+   ``scraped_at`` is at least ``cutoff_minutes_before_kickoff`` before
+   kickoff (so the "early" reference is the named team list, not another
+   intra-window scrape).
+5. Writes one ``LateTeamChange`` per add/drop/position-change to
+   ``late_team_changes``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fantasy_coach.features import PlayerRow
+from fantasy_coach.injury import LateTeamChange
+from fantasy_coach.storage.injury import LateTeamChangeRepository
+from fantasy_coach.storage.team_list import TeamListRepository
+from fantasy_coach.team_lists import TeamListSnapshot
+
+logger = logging.getLogger(__name__)
+
+# Default kickoff-window settings. Tunable via the CLI subcommand.
+DEFAULT_LEAD_MINUTES = 90
+DEFAULT_CUTOFF_MINUTES = 60
+
+
+def compute_late_changes(
+    *,
+    earlier: TeamListSnapshot,
+    later: TeamListSnapshot,
+) -> list[LateTeamChange]:
+    """Diff two snapshots into a flat list of ``LateTeamChange`` rows.
+
+    Mirrors the (match_id, team_id) guard from
+    ``compute_team_list_changes`` but emits one row per *player* rather
+    than two grouped tuples — that lines up with how ``late_team_changes``
+    stores them and how the feature builder reads them.
+
+    Players whose ``is_on_field`` is ``None`` in *either* snapshot are
+    skipped. A pre-team-list-drop scrape doesn't carry ``is_on_field``,
+    so a sensible "starter" set isn't derivable.
+    """
+    if earlier.match_id != later.match_id or earlier.team_id != later.team_id:
+        raise ValueError(
+            f"Snapshots must share (match_id, team_id); got "
+            f"({earlier.match_id}, {earlier.team_id}) vs ({later.match_id}, {later.team_id})"
+        )
+
+    earlier_by_id = {p.player_id: p for p in earlier.players}
+    later_by_id = {p.player_id: p for p in later.players}
+
+    # Skip players whose is_on_field is None in either snapshot — we
+    # can't tell whether they're starting, so we can't claim a change.
+    # A pre-team-list-drop scrape carries None for everyone, so this
+    # is the right guard against false-positive "added" rows on the
+    # first scrape after the team list drops.
+    rows: list[LateTeamChange] = []
+
+    union_pids = set(earlier_by_id) | set(later_by_id)
+    for pid in union_pids:
+        before = earlier_by_id.get(pid)
+        after = later_by_id.get(pid)
+        before_known = before is not None and before.is_on_field is not None
+        after_known = after is not None and after.is_on_field is not None
+        if not (before_known and after_known):
+            continue
+        was = bool(before.is_on_field)
+        now_starting = bool(after.is_on_field)
+        if was and not now_starting:
+            rows.append(
+                _row(
+                    later,
+                    pid,
+                    before.position,
+                    was_starting=True,
+                    is_starting=False,
+                    kind="withdrawn",
+                )
+            )
+        elif not was and now_starting:
+            rows.append(
+                _row(
+                    later,
+                    pid,
+                    after.position,
+                    was_starting=False,
+                    is_starting=True,
+                    kind="added",
+                )
+            )
+        elif was and now_starting and before.position != after.position:
+            # Position changes inside the starting XIII (e.g. halfback
+            # → five-eighth). Bench/reserve position swaps don't move
+            # closing lines so we don't bother recording them.
+            rows.append(
+                _row(
+                    later,
+                    pid,
+                    after.position,
+                    was_starting=True,
+                    is_starting=True,
+                    kind="position_change",
+                )
+            )
+
+    rows.sort(key=lambda r: (r.player_id, r.change_type))
+    return rows
+
+
+def _row(
+    later: TeamListSnapshot,
+    player_id: int,
+    position: str | None,
+    *,
+    was_starting: bool,
+    is_starting: bool,
+    kind: str,
+) -> LateTeamChange:
+    return LateTeamChange(
+        match_id=later.match_id,
+        team_id=later.team_id,
+        player_id=player_id,
+        change_type=kind,
+        position=position,
+        was_starting=was_starting,
+        is_starting=is_starting,
+        detected_at=later.scraped_at,
+    )
+
+
+def select_reference_snapshot(
+    snapshots: Iterable[TeamListSnapshot],
+    *,
+    kickoff: datetime,
+    cutoff_minutes_before_kickoff: int = DEFAULT_CUTOFF_MINUTES,
+) -> TeamListSnapshot | None:
+    """Pick the latest snapshot at least ``cutoff_minutes`` before kickoff.
+
+    Filters out snapshots from inside the kickoff window so multiple
+    watcher invocations don't compare against each other (we want each
+    intra-window scrape to compare against the named team list, not
+    against a 30-minute-old version of itself).
+    """
+    cutoff = kickoff - timedelta(minutes=cutoff_minutes_before_kickoff)
+    eligible = [s for s in snapshots if s.scraped_at < cutoff]
+    if not eligible:
+        return None
+    return max(eligible, key=lambda s: s.scraped_at)
+
+
+def watch_match(
+    *,
+    match: Any,
+    fetch_match: Any,
+    team_list_repo: TeamListRepository,
+    late_repo: LateTeamChangeRepository,
+    now: datetime | None = None,
+    cutoff_minutes_before_kickoff: int = DEFAULT_CUTOFF_MINUTES,
+) -> list[LateTeamChange]:
+    """Snapshot a match's team lists + emit any late changes vs the
+    pre-window reference snapshot.
+
+    ``match`` is a ``MatchRow``-shaped object: requires ``match_id``,
+    ``season``, ``round``, ``start_time``, ``home.team_id``,
+    ``away.team_id``. ``fetch_match`` is a ``(matchCentreUrl,) -> dict``
+    callable (or ``None`` on 304/404) so callers can plug in the live
+    scraper or a fake. The watcher only writes when there's actual
+    fresh data — a 304 cache hit short-circuits.
+
+    Returns the rows written for this match (empty if no late changes).
+    """
+    now = now or datetime.now(UTC)
+    payload = fetch_match(match)
+    if payload is None:
+        # 304 or 404 — nothing to record.
+        logger.info("watch_match: no fresh payload for match_id=%s", match.match_id)
+        return []
+
+    fresh_home = _snapshot_from_payload(payload, match=match, side="home", scraped_at=now)
+    fresh_away = _snapshot_from_payload(payload, match=match, side="away", scraped_at=now)
+
+    written: list[LateTeamChange] = []
+    for fresh in (fresh_home, fresh_away):
+        # Always store the fresh snapshot so the next invocation has a
+        # current baseline for the broader Tue/Thu diff path too.
+        team_list_repo.record_snapshot(fresh)
+
+        prior_snapshots = team_list_repo.list_snapshots(
+            match_id=match.match_id, team_id=fresh.team_id
+        )
+        # Filter out the snapshot we just inserted — listing is
+        # repository-implementation dependent on whether the read sees
+        # an uncommitted insert in the same transaction. Ordering by
+        # scraped_at lets us drop anything at or after `now`.
+        prior_snapshots = [s for s in prior_snapshots if s.scraped_at < now]
+
+        reference = select_reference_snapshot(
+            prior_snapshots,
+            kickoff=match.start_time,
+            cutoff_minutes_before_kickoff=cutoff_minutes_before_kickoff,
+        )
+        if reference is None:
+            logger.info(
+                "watch_match: no reference snapshot for match=%s team=%s; recording snapshot only",
+                match.match_id,
+                fresh.team_id,
+            )
+            continue
+
+        for change in compute_late_changes(earlier=reference, later=fresh):
+            late_repo.record_change(change)
+            written.append(change)
+
+    return written
+
+
+def _snapshot_from_payload(
+    payload: dict[str, Any], *, match: Any, side: str, scraped_at: datetime
+) -> TeamListSnapshot:
+    team_key = "homeTeam" if side == "home" else "awayTeam"
+    team_payload = payload.get(team_key) or {}
+    raw_players = team_payload.get("players") or []
+    fallback_team = match.home if side == "home" else match.away
+    team_id = int(team_payload.get("teamId") or fallback_team.team_id)
+    return TeamListSnapshot(
+        season=match.season,
+        round=match.round,
+        match_id=match.match_id,
+        team_id=team_id,
+        scraped_at=scraped_at,
+        players=tuple(_player_from_payload(p) for p in raw_players),
+    )
+
+
+def _player_from_payload(p: dict[str, Any]) -> PlayerRow:
+    raw_on_field = p.get("isOnField")
+    return PlayerRow(
+        player_id=int(p["playerId"]),
+        jersey_number=_optional_int(p.get("number")),
+        position=p.get("position"),
+        first_name=p.get("firstName"),
+        last_name=p.get("lastName"),
+        is_on_field=bool(raw_on_field) if raw_on_field is not None else None,
+    )
+
+
+def _optional_int(raw: Any) -> int | None:
+    if raw is None or raw == "":
+        return None
+    return int(raw)
+
+
+def find_matches_in_window(
+    *,
+    matches: Iterable[Any],
+    now: datetime,
+    lead_minutes: int = DEFAULT_LEAD_MINUTES,
+) -> list[Any]:
+    """Filter to upcoming matches whose kickoff is inside ``[now, now + lead]``.
+
+    Already-kicked-off matches are excluded — we only care about late
+    changes, not in-game lineups.
+    """
+    horizon = now + timedelta(minutes=lead_minutes)
+    return [m for m in matches if now <= m.start_time <= horizon]

--- a/tests/test_late_change_watcher.py
+++ b/tests/test_late_change_watcher.py
@@ -1,0 +1,432 @@
+"""Tests for the late team-list watcher (#208 PR B)."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from fantasy_coach.features import PlayerRow
+from fantasy_coach.injury import LateTeamChange
+from fantasy_coach.late_change_watcher import (
+    compute_late_changes,
+    find_matches_in_window,
+    select_reference_snapshot,
+    watch_match,
+)
+from fantasy_coach.storage.injury import SQLiteLateTeamChangeRepository
+from fantasy_coach.storage.sqlite import SQLiteRepository
+from fantasy_coach.storage.team_list import SQLiteTeamListRepository
+from fantasy_coach.team_lists import TeamListSnapshot
+
+
+def _player(
+    player_id: int,
+    *,
+    jersey: int,
+    position: str = "Halfback",
+    is_on_field: bool | None = True,
+) -> PlayerRow:
+    return PlayerRow(
+        player_id=player_id,
+        jersey_number=jersey,
+        position=position,
+        first_name=f"First{player_id}",
+        last_name=f"Last{player_id}",
+        is_on_field=is_on_field,
+    )
+
+
+def _snapshot(
+    *,
+    match_id: int = 1000,
+    team_id: int = 500001,
+    scraped_at: datetime,
+    players: tuple[PlayerRow, ...],
+) -> TeamListSnapshot:
+    return TeamListSnapshot(
+        season=2026,
+        round=8,
+        match_id=match_id,
+        team_id=team_id,
+        scraped_at=scraped_at,
+        players=players,
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_late_changes
+# ---------------------------------------------------------------------------
+
+
+def test_compute_returns_empty_when_identical() -> None:
+    players = (_player(1, jersey=7), _player(2, jersey=14, is_on_field=False))
+    early = _snapshot(scraped_at=datetime(2026, 4, 25, 6, 0, tzinfo=UTC), players=players)
+    late = _snapshot(scraped_at=datetime(2026, 4, 25, 9, 30, tzinfo=UTC), players=players)
+    assert compute_late_changes(earlier=early, later=late) == []
+
+
+def test_compute_emits_withdrawn_and_added_for_swap() -> None:
+    early = _snapshot(
+        scraped_at=datetime(2026, 4, 25, 6, 0, tzinfo=UTC),
+        players=(
+            _player(1, jersey=7, is_on_field=True),
+            _player(2, jersey=14, is_on_field=False),
+        ),
+    )
+    late = _snapshot(
+        scraped_at=datetime(2026, 4, 25, 9, 30, tzinfo=UTC),
+        players=(
+            _player(1, jersey=14, is_on_field=False),
+            _player(2, jersey=7, is_on_field=True),
+        ),
+    )
+    rows = compute_late_changes(earlier=early, later=late)
+    assert len(rows) == 2
+    by_kind = {r.change_type: r for r in rows}
+    assert by_kind["withdrawn"].player_id == 1
+    assert by_kind["withdrawn"].was_starting is True
+    assert by_kind["withdrawn"].is_starting is False
+    assert by_kind["added"].player_id == 2
+    assert by_kind["added"].was_starting is False
+    assert by_kind["added"].is_starting is True
+    # detected_at is the LATER snapshot's scraped_at.
+    assert by_kind["withdrawn"].detected_at == late.scraped_at
+
+
+def test_compute_emits_position_change_when_starter_moves() -> None:
+    early = _snapshot(
+        scraped_at=datetime(2026, 4, 25, 6, 0, tzinfo=UTC),
+        players=(_player(1, jersey=7, position="Halfback"),),
+    )
+    late = _snapshot(
+        scraped_at=datetime(2026, 4, 25, 9, 30, tzinfo=UTC),
+        players=(_player(1, jersey=6, position="Five-Eighth"),),
+    )
+    rows = compute_late_changes(earlier=early, later=late)
+    assert len(rows) == 1
+    assert rows[0].change_type == "position_change"
+    assert rows[0].position == "Five-Eighth"  # the *new* position
+
+
+def test_compute_skips_players_with_none_is_on_field() -> None:
+    # A pre-team-list-drop snapshot has is_on_field=None for everyone — we
+    # can't derive a starter set so the player is invisible to the diff.
+    early = _snapshot(
+        scraped_at=datetime(2026, 4, 25, 6, 0, tzinfo=UTC),
+        players=(_player(1, jersey=7, is_on_field=None),),
+    )
+    late = _snapshot(
+        scraped_at=datetime(2026, 4, 25, 9, 30, tzinfo=UTC),
+        players=(_player(1, jersey=7, is_on_field=True),),
+    )
+    assert compute_late_changes(earlier=early, later=late) == []
+
+
+def test_compute_rejects_mismatched_match_or_team() -> None:
+    a = _snapshot(
+        match_id=1, team_id=10, scraped_at=datetime(2026, 4, 25, 6, 0, tzinfo=UTC), players=()
+    )
+    b = _snapshot(
+        match_id=2, team_id=10, scraped_at=datetime(2026, 4, 25, 9, 0, tzinfo=UTC), players=()
+    )
+    with pytest.raises(ValueError):
+        compute_late_changes(earlier=a, later=b)
+
+
+# ---------------------------------------------------------------------------
+# select_reference_snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_select_reference_picks_latest_before_cutoff() -> None:
+    kickoff = datetime(2026, 4, 25, 10, 0, tzinfo=UTC)
+    candidates = [
+        _snapshot(scraped_at=kickoff - timedelta(days=4), players=()),  # Tuesday
+        _snapshot(scraped_at=kickoff - timedelta(days=2), players=()),  # Thursday
+        _snapshot(scraped_at=kickoff - timedelta(minutes=30), players=()),  # inside window
+    ]
+    chosen = select_reference_snapshot(
+        candidates, kickoff=kickoff, cutoff_minutes_before_kickoff=60
+    )
+    assert chosen is not None
+    # Latest snapshot at LEAST 60 min before kickoff = the Thursday one.
+    assert chosen.scraped_at == kickoff - timedelta(days=2)
+
+
+def test_select_reference_returns_none_when_all_inside_window() -> None:
+    kickoff = datetime(2026, 4, 25, 10, 0, tzinfo=UTC)
+    candidates = [
+        _snapshot(scraped_at=kickoff - timedelta(minutes=45), players=()),
+        _snapshot(scraped_at=kickoff - timedelta(minutes=15), players=()),
+    ]
+    assert (
+        select_reference_snapshot(candidates, kickoff=kickoff, cutoff_minutes_before_kickoff=60)
+        is None
+    )
+
+
+def test_select_reference_returns_none_when_no_candidates() -> None:
+    assert select_reference_snapshot([], kickoff=datetime(2026, 4, 25, 10, 0, tzinfo=UTC)) is None
+
+
+# ---------------------------------------------------------------------------
+# find_matches_in_window
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _StubMatch:
+    match_id: int
+    start_time: datetime
+
+
+def test_find_matches_in_window_filters_by_kickoff() -> None:
+    now = datetime(2026, 4, 25, 9, 0, tzinfo=UTC)
+    matches = [
+        _StubMatch(1, now + timedelta(minutes=30)),  # in window
+        _StubMatch(2, now + timedelta(minutes=89)),  # in window
+        _StubMatch(3, now + timedelta(minutes=120)),  # too far away
+        _StubMatch(4, now - timedelta(minutes=10)),  # already kicked off
+    ]
+    chosen = find_matches_in_window(matches=matches, now=now, lead_minutes=90)
+    assert [m.match_id for m in chosen] == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# watch_match — end-to-end with fake fetcher + real SQLite repos
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sqlite_conn(tmp_path: Path) -> sqlite3.Connection:
+    repo = SQLiteRepository(tmp_path / "watch.db")
+    return repo._conn  # noqa: SLF001 — share schema-bootstrapped conn
+
+
+@dataclass(frozen=True)
+class _StubTeam:
+    team_id: int
+
+
+@dataclass(frozen=True)
+class _StubMatchRow:
+    match_id: int
+    season: int
+    round: int
+    start_time: datetime
+    home: _StubTeam
+    away: _StubTeam
+
+
+def _make_payload(
+    *,
+    home_team_id: int,
+    away_team_id: int,
+    home_players: list[dict[str, Any]],
+    away_players: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "homeTeam": {"teamId": home_team_id, "players": home_players},
+        "awayTeam": {"teamId": away_team_id, "players": away_players},
+    }
+
+
+def _player_payload(player_id: int, *, position: str, is_on_field: bool, jersey: int) -> dict:
+    return {
+        "playerId": player_id,
+        "position": position,
+        "isOnField": is_on_field,
+        "number": jersey,
+        "firstName": f"First{player_id}",
+        "lastName": f"Last{player_id}",
+    }
+
+
+def test_watch_match_writes_late_change_when_starter_dropped(
+    sqlite_conn: sqlite3.Connection,
+) -> None:
+    team_list_repo = SQLiteTeamListRepository(sqlite_conn)
+    late_repo = SQLiteLateTeamChangeRepository(sqlite_conn)
+
+    kickoff = datetime(2026, 4, 25, 10, 0, tzinfo=UTC)
+    match = _StubMatchRow(
+        match_id=1000,
+        season=2026,
+        round=8,
+        start_time=kickoff,
+        home=_StubTeam(team_id=500001),
+        away=_StubTeam(team_id=500002),
+    )
+
+    # Pre-window reference snapshot (named team list dropped Thursday).
+    earlier = TeamListSnapshot(
+        season=2026,
+        round=8,
+        match_id=1000,
+        team_id=500001,
+        scraped_at=kickoff - timedelta(days=2),
+        players=(
+            _player(1, jersey=7, position="Halfback", is_on_field=True),
+            _player(2, jersey=14, position="Bench", is_on_field=False),
+        ),
+    )
+    team_list_repo.record_snapshot(earlier)
+    # Away team has its named-team-list snapshot but no late changes
+    # — still recorded so list_snapshots(team_id=away) is non-empty.
+    earlier_away = TeamListSnapshot(
+        season=2026,
+        round=8,
+        match_id=1000,
+        team_id=500002,
+        scraped_at=kickoff - timedelta(days=2),
+        players=(_player(10, jersey=7, position="Halfback", is_on_field=True),),
+    )
+    team_list_repo.record_snapshot(earlier_away)
+
+    # Watcher payload — player 1 dropped from starting XIII inside kickoff hour.
+    fresh = _make_payload(
+        home_team_id=500001,
+        away_team_id=500002,
+        home_players=[
+            _player_payload(1, position="Bench", is_on_field=False, jersey=14),
+            _player_payload(2, position="Halfback", is_on_field=True, jersey=7),
+        ],
+        away_players=[
+            _player_payload(10, position="Halfback", is_on_field=True, jersey=7),
+        ],
+    )
+
+    written = watch_match(
+        match=match,
+        fetch_match=lambda _m: fresh,
+        team_list_repo=team_list_repo,
+        late_repo=late_repo,
+        now=kickoff - timedelta(minutes=30),
+        cutoff_minutes_before_kickoff=60,
+    )
+
+    # One swap on the home team: player 1 dropped, player 2 promoted.
+    kinds = sorted(c.change_type for c in written)
+    assert kinds == ["added", "withdrawn"]
+    home_rows = late_repo.list_changes(match_id=1000, team_id=500001)
+    assert len(home_rows) == 2
+    away_rows = late_repo.list_changes(match_id=1000, team_id=500002)
+    assert away_rows == []
+
+
+def test_watch_match_records_snapshot_even_with_no_diff(
+    sqlite_conn: sqlite3.Connection,
+) -> None:
+    team_list_repo = SQLiteTeamListRepository(sqlite_conn)
+    late_repo = SQLiteLateTeamChangeRepository(sqlite_conn)
+
+    kickoff = datetime(2026, 4, 25, 10, 0, tzinfo=UTC)
+    match = _StubMatchRow(
+        match_id=2000,
+        season=2026,
+        round=8,
+        start_time=kickoff,
+        home=_StubTeam(team_id=600001),
+        away=_StubTeam(team_id=600002),
+    )
+
+    earlier = TeamListSnapshot(
+        season=2026,
+        round=8,
+        match_id=2000,
+        team_id=600001,
+        scraped_at=kickoff - timedelta(days=2),
+        players=(_player(1, jersey=7, position="Halfback", is_on_field=True),),
+    )
+    team_list_repo.record_snapshot(earlier)
+
+    fresh = _make_payload(
+        home_team_id=600001,
+        away_team_id=600002,
+        home_players=[_player_payload(1, position="Halfback", is_on_field=True, jersey=7)],
+        away_players=[],
+    )
+
+    now = kickoff - timedelta(minutes=30)
+    written = watch_match(
+        match=match,
+        fetch_match=lambda _m: fresh,
+        team_list_repo=team_list_repo,
+        late_repo=late_repo,
+        now=now,
+        cutoff_minutes_before_kickoff=60,
+    )
+    assert written == []
+    # The fresh snapshot should have been recorded for both teams.
+    home = team_list_repo.list_snapshots(match_id=2000, team_id=600001)
+    away = team_list_repo.list_snapshots(match_id=2000, team_id=600002)
+    assert any(s.scraped_at == now for s in home)
+    assert any(s.scraped_at == now for s in away)
+
+
+def test_watch_match_skips_when_fetcher_returns_none(
+    sqlite_conn: sqlite3.Connection,
+) -> None:
+    team_list_repo = SQLiteTeamListRepository(sqlite_conn)
+    late_repo = SQLiteLateTeamChangeRepository(sqlite_conn)
+
+    match = _StubMatchRow(
+        match_id=3000,
+        season=2026,
+        round=8,
+        start_time=datetime(2026, 4, 25, 10, 0, tzinfo=UTC),
+        home=_StubTeam(team_id=700001),
+        away=_StubTeam(team_id=700002),
+    )
+
+    written = watch_match(
+        match=match,
+        fetch_match=lambda _m: None,  # cache hit / 304 / 404
+        team_list_repo=team_list_repo,
+        late_repo=late_repo,
+        now=datetime(2026, 4, 25, 9, 30, tzinfo=UTC),
+    )
+    assert written == []
+    # Nothing should have been recorded on either side.
+    assert team_list_repo.list_snapshots(match_id=3000) == []
+
+
+def test_watch_match_no_reference_writes_snapshot_only(
+    sqlite_conn: sqlite3.Connection,
+) -> None:
+    """When there's no pre-window snapshot we still record the fresh one
+    but emit no LateTeamChange rows — there's nothing to diff against."""
+    team_list_repo = SQLiteTeamListRepository(sqlite_conn)
+    late_repo = SQLiteLateTeamChangeRepository(sqlite_conn)
+
+    kickoff = datetime(2026, 4, 25, 10, 0, tzinfo=UTC)
+    match = _StubMatchRow(
+        match_id=4000,
+        season=2026,
+        round=8,
+        start_time=kickoff,
+        home=_StubTeam(team_id=800001),
+        away=_StubTeam(team_id=800002),
+    )
+
+    fresh = _make_payload(
+        home_team_id=800001,
+        away_team_id=800002,
+        home_players=[_player_payload(1, position="Halfback", is_on_field=True, jersey=7)],
+        away_players=[_player_payload(2, position="Halfback", is_on_field=True, jersey=7)],
+    )
+    written: list[LateTeamChange] = watch_match(
+        match=match,
+        fetch_match=lambda _m: fresh,
+        team_list_repo=team_list_repo,
+        late_repo=late_repo,
+        now=kickoff - timedelta(minutes=30),
+    )
+    assert written == []
+    assert team_list_repo.list_snapshots(match_id=4000) != []
+    assert late_repo.list_changes(match_id=4000) == []


### PR DESCRIPTION
Second PR in the **#208 stack** (structured injury & late-withdrawal intelligence). Builds the **kickoff-hour watcher** — the part of the issue that captures the line-moving signal the Tue/Thu precompute Job systematically misses.

## Stack

- [#249 — PR A](https://github.com/lopeztech/fantasy-coach/pull/249) — schema v8 + injury repos. ✅ merged.
- **PR B (this one)** — late team-list watcher + ``watch-team-lists`` CLI. Writes to ``late_team_changes`` from PR A.
- **PR C** — NRL.com injury list scraper (likely Gemini-backed prose parser) + Wayback historical backfill.
- **PR D** — three injury features hit ``FEATURE_NAMES``, retrain XGBoost, re-pin baseline metrics.

> **Pivoted ahead of the NRL.com scraper:** PR B was originally going to be the prose parser. I swapped because (a) the watcher reuses existing scraper infra (no new prose-parsing complexity), and (b) historical backfill of late-change data is impossible without prospective signal — every day this isn't running is data we can't recover. NRL.com prose parsing slots in as PR C.

## Summary

- ``src/fantasy_coach/late_change_watcher.py``
  - ``compute_late_changes(earlier, later)`` — diffs two snapshots into flat ``LateTeamChange`` rows. **Skips players whose ``is_on_field`` is None in either snapshot** so we don't emit false-positive "added" rows on the first scrape after a team-list drop.
  - ``select_reference_snapshot`` — picks the latest snapshot at least ``cutoff_minutes`` before kickoff, so intra-window watcher runs diff against the *named team list*, not against another 30-min-old version of themselves.
  - ``find_matches_in_window`` — filters upcoming matches by kickoff lead time.
  - ``watch_match`` — end-to-end: fetch fresh payload, snapshot, diff, write. ``fetch_match`` is injected so the CLI plugs in ``fetch_match_from_url`` and tests use a stub.
- ``src/fantasy_coach/__main__.py`` — new ``watch-team-lists`` subcommand with ``--season`` / ``--round`` / ``--lead-minutes`` / ``--cutoff-minutes``. Uses the existing ``STORAGE_BACKEND`` switch so SQLite dev shares the matches connection and the Cloud Run Job writes to Firestore. Designed to run on a **third Cloud Run schedule** (every 15 min on match days) — infra wiring is a paired ``platform-infra`` PR I'll open after this merges.

## Test plan

- [x] ``uv run pytest tests/test_late_change_watcher.py`` — 13 passed (diff math: identical / swap / position-change / None-filter / mismatched-key; reference selection: latest pre-cutoff / all-inside-window / empty; window filtering; ``watch_match`` end-to-end against real SQLite repos with a fake fetcher).
- [x] ``uv run pytest`` — full suite **840 passed**, 1 skipped (pymc) — up from 827 on PR A.
- [x] ``make ci`` — ``ruff format --check`` + ``ruff check`` green.

## What this PR doesn't do

- **No feature engineering.** ``late_withdrawal_diff`` lands in PR D.
- **No retroactive signal.** Historical training data has no intra-kickoff-hour snapshots, so we can't backfill ``LateTeamChange`` from existing ``team_list_snapshots``. The watcher is a prospective signal — it kicks in on the next match-day schedule.
- **No infra change.** The Cloud Run Schedule for the watcher lands in ``platform-infra`` as a paired PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)