### PR TITLE
feat(#208 PR C): NRL.com injury-list scraper (Gemini-backed)

### DIFF
--- a/src/fantasy_coach/__main__.py
+++ b/src/fantasy_coach/__main__.py
@@ -427,6 +427,45 @@ def main(argv: list[str] | None = None) -> int:
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
     )
 
+    si = sub.add_parser(
+        "scrape-injuries",
+        help=(
+            "Fetch + parse an NRL.com injury-list article into structured "
+            "InjuryReport rows (#208). Uses Gemini (commentary client) to "
+            "extract names + statuses from the prose. The CLI takes a single "
+            "URL per run; auto-discovery + Wayback historical backfill are "
+            "follow-up issues."
+        ),
+    )
+    si.add_argument("--url", required=True, help="NRL.com injury-list article URL.")
+    si.add_argument("--season", type=int, required=True)
+    si.add_argument("--round", type=int, required=True)
+    si.add_argument(
+        "--match-season",
+        type=int,
+        default=None,
+        help=(
+            "Season(s) to read for the player-name → player_id index. "
+            "Defaults to --season; pass an earlier season when scraping a "
+            "round whose own match data hasn't been fetched yet."
+        ),
+    )
+    si.add_argument(
+        "--gemini-project",
+        default=None,
+        help="GCP project for the Gemini client. Defaults to FIREBASE_PROJECT_ID.",
+    )
+    si.add_argument(
+        "--source-label",
+        default="nrl.com",
+        help="Source label written to injury_reports.source.",
+    )
+    si.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+    )
+
     wtl = sub.add_parser(
         "watch-team-lists",
         help=(
@@ -502,6 +541,8 @@ def main(argv: list[str] | None = None) -> int:
         return _run_clear_commentary_cache(args)
     if args.command == "watch-team-lists":
         return _run_watch_team_lists(args)
+    if args.command == "scrape-injuries":
+        return _run_scrape_injuries(args)
     parser.error(f"unknown command {args.command!r}")
     return 2  # unreachable
 
@@ -1343,6 +1384,73 @@ def _run_notify_round_published(args: argparse.Namespace) -> int:
     from fantasy_coach.notifications import send_round_published  # noqa: PLC0415
 
     send_round_published(season=args.season, round_id=args.round_id)
+    return 0
+
+
+def _run_scrape_injuries(args: argparse.Namespace) -> int:
+    """Scrape an NRL.com injury-list article into structured rows (#208 PR C)."""
+    import os  # noqa: PLC0415
+
+    from fantasy_coach.commentary.client import GeminiClient  # noqa: PLC0415
+    from fantasy_coach.config import get_repository  # noqa: PLC0415
+    from fantasy_coach.injury_scraper import (  # noqa: PLC0415
+        GeminiInjuryListParser,
+        HttpInjuryListSource,
+        build_player_index,
+        scrape_injury_list,
+    )
+    from fantasy_coach.storage.injury import (  # noqa: PLC0415
+        FirestoreInjuryReportRepository,
+        SQLiteInjuryReportRepository,
+    )
+
+    project = (
+        args.gemini_project or os.getenv("FIREBASE_PROJECT_ID") or os.getenv("GOOGLE_CLOUD_PROJECT")
+    )
+    if not project:
+        print("scrape-injuries: --gemini-project or FIREBASE_PROJECT_ID is required.")
+        return 1
+
+    repo = get_repository()
+    backend = os.getenv("STORAGE_BACKEND", "sqlite").lower()
+    if backend == "firestore":
+        injury_repo: Any = FirestoreInjuryReportRepository()
+    else:
+        conn = getattr(repo, "_conn", None)
+        if conn is None:
+            print("scrape-injuries: SQLite repo has no `_conn`; aborting.")
+            return 1
+        injury_repo = SQLiteInjuryReportRepository(conn)
+
+    match_season = args.match_season or args.season
+    matches = repo.list_matches(match_season)
+    if not matches:
+        print(
+            f"scrape-injuries: no matches in season {match_season}; "
+            "player-name index will be empty so every report will be skipped. "
+            "Backfill the season or pass --match-season."
+        )
+    player_index = build_player_index(list(matches))
+
+    parser = GeminiInjuryListParser(
+        client=GeminiClient(project=project),
+        source_label=args.source_label,
+    )
+    reports = scrape_injury_list(
+        url=args.url,
+        season=args.season,
+        round=args.round,
+        source=HttpInjuryListSource(),
+        parser=parser,
+        player_index=player_index,
+    )
+    for report in reports:
+        injury_repo.record_report(report)
+
+    print(
+        f"scrape-injuries: parsed {len(reports)} reports for "
+        f"season={args.season} round={args.round} (source={args.source_label})."
+    )
     return 0
 
 

--- a/src/fantasy_coach/injury_scraper.py
+++ b/src/fantasy_coach/injury_scraper.py
@@ -1,0 +1,422 @@
+"""NRL.com injury-list scraper (#208 PR C).
+
+NRL.com publishes a weekly injury list as a news article in unstructured
+prose — there's no JSON endpoint to scrape. We solve this with a Gemini
+call that takes the raw page text + a strict JSON schema and returns a
+list of ``InjuryReport``-shaped dicts. The parser is split from the
+fetcher so tests can exercise the parsing path with a fake Gemini
+response and the live source-of-truth lives in one place.
+
+Player-name resolution: the parser returns names; we map them to
+``player_id`` + ``team_id`` via ``build_player_index`` over the matches
+store. Names that don't resolve are logged + dropped — better to silently
+skip than to invent IDs.
+
+Historical backfill (Wayback Machine for 2024+2025) is a follow-up
+issue; the MVP supports a single URL per invocation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+import httpx
+
+from fantasy_coach.injury import InjuryReport, InjuryStatus
+from fantasy_coach.scraper import DEFAULT_TIMEOUT, USER_AGENT
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Source Protocol — abstracts "where do we get the page text from"
+# ---------------------------------------------------------------------------
+
+
+class InjuryListSource(Protocol):
+    def fetch(self, url: str) -> str: ...
+
+
+@dataclass
+class HttpInjuryListSource:
+    """Fetches the URL via httpx + strips HTML to plain text.
+
+    Raises ``httpx.HTTPError`` on failure — callers decide whether to
+    retry or skip. Throttle is not enforced here because injury-list
+    scraping is one-call-per-week, far below the hot-path scraper's
+    politeness window.
+    """
+
+    timeout: float = DEFAULT_TIMEOUT
+    user_agent: str = USER_AGENT
+
+    def fetch(self, url: str) -> str:
+        with httpx.Client(timeout=self.timeout, follow_redirects=True) as client:
+            resp = client.get(url, headers={"User-Agent": self.user_agent})
+            resp.raise_for_status()
+            return strip_html_to_text(resp.text)
+
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"[ \t]+")
+_BLANK_LINE_RE = re.compile(r"\n\s*\n")
+
+
+def strip_html_to_text(html: str) -> str:
+    """Quick-and-dirty HTML → plain text, no BeautifulSoup dependency.
+
+    Drops <script>/<style> blocks, strips remaining tags, decodes the
+    handful of common entities, and collapses whitespace. Good enough
+    for feeding into Gemini, which is robust to messy input.
+    """
+    cleaned = re.sub(r"<(script|style)[^>]*>.*?</\1>", " ", html, flags=re.DOTALL | re.IGNORECASE)
+    cleaned = _TAG_RE.sub(" ", cleaned)
+    cleaned = (
+        cleaned.replace("&amp;", "&")
+        .replace("&nbsp;", " ")
+        .replace("&#39;", "'")
+        .replace("&quot;", '"')
+        .replace("&ndash;", "-")
+        .replace("&mdash;", "-")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+    )
+    cleaned = _WHITESPACE_RE.sub(" ", cleaned)
+    cleaned = _BLANK_LINE_RE.sub("\n\n", cleaned)
+    return cleaned.strip()
+
+
+# ---------------------------------------------------------------------------
+# Parser Protocol — abstracts "how do we structure the prose"
+# ---------------------------------------------------------------------------
+
+
+class InjuryListParser(Protocol):
+    def parse(
+        self,
+        *,
+        text: str,
+        season: int,
+        round: int,
+        scraped_at: datetime,
+        player_index: PlayerIndex,
+    ) -> list[InjuryReport]: ...
+
+
+# Status synonyms the LLM might emit — normalised back to InjuryStatus.
+_STATUS_ALIASES: dict[str, InjuryStatus] = {
+    "out": InjuryStatus.OUT,
+    "ruled out": InjuryStatus.OUT,
+    "unavailable": InjuryStatus.OUT,
+    "test": InjuryStatus.TEST,
+    "fitness test": InjuryStatus.TEST,
+    "doubtful": InjuryStatus.TEST,
+    "21_man_squad": InjuryStatus.SQUAD_21,
+    "21-man squad": InjuryStatus.SQUAD_21,
+    "21 man squad": InjuryStatus.SQUAD_21,
+    "extended squad": InjuryStatus.SQUAD_21,
+    "returning": InjuryStatus.RETURNING,
+    "return": InjuryStatus.RETURNING,
+    "first match back": InjuryStatus.RETURNING,
+    "suspended": InjuryStatus.SUSPENDED,
+    "suspension": InjuryStatus.SUSPENDED,
+}
+
+
+GEMINI_SYSTEM_PROMPT = """\
+You are an information extractor for an NRL injury-list news article.
+Return JSON ONLY (no prose, no markdown fences). The JSON must be a
+single object of shape:
+
+{
+  "reports": [
+    {
+      "first_name": "string",
+      "last_name": "string",
+      "team_name": "string (NRL club nickname or full name)",
+      "status": "out | test | 21_man_squad | returning | suspended",
+      "weeks_out": number | null,
+      "body_part": "string | null"
+    },
+    ...
+  ]
+}
+
+Map every player named in the article to one entry. If the article
+mentions a body part ("hamstring") put it in body_part. If it estimates
+a return window ("expected back in 2 weeks") put weeks_out=2; otherwise
+null. Use the closest matching status from the enum. Do NOT invent
+players who aren't in the article.
+"""
+
+
+@dataclass
+class GeminiInjuryListParser:
+    """Gemini-backed parser — single LLM call extracts structured rows.
+
+    `client` is anything with a ``generate(prompt, *, system, max_output_tokens) -> obj.text``
+    interface. The real ``GeminiClient`` from ``commentary/client.py`` fits.
+    """
+
+    client: Any
+    source_label: str = "nrl.com"
+    max_output_tokens: int = 4096
+
+    def parse(
+        self,
+        *,
+        text: str,
+        season: int,
+        round: int,
+        scraped_at: datetime,
+        player_index: PlayerIndex,
+    ) -> list[InjuryReport]:
+        prompt = f"Round: {round}\nSeason: {season}\n\nArticle text:\n{text}"
+        response = self.client.generate(
+            prompt,
+            system=GEMINI_SYSTEM_PROMPT,
+            max_output_tokens=self.max_output_tokens,
+        )
+        raw_rows = _parse_gemini_json(response.text)
+        return _materialise_reports(
+            raw_rows,
+            season=season,
+            round=round,
+            scraped_at=scraped_at,
+            player_index=player_index,
+            source=self.source_label,
+        )
+
+
+def _parse_gemini_json(text: str) -> list[dict[str, Any]]:
+    """Extract a JSON object from the LLM's text response.
+
+    Tolerates the common failure modes: leading/trailing prose, ```json
+    fences, single-line preamble. Returns the ``reports`` array, or
+    [] if the structure is unrecognisable.
+    """
+    fence_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    candidate = fence_match.group(1) if fence_match else None
+    if candidate is None:
+        # Find the outermost {...} block.
+        start = text.find("{")
+        end = text.rfind("}")
+        if start == -1 or end == -1 or end <= start:
+            logger.warning("injury_parser: no JSON object found in Gemini response")
+            return []
+        candidate = text[start : end + 1]
+    try:
+        data = json.loads(candidate)
+    except json.JSONDecodeError as exc:
+        logger.warning("injury_parser: JSON decode failed: %s", exc)
+        return []
+    if not isinstance(data, dict):
+        return []
+    rows = data.get("reports") or []
+    return [r for r in rows if isinstance(r, dict)]
+
+
+# ---------------------------------------------------------------------------
+# Player-name resolution — names → (player_id, team_id)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PlayerIndex:
+    """Resolves (first_name, last_name) and team_name → (player_id, team_id).
+
+    Built once per scrape from the matches store. Names are normalised
+    by lowercasing + stripping punctuation so "Reece Walsh" matches
+    "reece walsh" and "O'Sullivan" matches "OSullivan".
+    """
+
+    by_full_name: dict[tuple[str, str], tuple[int, int]]
+    team_id_by_name: dict[str, int]
+
+    def resolve(
+        self, *, first_name: str, last_name: str, team_name: str | None
+    ) -> tuple[int, int] | None:
+        key = (_norm_name(first_name), _norm_name(last_name))
+        if key in self.by_full_name:
+            return self.by_full_name[key]
+        # Last-name-only fallback when first-name spelling differs
+        # (e.g. "Sam" vs "Samuel"). Only safe when the team is given —
+        # otherwise we'd collide on common surnames.
+        if team_name:
+            team_id = self.team_id_by_name.get(_norm_name(team_name))
+            if team_id is None:
+                return None
+            candidates = [
+                (pid, tid)
+                for (_, ln), (pid, tid) in self.by_full_name.items()
+                if ln == _norm_name(last_name) and tid == team_id
+            ]
+            if len(candidates) == 1:
+                return candidates[0]
+        return None
+
+
+_NAME_RE = re.compile(r"[^\w\s]")
+
+
+def _norm_name(s: str) -> str:
+    return _NAME_RE.sub("", s.casefold()).strip()
+
+
+def build_player_index(matches: list[Any]) -> PlayerIndex:
+    """Build a name → (player_id, team_id) lookup over a list of MatchRow.
+
+    Players appearing in multiple matches keep their *most recent*
+    team_id so trade-window moves resolve to the new club. Caller is
+    responsible for selecting the right slice of matches (e.g. last
+    season + this season).
+    """
+    by_full_name: dict[tuple[str, str], tuple[int, int]] = {}
+    team_id_by_name: dict[str, int] = {}
+    for match in sorted(matches, key=lambda m: m.start_time):
+        for side_name in ("home", "away"):
+            team = getattr(match, side_name)
+            team_id = team.team_id
+            for nick_or_name in (
+                getattr(team, "nick_name", None),
+                getattr(team, "name", None),
+            ):
+                if nick_or_name:
+                    team_id_by_name[_norm_name(nick_or_name)] = team_id
+            for player in team.players:
+                first = player.first_name or ""
+                last = player.last_name or ""
+                if not first or not last:
+                    continue
+                by_full_name[(_norm_name(first), _norm_name(last))] = (
+                    player.player_id,
+                    team_id,
+                )
+    return PlayerIndex(by_full_name=by_full_name, team_id_by_name=team_id_by_name)
+
+
+# ---------------------------------------------------------------------------
+# Materialisation — Gemini rows → InjuryReport[]
+# ---------------------------------------------------------------------------
+
+
+def _materialise_reports(
+    rows: list[dict[str, Any]],
+    *,
+    season: int,
+    round: int,
+    scraped_at: datetime,
+    player_index: PlayerIndex,
+    source: str,
+) -> list[InjuryReport]:
+    out: list[InjuryReport] = []
+    skipped = 0
+    for row in rows:
+        first = str(row.get("first_name") or "").strip()
+        last = str(row.get("last_name") or "").strip()
+        team_name = row.get("team_name")
+        if not first or not last:
+            skipped += 1
+            continue
+        resolved = player_index.resolve(
+            first_name=first,
+            last_name=last,
+            team_name=str(team_name) if team_name else None,
+        )
+        if resolved is None:
+            logger.info(
+                "injury_parser: could not resolve player_id for %s %s (team=%r); skipping",
+                first,
+                last,
+                team_name,
+            )
+            skipped += 1
+            continue
+        player_id, team_id = resolved
+
+        status_raw = str(row.get("status") or "").strip().lower()
+        status = _STATUS_ALIASES.get(status_raw)
+        if status is None:
+            try:
+                status = InjuryStatus(status_raw)
+            except ValueError:
+                logger.info("injury_parser: unknown status %r for %s %s", status_raw, first, last)
+                skipped += 1
+                continue
+
+        weeks_out = _coerce_int(row.get("weeks_out"))
+        body_part = row.get("body_part")
+        body_part = str(body_part).strip() if body_part else None
+
+        out.append(
+            InjuryReport(
+                player_id=player_id,
+                season=season,
+                round=round,
+                team_id=team_id,
+                status=status,
+                weeks_out=weeks_out,
+                body_part=body_part,
+                source=source,
+                scraped_at=scraped_at,
+            )
+        )
+    if skipped:
+        logger.info("injury_parser: skipped %d rows (unresolved or invalid)", skipped)
+    return out
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value >= 0 else None
+    if isinstance(value, float):
+        return int(value) if value >= 0 else None
+    try:
+        parsed = int(str(value).strip())
+        return parsed if parsed >= 0 else None
+    except (ValueError, TypeError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# High-level orchestrator
+# ---------------------------------------------------------------------------
+
+
+def scrape_injury_list(
+    *,
+    url: str,
+    season: int,
+    round: int,
+    source: InjuryListSource,
+    parser: InjuryListParser,
+    player_index: PlayerIndex,
+    now: datetime | None = None,
+) -> list[InjuryReport]:
+    """Fetch + parse an NRL.com injury list page into structured rows.
+
+    Returns the parsed reports. Doesn't write anywhere — caller hands
+    them to ``InjuryReportRepository.record_report`` so storage is
+    decoupled from scraping.
+    """
+    text = source.fetch(url)
+    if not text:
+        logger.warning("injury_scraper: empty body from %s", url)
+        return []
+    scraped_at = now or datetime.now(UTC)
+    return parser.parse(
+        text=text,
+        season=season,
+        round=round,
+        scraped_at=scraped_at,
+        player_index=player_index,
+    )

--- a/tests/test_injury_scraper.py
+++ b/tests/test_injury_scraper.py
@@ -1,0 +1,412 @@
+"""Tests for the injury-list scraper (#208 PR C)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from fantasy_coach.features import PlayerRow, TeamRow
+from fantasy_coach.injury import InjuryStatus
+from fantasy_coach.injury_scraper import (
+    GEMINI_SYSTEM_PROMPT,
+    GeminiInjuryListParser,
+    PlayerIndex,
+    _materialise_reports,
+    _parse_gemini_json,
+    build_player_index,
+    scrape_injury_list,
+    strip_html_to_text,
+)
+
+# ---------------------------------------------------------------------------
+# strip_html_to_text
+# ---------------------------------------------------------------------------
+
+
+def test_strip_html_drops_tags_scripts_and_entities() -> None:
+    html = (
+        "<html><head><style>body{}</style></head>"
+        "<body>"
+        "<script>alert('x')</script>"
+        "<h1>Round 8 injury list</h1>"
+        "<p>Reece Walsh &mdash; <strong>OUT</strong> &nbsp;(shoulder)</p>"
+        "</body></html>"
+    )
+    text = strip_html_to_text(html)
+    # Tag noise gone, text preserved.
+    assert "Round 8 injury list" in text
+    assert "Reece Walsh - OUT (shoulder)" in text
+    assert "<" not in text
+    assert "alert" not in text  # script body dropped
+    assert "&nbsp;" not in text  # entities decoded
+
+
+def test_strip_html_collapses_whitespace() -> None:
+    html = "<p>hello   world</p>\n\n\n<p>line two</p>"
+    text = strip_html_to_text(html)
+    # Single spaces inside lines, single blank line between blocks.
+    assert "hello world" in text
+    assert "\n\n\n" not in text
+
+
+# ---------------------------------------------------------------------------
+# _parse_gemini_json
+# ---------------------------------------------------------------------------
+
+
+def test_parse_gemini_json_with_fence() -> None:
+    raw = (
+        "Here is the JSON you asked for:\n"
+        "```json\n"
+        '{"reports": [{"first_name": "Reece", "last_name": "Walsh", '
+        '"team_name": "Broncos", "status": "out", "weeks_out": 2, '
+        '"body_part": "shoulder"}]}\n'
+        "```\n"
+    )
+    rows = _parse_gemini_json(raw)
+    assert len(rows) == 1
+    assert rows[0]["first_name"] == "Reece"
+
+
+def test_parse_gemini_json_without_fence() -> None:
+    raw = (
+        'Output:\n{"reports": [{"first_name": "James", "last_name": "Tedesco", '
+        '"team_name": "Roosters", "status": "test", "weeks_out": null, "body_part": "knee"}]}'
+    )
+    rows = _parse_gemini_json(raw)
+    assert len(rows) == 1
+    assert rows[0]["status"] == "test"
+
+
+def test_parse_gemini_json_invalid_returns_empty() -> None:
+    assert _parse_gemini_json("Sorry, I can't help.") == []
+    assert _parse_gemini_json("{not really json}") == []
+
+
+def test_parse_gemini_json_filters_non_dict_rows() -> None:
+    raw = '{"reports": [{"first_name": "A", "last_name": "B"}, "garbage", null]}'
+    rows = _parse_gemini_json(raw)
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# PlayerIndex
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _StubMatch:
+    """Minimal MatchRow stand-in for build_player_index tests."""
+
+    match_id: int
+    start_time: datetime
+    home: TeamRow
+    away: TeamRow
+
+
+def _player(player_id: int, first: str, last: str) -> PlayerRow:
+    return PlayerRow(
+        player_id=player_id,
+        jersey_number=1,
+        position="Halfback",
+        first_name=first,
+        last_name=last,
+        is_on_field=True,
+    )
+
+
+def _team(*, team_id: int, name: str, nick: str, players: list[PlayerRow]) -> TeamRow:
+    return TeamRow(team_id=team_id, name=name, nick_name=nick, score=None, players=players)
+
+
+def test_player_index_resolves_full_name() -> None:
+    match = _StubMatch(
+        match_id=1,
+        start_time=datetime(2026, 4, 25, 9, 0, tzinfo=UTC),
+        home=_team(
+            team_id=500001,
+            name="Brisbane Broncos",
+            nick="Broncos",
+            players=[_player(1001, "Reece", "Walsh")],
+        ),
+        away=_team(
+            team_id=500002,
+            name="Sydney Roosters",
+            nick="Roosters",
+            players=[_player(2001, "James", "Tedesco")],
+        ),
+    )
+    idx = build_player_index([match])
+    assert idx.resolve(first_name="Reece", last_name="Walsh", team_name=None) == (
+        1001,
+        500001,
+    )
+    # Case + punctuation insensitive.
+    assert idx.resolve(first_name="REECE", last_name="walsh", team_name=None) == (
+        1001,
+        500001,
+    )
+
+
+def test_player_index_last_name_fallback_when_team_known() -> None:
+    match = _StubMatch(
+        match_id=1,
+        start_time=datetime(2026, 4, 25, 9, 0, tzinfo=UTC),
+        home=_team(
+            team_id=500001,
+            name="Brisbane Broncos",
+            nick="Broncos",
+            players=[_player(1001, "Samuel", "Walker")],
+        ),
+        away=_team(
+            team_id=500002,
+            name="Sydney Roosters",
+            nick="Roosters",
+            players=[_player(2001, "Spencer", "Leniu")],
+        ),
+    )
+    idx = build_player_index([match])
+    # Article says "Sam Walker" — first name nickname differs but last+team match.
+    resolved = idx.resolve(first_name="Sam", last_name="Walker", team_name="Broncos")
+    assert resolved == (1001, 500001)
+
+
+def test_player_index_returns_none_when_unknown() -> None:
+    match = _StubMatch(
+        match_id=1,
+        start_time=datetime(2026, 4, 25, 9, 0, tzinfo=UTC),
+        home=_team(team_id=1, name="A", nick="A", players=[_player(1, "Reece", "Walsh")]),
+        away=_team(team_id=2, name="B", nick="B", players=[_player(2, "James", "Tedesco")]),
+    )
+    idx = build_player_index([match])
+    assert idx.resolve(first_name="Made", last_name="Up", team_name=None) is None
+
+
+def test_player_index_uses_most_recent_team_id() -> None:
+    """A player who appears for multiple teams resolves to the latest."""
+    earlier = _StubMatch(
+        match_id=1,
+        start_time=datetime(2025, 8, 1, 9, 0, tzinfo=UTC),
+        home=_team(team_id=500001, name="Old", nick="Old", players=[_player(1, "X", "Y")]),
+        away=_team(team_id=999, name="z", nick="z", players=[]),
+    )
+    later = _StubMatch(
+        match_id=2,
+        start_time=datetime(2026, 3, 1, 9, 0, tzinfo=UTC),
+        home=_team(team_id=500002, name="New", nick="New", players=[_player(1, "X", "Y")]),
+        away=_team(team_id=999, name="z", nick="z", players=[]),
+    )
+    idx = build_player_index([earlier, later])
+    assert idx.resolve(first_name="X", last_name="Y", team_name=None) == (1, 500002)
+
+
+# ---------------------------------------------------------------------------
+# _materialise_reports
+# ---------------------------------------------------------------------------
+
+
+def _index_for(player_id: int = 1001, team_id: int = 500001) -> PlayerIndex:
+    return PlayerIndex(
+        by_full_name={("reece", "walsh"): (player_id, team_id)},
+        team_id_by_name={"broncos": team_id},
+    )
+
+
+def test_materialise_normalises_status_alias() -> None:
+    rows = [
+        {
+            "first_name": "Reece",
+            "last_name": "Walsh",
+            "team_name": "Broncos",
+            "status": "ruled out",  # alias for OUT
+            "weeks_out": 2,
+            "body_part": "shoulder",
+        }
+    ]
+    out = _materialise_reports(
+        rows,
+        season=2026,
+        round=8,
+        scraped_at=datetime(2026, 4, 21, 9, 0, tzinfo=UTC),
+        player_index=_index_for(),
+        source="nrl.com",
+    )
+    assert len(out) == 1
+    assert out[0].status == InjuryStatus.OUT
+    assert out[0].player_id == 1001
+    assert out[0].team_id == 500001
+    assert out[0].weeks_out == 2
+
+
+def test_materialise_skips_unresolved_player() -> None:
+    rows = [{"first_name": "No", "last_name": "Body", "status": "out"}]
+    out = _materialise_reports(
+        rows,
+        season=2026,
+        round=8,
+        scraped_at=datetime(2026, 4, 21, 9, 0, tzinfo=UTC),
+        player_index=_index_for(),
+        source="nrl.com",
+    )
+    assert out == []
+
+
+def test_materialise_skips_unknown_status() -> None:
+    rows = [
+        {"first_name": "Reece", "last_name": "Walsh", "status": "blue-flu"},
+    ]
+    out = _materialise_reports(
+        rows,
+        season=2026,
+        round=8,
+        scraped_at=datetime(2026, 4, 21, 9, 0, tzinfo=UTC),
+        player_index=_index_for(),
+        source="nrl.com",
+    )
+    assert out == []
+
+
+def test_materialise_handles_null_weeks_out_and_body_part() -> None:
+    rows = [
+        {
+            "first_name": "Reece",
+            "last_name": "Walsh",
+            "team_name": "Broncos",
+            "status": "test",
+            "weeks_out": None,
+            "body_part": None,
+        }
+    ]
+    out = _materialise_reports(
+        rows,
+        season=2026,
+        round=8,
+        scraped_at=datetime(2026, 4, 21, 9, 0, tzinfo=UTC),
+        player_index=_index_for(),
+        source="nrl.com",
+    )
+    assert len(out) == 1
+    assert out[0].weeks_out is None
+    assert out[0].body_part is None
+
+
+def test_materialise_drops_negative_weeks_out() -> None:
+    rows = [
+        {
+            "first_name": "Reece",
+            "last_name": "Walsh",
+            "team_name": "Broncos",
+            "status": "out",
+            "weeks_out": -3,
+        }
+    ]
+    out = _materialise_reports(
+        rows,
+        season=2026,
+        round=8,
+        scraped_at=datetime(2026, 4, 21, 9, 0, tzinfo=UTC),
+        player_index=_index_for(),
+        source="nrl.com",
+    )
+    assert len(out) == 1
+    # Negative weeks_out gets coerced to None rather than blowing up the dataclass invariant.
+    assert out[0].weeks_out is None
+
+
+# ---------------------------------------------------------------------------
+# scrape_injury_list — end-to-end with stubs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubSource:
+    text: str
+    fetched_urls: list[str] = field(default_factory=list)
+
+    def fetch(self, url: str) -> str:
+        self.fetched_urls.append(url)
+        return self.text
+
+
+@dataclass
+class _StubGeminiResponse:
+    text: str
+
+
+@dataclass
+class _StubGemini:
+    text: str
+    captured: dict = field(default_factory=dict)
+
+    def generate(self, prompt: str, *, system: str, max_output_tokens: int):
+        self.captured = {"prompt": prompt, "system": system, "max": max_output_tokens}
+        return _StubGeminiResponse(text=self.text)
+
+
+def test_scrape_injury_list_end_to_end() -> None:
+    article = "Round 8 injuries — Reece Walsh: OUT, shoulder, 2 weeks."
+    gemini_json = (
+        '{"reports": [{"first_name": "Reece", "last_name": "Walsh", '
+        '"team_name": "Broncos", "status": "out", "weeks_out": 2, '
+        '"body_part": "shoulder"}]}'
+    )
+    source = _StubSource(text=article)
+    gemini = _StubGemini(text=gemini_json)
+    parser = GeminiInjuryListParser(client=gemini)
+    idx = _index_for()
+
+    reports = scrape_injury_list(
+        url="https://www.nrl.com/news/2026/04/21/round-8-injury-list/",
+        season=2026,
+        round=8,
+        source=source,
+        parser=parser,
+        player_index=idx,
+        now=datetime(2026, 4, 21, 9, 0, tzinfo=UTC),
+    )
+
+    assert len(reports) == 1
+    assert reports[0].player_id == 1001
+    assert reports[0].status == InjuryStatus.OUT
+    # The fetcher was called with the URL we passed, and the system
+    # prompt was the strict-schema one.
+    assert source.fetched_urls == ["https://www.nrl.com/news/2026/04/21/round-8-injury-list/"]
+    assert gemini.captured["system"] == GEMINI_SYSTEM_PROMPT
+    assert "Round 8 injuries" in gemini.captured["prompt"]
+
+
+def test_scrape_injury_list_returns_empty_on_blank_body() -> None:
+    source = _StubSource(text="")
+    gemini = _StubGemini(text='{"reports":[]}')
+    parser = GeminiInjuryListParser(client=gemini)
+    idx = _index_for()
+
+    reports = scrape_injury_list(
+        url="https://example.com",
+        season=2026,
+        round=8,
+        source=source,
+        parser=parser,
+        player_index=idx,
+    )
+    assert reports == []
+    # Gemini wasn't called when the source returned nothing.
+    assert gemini.captured == {}
+
+
+def test_scrape_injury_list_tolerates_gemini_garbage() -> None:
+    """If Gemini drops a non-JSON response we degrade to an empty list,
+    not a crash — the weekly scrape job retries next round."""
+    source = _StubSource(text="Round 8 injuries — Reece Walsh: OUT")
+    gemini = _StubGemini(text="I cannot parse this article today.")
+    parser = GeminiInjuryListParser(client=gemini)
+    idx = _index_for()
+    reports = scrape_injury_list(
+        url="https://example.com",
+        season=2026,
+        round=8,
+        source=source,
+        parser=parser,
+        player_index=idx,
+    )
+    assert reports == []


### PR DESCRIPTION
Third PR in the **#208 stack**. NRL.com publishes the weekly injury list as a news article in unstructured prose — no JSON endpoint to scrape — so we feed the page text plus a strict JSON schema to Gemini and materialise the response into ``InjuryReport`` rows from PR A's storage.

## Stack

- [#249 — PR A](https://github.com/lopeztech/fantasy-coach/pull/249) — schema v8 + injury repos. ✅ merged.
- [#250 — PR B](https://github.com/lopeztech/fantasy-coach/pull/250) — late team-list watcher. ✅ merged.
- **PR C (this one)** — NRL.com injury-list scraper.
- **PR D** — three injury features hit ``FEATURE_NAMES``, retrain XGBoost, re-pin baseline metrics. (Blocked on at least one weekly scrape running so `injury_reports` isn't empty.)

## Summary

- ``src/fantasy_coach/injury_scraper.py``
  - ``InjuryListSource`` Protocol + ``HttpInjuryListSource`` (httpx fetch + HTML→text via a small regex stripper; no BS4 dependency).
  - ``InjuryListParser`` Protocol + ``GeminiInjuryListParser`` (single ``generateContent`` call with ``GEMINI_SYSTEM_PROMPT`` pinning the JSON schema).
  - ``PlayerIndex`` + ``build_player_index`` — name → ``(player_id, team_id)`` lookup over the matches store. Full-name match is case/punctuation-folded; falls back to last-name + team for nickname mismatches ("Sam" vs "Samuel"). Players appearing for multiple teams resolve to their most recent ``team_id``.
  - ``_parse_gemini_json`` tolerates fenced + bare-prose responses, drops non-dict rows, returns ``[]`` on garbage so a bad LLM response degrades gracefully rather than crashing the weekly job.
  - Status alias map normalises "ruled out", "doubtful", "extended squad" etc. back to the ``InjuryStatus`` enum.
  - ``scrape_injury_list`` orchestrator returns rows; storage is the caller's job (decoupled for testability).
- ``src/fantasy_coach/__main__.py`` — new ``scrape-injuries`` subcommand with ``--url`` / ``--season`` / ``--round`` / ``--gemini-project``. Reads matches from the configured store for the player index, fetches via ``HttpInjuryListSource``, parses via ``GeminiInjuryListParser``, writes to the ``STORAGE_BACKEND``-appropriate ``InjuryReportRepository``.

## Test plan

- [x] ``uv run pytest tests/test_injury_scraper.py`` — 18 passed (HTML stripping; JSON extraction fenced / bare / garbage / non-dict rows; player-index resolution full-name / last-name fallback / unknown / most-recent-team; report materialisation alias / unresolved / unknown-status / null fields / negative-weeks-out coerce; end-to-end scrape with stub source + stub Gemini).
- [x] ``uv run pytest`` — full suite **858 passed**, 1 skipped (pymc) — up from 840 on PR B.
- [x] ``make ci`` — ``ruff format --check`` + ``ruff check`` green.

## Out of scope (follow-up issues)

- **Auto-discovery** of NRL.com injury-list URLs from the news index. The MVP CLI takes one URL per run.
- **Wayback Machine historical backfill** for 2024+2025+2026 R1-7. Needed before PR D's features have training signal.
- **Cloud Run schedule** for the weekly run — lands in ``lopeztech/platform-infra``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)