### PR TITLE
feat(#251): per-player rolling form trajectory features

### DIFF
--- a/src/fantasy_coach/feature_engineering.py
+++ b/src/fantasy_coach/feature_engineering.py
@@ -37,7 +37,7 @@ from datetime import datetime
 import numpy as np
 
 from fantasy_coach.bookmaker.lines import devig_two_way
-from fantasy_coach.features import MatchRow, PlayerRow, TeamStat
+from fantasy_coach.features import MatchRow, PlayerMatchStat, PlayerRow, TeamStat
 from fantasy_coach.models.elo import Elo
 from fantasy_coach.models.elo_mov import EloMOV
 from fantasy_coach.models.player_ratings import POSITION_GROUPS, PlayerRatings
@@ -222,6 +222,20 @@ FEATURE_NAMES = (
     "must_win_intensity",
     "dead_rubber_indicator",
     "missing_ladder",
+    # Per-player rolling form trajectory (#251). Captures whether individual
+    # players are trending up or down over their last 3 matches vs their
+    # season baseline — a signal invisible to team-level rolling stats.
+    # Composite per player = tackle_breaks + line_breaks + try_assists
+    #   + 0.05 × tackles_made − 0.5 × errors (signed).
+    # Trajectory = (last-3 avg − season avg), position-weighted, home − away.
+    #
+    # player_form_trajectory_diff: full starting XIII, all positions.
+    # key_player_trajectory_diff: spine only (halves, hooker, fullback).
+    # missing_player_trajectory: 1.0 when ≥ 5 named XIII players on either
+    #   team have fewer than 3 recorded stat composites (early season, debuts).
+    "player_form_trajectory_diff",
+    "key_player_trajectory_diff",
+    "missing_player_trajectory",
 )
 
 # Plain-English rationale in docs/model.md. These are expert-prior weights:
@@ -283,6 +297,11 @@ _TEAM_STATS_WINDOW = 5
 # Ladder-position feature constants (#255).
 LADDER_MIN_ROUND = 5  # emit missing_ladder=1.0 for rounds below this threshold
 NRL_SEASON_ROUNDS = 27  # regular-season rounds in the NRL calendar
+
+# Player form-trajectory constants (#251).
+_PLAYER_TRAJ_WINDOW = 20  # rolling window for season baseline
+_PLAYER_TRAJ_RECENT = 3  # recent window for "current form" snapshot
+_PLAYER_TRAJ_MISSING_N = 5  # ≥ this many XIII players without history → flag
 
 
 @dataclass
@@ -404,6 +423,12 @@ class FeatureBuilder:
         self._team_venue_season_counts: dict[tuple[int, str, int], int] = defaultdict(int)
         # Running competition ladder (#255). Keyed by team_id; reset each season.
         self._ladder: dict[int, _TeamLadder] = {}
+        # Per-player rolling stat composite history (#251). Each entry is the
+        # _player_stat_composite() value for a completed starting appearance.
+        # Walk-forward only — record() writes, feature_row() reads prior state.
+        self._player_stat_history: dict[int, deque[float]] = defaultdict(
+            lambda: deque(maxlen=_PLAYER_TRAJ_WINDOW)
+        )
 
     def feature_row(
         self, match: MatchRow, *, weather_forecast: WeatherForecast | None = None
@@ -502,6 +527,12 @@ class FeatureBuilder:
             match.round, h_id, a_id
         )
 
+        traj_h = self._team_trajectory(match.home.players, spine_only=False)
+        traj_a = self._team_trajectory(match.away.players, spine_only=False)
+        spine_traj_h = self._team_trajectory(match.home.players, spine_only=True)
+        spine_traj_a = self._team_trajectory(match.away.players, spine_only=True)
+        miss_traj = self._missing_trajectory(match.home.players, match.away.players)
+
         return [
             elo_diff,
             form_pf_h - form_pf_a,
@@ -560,6 +591,9 @@ class FeatureBuilder:
             must_win_int,
             dead_rub,
             miss_lad,
+            traj_h - traj_a,
+            spine_traj_h - spine_traj_a,
+            miss_traj,
         ]
 
     def _ladder_features(
@@ -627,6 +661,47 @@ class FeatureBuilder:
             dead_rubber,
             0.0,
         )
+
+    def _team_trajectory(self, players: list[PlayerRow], *, spine_only: bool) -> float:
+        """Position-weighted sum of (last-3 avg − season avg) per starter (#251).
+
+        Returns 0.0 when no starters have sufficient stat history, which is the
+        correct neutral value for early-season matches and debut appearances.
+        """
+        _spine: frozenset[str] = (
+            POSITION_GROUPS["halves"] | POSITION_GROUPS["hooker"] | POSITION_GROUPS["outside_backs"]
+        )
+        total = 0.0
+        for p in players:
+            if not p.is_on_field or p.position is None:
+                continue
+            if spine_only and p.position not in _spine:
+                continue
+            hist = self._player_stat_history.get(p.player_id)
+            if not hist or len(hist) < _PLAYER_TRAJ_RECENT:
+                continue
+            hist_list = list(hist)
+            last3_avg = sum(hist_list[-_PLAYER_TRAJ_RECENT:]) / _PLAYER_TRAJ_RECENT
+            season_avg = sum(hist_list) / len(hist_list)
+            weight = POSITION_WEIGHTS.get(p.position, 1.0)
+            total += (last3_avg - season_avg) * weight
+        return total
+
+    def _missing_trajectory(
+        self, home_players: list[PlayerRow], away_players: list[PlayerRow]
+    ) -> float:
+        """1.0 when ≥ _PLAYER_TRAJ_MISSING_N named XIII players on either team
+        lack sufficient stat history to compute a trajectory."""
+        for players in (home_players, away_players):
+            starters = [p for p in players if p.is_on_field]
+            missing = sum(
+                1
+                for p in starters
+                if len(self._player_stat_history.get(p.player_id) or []) < _PLAYER_TRAJ_RECENT
+            )
+            if missing >= _PLAYER_TRAJ_MISSING_N:
+                return 1.0
+        return 0.0
 
     def _team_venue_hga_estimate(self, team_id: int, vkey: str) -> float:
         """Rolling win-over-expected for (home team, venue); regressed toward 0."""
@@ -927,6 +1002,17 @@ class FeatureBuilder:
         else:  # draw
             self._ladder[h_id].pts += 1
             self._ladder[a_id].pts += 1
+        # Update per-player stat composite history (#251).
+        for side_stats, side_players in (
+            (match.home_player_stats, match.home.players),
+            (match.away_player_stats, match.away.players),
+        ):
+            stats_by_id = {s.player_id: s for s in side_stats}
+            for p in side_players:
+                if p.is_on_field and p.player_id in stats_by_id:
+                    composite = _player_stat_composite(stats_by_id[p.player_id])
+                    if composite is not None:
+                        self._player_stat_history[p.player_id].append(composite)
 
 
 def build_training_frame(
@@ -981,6 +1067,24 @@ def build_training_frame(
         y=np.asarray(targets, dtype=int),
         match_ids=np.asarray(match_ids, dtype=int),
         start_times=np.asarray(start_times, dtype="datetime64[s]"),
+    )
+
+
+def _player_stat_composite(stat: PlayerMatchStat) -> float | None:
+    """Weighted composite of attacking/defensive KPIs for one player's match (#251).
+
+    Returns None when the key attacking stats are entirely absent (e.g. a player
+    entry with only ``player_id`` populated). The composite is intentionally
+    sparse-safe — any missing field is treated as 0 rather than propagating None.
+    """
+    if stat.tackle_breaks is None and stat.line_breaks is None and stat.try_assists is None:
+        return None
+    return (
+        (stat.tackle_breaks or 0)
+        + (stat.line_breaks or 0)
+        + (stat.try_assists or 0)
+        + 0.05 * (stat.tackles_made or 0)
+        - 0.5 * (stat.errors or 0)
     )
 
 

--- a/src/fantasy_coach/feature_engineering.py
+++ b/src/fantasy_coach/feature_engineering.py
@@ -203,6 +203,25 @@ FEATURE_NAMES = (
     # error independent of the underlying weather signal).
     "rain_intensity",
     "weather_source",
+    # Ladder-position / finals-race features (#255). Emitted from the running
+    # competition ladder maintained in FeatureBuilder. All values default to
+    # 0.0 with missing_ladder=1.0 for rounds < LADDER_MIN_ROUND (positions
+    # aren't stable until ≥5 rounds have been played).
+    #
+    # ladder_position_diff: current ladder rank (1–17), home minus away.
+    #   Negative means home is ranked higher (better).
+    # points_to_top8_diff: (top8_pts − team_pts), signed, home minus away.
+    #   Negative = home is comfortably inside top 8 relative to away.
+    # must_win_intensity: max(0, 1 − (remaining − pts_to_top8 / 2)) for
+    #   the more desperate team; reaches 1.0 when elimination is imminent.
+    # dead_rubber_indicator: 1.0 when neither team can change their top-8
+    #   status regardless of remaining match results.
+    # missing_ladder: 1.0 for rounds < LADDER_MIN_ROUND or no ladder data.
+    "ladder_position_diff",
+    "points_to_top8_diff",
+    "must_win_intensity",
+    "dead_rubber_indicator",
+    "missing_ladder",
 )
 
 # Plain-English rationale in docs/model.md. These are expert-prior weights:
@@ -260,6 +279,25 @@ DEFAULT_DAYS_REST = 14
 REF_WINDOW = 20  # rolling window for referee stats
 REF_SHRINKAGE_N = 10  # shrink toward league mean for fewer than N prior matches
 _TEAM_STATS_WINDOW = 5
+
+# Ladder-position feature constants (#255).
+LADDER_MIN_ROUND = 5  # emit missing_ladder=1.0 for rounds below this threshold
+NRL_SEASON_ROUNDS = 27  # regular-season rounds in the NRL calendar
+
+
+@dataclass
+class _TeamLadder:
+    """Per-team running ladder entry maintained by FeatureBuilder."""
+
+    team_id: int
+    pts: int = 0  # competition points (2 win, 1 draw, 0 loss)
+    pts_for: int = 0  # total match points scored
+    pts_against: int = 0
+    played: int = 0
+
+    @property
+    def pts_diff(self) -> int:
+        return self.pts_for - self.pts_against
 
 
 @dataclass(frozen=True)
@@ -364,6 +402,8 @@ class FeatureBuilder:
         # How many times each (team_id, venue_key, season) combination has appeared.
         # Used to determine whether a venue is a home ground for neutral-venue detection.
         self._team_venue_season_counts: dict[tuple[int, str, int], int] = defaultdict(int)
+        # Running competition ladder (#255). Keyed by team_id; reset each season.
+        self._ladder: dict[int, _TeamLadder] = {}
 
     def feature_row(
         self, match: MatchRow, *, weather_forecast: WeatherForecast | None = None
@@ -458,6 +498,10 @@ class FeatureBuilder:
         # Interaction: fires only when both groups push in the same direction.
         halves_x_fwds = fwds_diff if halves_diff * fwds_diff > 0 else 0.0
 
+        lad_pos_diff, pts8_diff, must_win_int, dead_rub, miss_lad = self._ladder_features(
+            match.round, h_id, a_id
+        )
+
         return [
             elo_diff,
             form_pf_h - form_pf_a,
@@ -511,7 +555,78 @@ class FeatureBuilder:
             halves_x_fwds,
             rain_intensity,
             weather_source,
+            lad_pos_diff,
+            pts8_diff,
+            must_win_int,
+            dead_rub,
+            miss_lad,
         ]
+
+    def _ladder_features(
+        self, round_: int, h_id: int, a_id: int
+    ) -> tuple[float, float, float, float, float]:
+        """Return (ladder_position_diff, points_to_top8_diff, must_win_intensity,
+        dead_rubber_indicator, missing_ladder) from the running competition table.
+
+        All values are 0.0 / missing_ladder=1.0 when the round is below
+        LADDER_MIN_ROUND or either team hasn't appeared on the ladder yet.
+        """
+        if round_ < LADDER_MIN_ROUND or h_id not in self._ladder or a_id not in self._ladder:
+            return 0.0, 0.0, 0.0, 0.0, 1.0
+
+        entries = sorted(self._ladder.values(), key=lambda e: (-e.pts, -e.pts_diff))
+        if len(entries) < 2:
+            return 0.0, 0.0, 0.0, 0.0, 1.0
+
+        pos_map = {e.team_id: i + 1 for i, e in enumerate(entries)}
+        pts_map = {e.team_id: e.pts for e in entries}
+        played_map = {e.team_id: e.played for e in entries}
+
+        h_pos = pos_map.get(h_id, len(entries))
+        a_pos = pos_map.get(a_id, len(entries))
+
+        top8_pts = entries[7].pts if len(entries) >= 8 else entries[-1].pts
+
+        h_pts_to_8 = top8_pts - pts_map.get(h_id, 0)
+        a_pts_to_8 = top8_pts - pts_map.get(a_id, 0)
+
+        h_remaining = max(0, NRL_SEASON_ROUNDS - played_map.get(h_id, 0))
+        a_remaining = max(0, NRL_SEASON_ROUNDS - played_map.get(a_id, 0))
+
+        def _must_win_score(pts_to_8: float, remaining: int) -> float:
+            if pts_to_8 <= 0 or remaining == 0:
+                return 0.0
+            return max(0.0, min(1.0, 1.0 - (remaining - pts_to_8 / 2.0)))
+
+        must_win_intensity = max(
+            _must_win_score(h_pts_to_8, h_remaining),
+            _must_win_score(a_pts_to_8, a_remaining),
+        )
+
+        def _top8_locked(team_pts: int, pos: int, remaining: int) -> bool:
+            """True when this team's top-8 status cannot change."""
+            if remaining == 0:
+                return True
+            if pos > 8:
+                return team_pts + 2 * remaining < top8_pts
+            else:
+                if len(entries) < 9:
+                    return True
+                ninth = entries[8]
+                ninth_remaining = max(0, NRL_SEASON_ROUNDS - ninth.played)
+                return ninth.pts + 2 * ninth_remaining < team_pts
+
+        h_dead = _top8_locked(pts_map.get(h_id, 0), h_pos, h_remaining)
+        a_dead = _top8_locked(pts_map.get(a_id, 0), a_pos, a_remaining)
+        dead_rubber = 1.0 if (h_dead and a_dead) else 0.0
+
+        return (
+            float(h_pos - a_pos),
+            float(h_pts_to_8 - a_pts_to_8),
+            must_win_intensity,
+            dead_rubber,
+            0.0,
+        )
 
     def _team_venue_hga_estimate(self, team_id: int, vkey: str) -> float:
         """Rolling win-over-expected for (home team, venue); regressed toward 0."""
@@ -703,6 +818,7 @@ class FeatureBuilder:
         if match.season != self._current_season:
             self.elo.regress_to_mean()
             self.player_ratings.regress_to_mean()
+            self._ladder = {}  # fresh ladder each season (#255)
             self._current_season = match.season
 
     def record(self, match: MatchRow) -> None:
@@ -793,6 +909,24 @@ class FeatureBuilder:
             ar = _extract_stat(match.team_stats, "All Runs", side)
             if ar is not None:
                 self._team_all_runs[team_id].append(ar)
+        # Update running ladder (#255). Must happen after scores are confirmed.
+        for team_id, scored, conceded in (
+            (h_id, h_score, a_score),
+            (a_id, a_score, h_score),
+        ):
+            if team_id not in self._ladder:
+                self._ladder[team_id] = _TeamLadder(team_id=team_id)
+            e = self._ladder[team_id]
+            e.pts_for += scored
+            e.pts_against += conceded
+            e.played += 1
+        if h_score > a_score:
+            self._ladder[h_id].pts += 2
+        elif a_score > h_score:
+            self._ladder[a_id].pts += 2
+        else:  # draw
+            self._ladder[h_id].pts += 1
+            self._ladder[a_id].pts += 1
 
 
 def build_training_frame(

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -11,7 +11,7 @@ from fantasy_coach.feature_engineering import (
     FeatureBuilder,
     build_training_frame,
 )
-from fantasy_coach.features import MatchRow, PlayerRow, TeamRow
+from fantasy_coach.features import MatchRow, PlayerMatchStat, PlayerRow, TeamRow
 
 
 def _match(
@@ -693,3 +693,132 @@ def test_ladder_dead_rubber_when_top8_status_locked() -> None:
     row = dict(zip(FEATURE_NAMES, builder.feature_row(query), strict=True))
     assert row["missing_ladder"] == 0.0
     assert row["dead_rubber_indicator"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Player form-trajectory features (#251)
+# ---------------------------------------------------------------------------
+
+
+def _make_player_stat(
+    player_id: int,
+    *,
+    tackle_breaks: int = 0,
+    line_breaks: int = 0,
+    try_assists: int = 0,
+    tackles_made: int = 20,
+    errors: int = 0,
+) -> PlayerMatchStat:
+    return PlayerMatchStat(
+        player_id=player_id,
+        tackle_breaks=tackle_breaks,
+        line_breaks=line_breaks,
+        try_assists=try_assists,
+        tackles_made=tackles_made,
+        errors=errors,
+    )
+
+
+def test_trajectory_zero_with_no_player_data() -> None:
+    """When no player stats are available both trajectory diffs are 0.0."""
+    builder = FeatureBuilder()
+    home_players = [_player(1, "Halfback")]
+    away_players = [_player(2, "Halfback")]
+    match = _make_match_with_players(home_players, away_players)
+    row = dict(zip(FEATURE_NAMES, builder.feature_row(match), strict=True))
+    assert row["player_form_trajectory_diff"] == pytest.approx(0.0)
+    assert row["key_player_trajectory_diff"] == pytest.approx(0.0)
+
+
+def test_trajectory_missing_flag_fires_when_roster_lacks_history() -> None:
+    """missing_player_trajectory=1.0 when ≥5 XIII players have < 3 recorded composites."""
+    builder = FeatureBuilder()
+    # 6 home starters, none with history → missing flag fires
+    home_players = [_player(i, "Prop") for i in range(1, 7)]
+    away_players = [_player(i, "Prop") for i in range(11, 17)]
+    match = _make_match_with_players(home_players, away_players)
+    row = dict(zip(FEATURE_NAMES, builder.feature_row(match), strict=True))
+    assert row["missing_player_trajectory"] == 1.0
+
+
+def test_trajectory_strictly_walk_forward() -> None:
+    """Trajectory must not include the current match's own stats."""
+    builder = FeatureBuilder()
+    home_players = [_player(1, "Halfback")]
+    away_players = [_player(2, "Halfback")]
+
+    # Play 5 prior matches so player 1 has history.
+    for i in range(1, 6):
+        m = MatchRow(
+            match_id=i,
+            season=2025,
+            round=i,
+            start_time=datetime(2025, 3, 1, tzinfo=UTC) + timedelta(weeks=i - 1),
+            match_state="FullTime",
+            venue=None,
+            venue_city=None,
+            weather=None,
+            home=TeamRow(team_id=10, name="H", nick_name="H", score=20, players=home_players),
+            away=TeamRow(team_id=20, name="A", nick_name="A", score=10, players=away_players),
+            team_stats=[],
+            home_player_stats=[_make_player_stat(1, line_breaks=i)],
+            away_player_stats=[_make_player_stat(2, line_breaks=0)],
+        )
+        builder.advance_season_if_needed(m)
+        builder.record(m)
+
+    # In match 6, player 1 will have a huge line-break game; feature_row
+    # must only see rounds 1–5 (not round 6's stats).
+    query = MatchRow(
+        match_id=6,
+        season=2025,
+        round=6,
+        start_time=datetime(2025, 3, 1, tzinfo=UTC) + timedelta(weeks=5),
+        match_state="FullTime",
+        venue=None,
+        venue_city=None,
+        weather=None,
+        home=TeamRow(team_id=10, name="H", nick_name="H", score=20, players=home_players),
+        away=TeamRow(team_id=20, name="A", nick_name="A", score=10, players=away_players),
+        team_stats=[],
+        home_player_stats=[_make_player_stat(1, line_breaks=100)],  # huge game
+        away_player_stats=[_make_player_stat(2, line_breaks=0)],
+    )
+    builder.advance_season_if_needed(query)
+    row_before = dict(zip(FEATURE_NAMES, builder.feature_row(query), strict=True))
+    # Trajectory is based on rounds 1–5 only; the 100-line-break round hasn't
+    # been recorded yet → trajectory should be a small positive (rounds 3-5
+    # avg > season avg of rounds 1-5).
+    assert row_before["player_form_trajectory_diff"] < 50  # definitely not 100
+
+
+def test_improving_spine_produces_positive_key_trajectory() -> None:
+    """Team with improving spine (halves + hooker) has positive key_player_trajectory_diff."""
+    builder = FeatureBuilder()
+    halfback_home = _player(1, "Halfback")
+    halfback_away = _player(2, "Halfback")
+
+    # Play 6 matches: home halfback improves each round; away stays flat.
+    for i in range(1, 7):
+        m = MatchRow(
+            match_id=i,
+            season=2025,
+            round=i,
+            start_time=datetime(2025, 3, 1, tzinfo=UTC) + timedelta(weeks=i - 1),
+            match_state="FullTime",
+            venue=None,
+            venue_city=None,
+            weather=None,
+            home=TeamRow(team_id=10, name="H", nick_name="H", score=20, players=[halfback_home]),
+            away=TeamRow(team_id=20, name="A", nick_name="A", score=10, players=[halfback_away]),
+            team_stats=[],
+            home_player_stats=[_make_player_stat(1, line_breaks=i * 2)],  # trending up
+            away_player_stats=[_make_player_stat(2, line_breaks=1)],  # flat
+        )
+        builder.advance_season_if_needed(m)
+        builder.record(m)
+
+    query = _make_match_with_players([halfback_home], [halfback_away], match_id=7)
+    row = dict(zip(FEATURE_NAMES, builder.feature_row(query), strict=True))
+    # Home halfback is trending up → positive key_player_trajectory_diff.
+    assert row["key_player_trajectory_diff"] > 0

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -520,3 +520,176 @@ def test_position_pair_feature_count_matches_feature_names() -> None:
     match = _make_match_with_players([], [])
     row = builder.feature_row(match)
     assert len(row) == len(FEATURE_NAMES)
+
+
+# ---------------------------------------------------------------------------
+# Ladder-position features (#255)
+# ---------------------------------------------------------------------------
+
+
+def _match_r(
+    *,
+    match_id: int,
+    home_id: int,
+    away_id: int,
+    home_score: int,
+    away_score: int,
+    round_: int,
+    season: int = 2025,
+) -> MatchRow:
+    """Helper like _match() but accepts explicit round number."""
+    from datetime import UTC
+
+    when = datetime(season, 3, 1, tzinfo=UTC) + timedelta(weeks=round_ - 1)
+    return MatchRow(
+        match_id=match_id,
+        season=season,
+        round=round_,
+        start_time=when,
+        match_state="FullTime",
+        venue=None,
+        venue_city=None,
+        weather=None,
+        home=TeamRow(
+            team_id=home_id,
+            name=str(home_id),
+            nick_name=str(home_id),
+            score=home_score,
+            players=[],
+        ),
+        away=TeamRow(
+            team_id=away_id,
+            name=str(away_id),
+            nick_name=str(away_id),
+            score=away_score,
+            players=[],
+        ),
+        team_stats=[],
+    )
+
+
+def test_ladder_missing_flag_for_early_rounds() -> None:
+    """missing_ladder=1.0 for rounds below LADDER_MIN_ROUND."""
+    builder = FeatureBuilder()
+    match = _match_r(match_id=1, home_id=10, away_id=20, home_score=24, away_score=12, round_=2)
+    row = dict(zip(FEATURE_NAMES, builder.feature_row(match), strict=True))
+    assert row["missing_ladder"] == 1.0
+    assert row["ladder_position_diff"] == 0.0
+    assert row["must_win_intensity"] == 0.0
+    assert row["dead_rubber_indicator"] == 0.0
+
+
+def test_ladder_position_diff_after_several_rounds() -> None:
+    """Home is ranked higher (lower position number) → negative ladder_position_diff."""
+    builder = FeatureBuilder()
+    teams = list(range(10, 26))  # 16 teams
+    # Play 6 rounds: team 10 wins all, team 20 loses all, others split.
+    match_id = 0
+    for r in range(1, 7):
+        for i in range(0, len(teams), 2):
+            h, a = teams[i], teams[i + 1]
+            # team 10 always wins at home, team 20 always loses as away
+            match = _match_r(
+                match_id=match_id,
+                home_id=h,
+                away_id=a,
+                home_score=20,
+                away_score=10,
+                round_=r,
+            )
+            builder.advance_season_if_needed(match)
+            builder.record(match)
+            match_id += 1
+
+    # After 6 rounds team 10 (home winner every round) should be high on table;
+    # team 25 (always away loser) should be low.
+    query = _match_r(
+        match_id=match_id, home_id=10, away_id=25, home_score=0, away_score=0, round_=7
+    )
+    builder.advance_season_if_needed(query)
+    row = dict(zip(FEATURE_NAMES, builder.feature_row(query), strict=True))
+    assert row["missing_ladder"] == 0.0
+    # home (10) should have better (lower) position than away (25)
+    assert row["ladder_position_diff"] < 0
+
+
+def test_ladder_must_win_intensity_for_outside_top8() -> None:
+    """A team on the ladder bubble with few games remaining has high must_win_intensity."""
+    from fantasy_coach.feature_engineering import NRL_SEASON_ROUNDS
+
+    builder = FeatureBuilder()
+    # Simulate late season: play NRL_SEASON_ROUNDS - 2 rounds for many teams.
+    # team 10 sits just outside top 8 (8th has 2 more pts, 1 game remaining for both).
+    teams_top8 = list(range(1, 9))
+    teams_outside = list(range(9, 17))
+    match_id = 0
+
+    rounds_to_play = NRL_SEASON_ROUNDS - 2
+    for r in range(1, rounds_to_play + 1):
+        for h, a in zip(teams_top8, teams_outside, strict=True):
+            m = _match_r(
+                match_id=match_id,
+                home_id=h,
+                away_id=a,
+                home_score=20,
+                away_score=10,
+                round_=r,
+            )
+            builder.advance_season_if_needed(m)
+            builder.record(m)
+            match_id += 1
+
+    # Query: team 10 vs team 1 in final rounds — team 10 is outside top 8.
+    query = _match_r(
+        match_id=match_id,
+        home_id=10,  # outside top 8
+        away_id=1,  # inside top 8
+        home_score=0,
+        away_score=0,
+        round_=NRL_SEASON_ROUNDS - 1,
+    )
+    builder.advance_season_if_needed(query)
+    row = dict(zip(FEATURE_NAMES, builder.feature_row(query), strict=True))
+    # Home is outside top 8 with few games left → must_win_intensity > 0
+    assert row["missing_ladder"] == 0.0
+    assert row["must_win_intensity"] > 0.0
+
+
+def test_ladder_dead_rubber_when_top8_status_locked() -> None:
+    """dead_rubber_indicator fires when both teams' top-8 status is mathematically decided."""
+    from fantasy_coach.feature_engineering import NRL_SEASON_ROUNDS
+
+    builder = FeatureBuilder()
+    # team 1 wins all → comfortably in top 8
+    # team 20 loses all → comfortably out of top 8
+    # After 26 rounds both positions are locked.
+    teams = list(range(1, 17))
+    match_id = 0
+    for r in range(1, NRL_SEASON_ROUNDS):
+        for i in range(0, len(teams), 2):
+            h, a = teams[i], teams[i + 1]
+            m = _match_r(
+                match_id=match_id,
+                home_id=h,
+                away_id=a,
+                home_score=30,
+                away_score=0,
+                round_=r,
+            )
+            builder.advance_season_if_needed(m)
+            builder.record(m)
+            match_id += 1
+
+    # Final round: top-ranked vs bottom-ranked — neither can change status.
+    query = _match_r(
+        match_id=match_id,
+        home_id=teams[0],  # top of table
+        away_id=teams[-1],  # bottom of table
+        home_score=0,
+        away_score=0,
+        round_=NRL_SEASON_ROUNDS,
+    )
+    builder.advance_season_if_needed(query)
+    row = dict(zip(FEATURE_NAMES, builder.feature_row(query), strict=True))
+    assert row["missing_ladder"] == 0.0
+    assert row["dead_rubber_indicator"] == 1.0


### PR DESCRIPTION
Closes #251

**Stacked on #271** (ladder features) — re-target base to `main` before merging.

## Summary
- Adds 3 new features derived from per-player `match_player_stats` data (already persisted via #142), walk-forward with no new scrapes:
  - `player_form_trajectory_diff` — position-weighted sum of (last-3 avg − season avg) stat composite per starting XIII player, home minus away
  - `key_player_trajectory_diff` — same but restricted to spine (halves, hooker, fullback)
  - `missing_player_trajectory` — 1.0 when ≥5 named XIII players on either side have < 3 recorded composites
- Composite per player = `tackle_breaks + line_breaks + try_assists + 0.05×tackles_made − 0.5×errors`
- `_player_stat_history` deque (maxlen=20) populated in `record()` from `match.home/away_player_stats`; `feature_row()` reads prior state only — strictly walk-forward, no leakage

## Test evidence
```
26 passed in 0.38s
```
(4 new tests: zero with no data, missing flag fires, walk-forward enforcement, improving spine → positive key trajectory)

## Notes
- FEATURE_NAMES now has 62 features; model retrain required after merge.
- `test_baseline_metrics.py` EXPECTED needs re-pinning after retrain.

https://claude.ai/code/session_01BjuGC3QPWepHfvx1cyASnz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjuGC3QPWepHfvx1cyASnz)_