### PR TITLE
feat(#280): Betting Tips page (singles + doubles + trebles)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,15 @@ FIREBASE_PROJECT_ID=your-firebase-project-id
 # GEMINI_COMMENTARY_MODEL=gemini-2.0-flash-001
 
 # ---------------------------------------------------------------------------
+# Betting tips — the-odds-api.com (optional)
+# ---------------------------------------------------------------------------
+# When set, the precompute Job fetches NRL totals (over/under) lines and adds
+# them to the weekly Betting Tips card. Unset = H2H-only card from scraped
+# nrl.com odds. Free tier is 500 req/month — Tue+Thu precompute uses ~8/month.
+# Matches the Secret Manager secret "odds-api-key".
+# FANTASY_COACH_ODDS_API_KEY=
+
+# ---------------------------------------------------------------------------
 # Push notifications (FCM) — #172
 # ---------------------------------------------------------------------------
 # VAPID key for Firebase Cloud Messaging (web push). Generate in:

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -9,6 +9,7 @@ development reads the same variable names from a `.env` file (gitignored).
 | Secret Manager name | Env var | Purpose | Who can rotate |
 |---|---|---|---|
 | `firebase-project-id` | `FIREBASE_PROJECT_ID` | Firebase project for ID-token verification (issue #17) | Project owner |
+| `odds-api-key` | `FANTASY_COACH_ODDS_API_KEY` | the-odds-api.com key for NRL totals lines on the Betting Tips card. Optional — without it the card is H2H-only. | Project owner |
 
 ## Naming convention
 
@@ -85,3 +86,21 @@ make run
 
 If a paid bookmaker odds API is added (issue #26), its API key goes here
 under `bookmaker-odds-api-key` / `BOOKMAKER_ODDS_API_KEY`.
+
+## Paired platform-infra work
+
+Each new secret needs a matching pair of resources in
+[`lopeztech/platform-infra`](https://github.com/lopeztech/platform-infra)
+under `projects/fantasy-coach/`:
+
+1. `google_secret_manager_secret.<name>` — the secret container.
+2. `google_secret_manager_secret_iam_member` bindings granting
+   `roles/secretmanager.secretAccessor` to **both** the API runtime SA
+   (`fantasy-coach-runtime`) and the precompute Job runtime SA.
+
+Then update `.github/workflows/deploy.yml` to inject the value via
+`--set-secrets ENV_VAR=<secret-name>:latest` on both the Cloud Run service
+and the Cloud Run Job. Make sure the env var is listed in the Terraform
+`lifecycle.ignore_changes` block on the Cloud Run resource — otherwise the
+next `terraform apply` will silently strip it (see memory note
+"Terraform can wipe Cloud Run runtime config").

--- a/src/fantasy_coach/__main__.py
+++ b/src/fantasy_coach/__main__.py
@@ -941,6 +941,51 @@ def _run_precompute(args: argparse.Namespace) -> int:
         if refreshed:
             print(f"Refreshed {refreshed} stale past-start-time matches in season {season}")
 
+        # Generate the weekly Betting Tips card. Non-fatal — the API
+        # gracefully returns 503 on cache miss. Skipped silently when there
+        # are no predictions. Totals legs require FANTASY_COACH_ODDS_API_KEY;
+        # without it the card is H2H-only (still useful).
+        try:
+            from fantasy_coach.betting.generator import generate_tips  # noqa: PLC0415
+            from fantasy_coach.betting.store import get_betting_tips_store  # noqa: PLC0415
+
+            if predictions:
+                totals_lines: dict = {}
+                odds_snapshot_at: str | None = None
+                odds_api_key = os.environ.get("FANTASY_COACH_ODDS_API_KEY")
+                if odds_api_key:
+                    try:
+                        from fantasy_coach.betting.odds_client import (  # noqa: PLC0415
+                            OddsApiClient,
+                        )
+
+                        totals_lines = OddsApiClient(api_key=odds_api_key).fetch_totals()
+                        odds_snapshot_at = datetime.now(UTC).isoformat()
+                    except Exception as _odds_exc:  # noqa: BLE001
+                        print(f"Betting tips: odds-api fetch failed (non-fatal): {_odds_exc}")
+                else:
+                    print("Betting tips: FANTASY_COACH_ODDS_API_KEY unset — H2H-only card")
+
+                tips = generate_tips(
+                    season,
+                    round_,
+                    predictions,
+                    totals_lines=totals_lines,
+                    odds_snapshot_at=odds_snapshot_at,
+                )
+                tips_store = get_betting_tips_store()
+                try:
+                    tips_store.put(tips)
+                finally:
+                    if hasattr(tips_store, "close"):
+                        tips_store.close()
+                print(
+                    f"Betting tips: wrote {len(tips.singles)} singles, "
+                    f"{len(tips.doubles)} doubles, {len(tips.trebles)} trebles"
+                )
+        except Exception as _tips_exc:  # noqa: BLE001
+            print(f"Betting tips computation failed (non-fatal): {_tips_exc}")
+
         # Run Monte Carlo season simulation (#217). Failures are non-fatal.
         try:
             from fantasy_coach.simulation import simulate_season  # noqa: PLC0415

--- a/src/fantasy_coach/app.py
+++ b/src/fantasy_coach/app.py
@@ -12,6 +12,12 @@ from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
 from fantasy_coach import __version__
+from fantasy_coach.betting.models import BettingTipsOut
+from fantasy_coach.betting.store import (
+    BettingTipsStore,
+    FirestoreBettingTipsStore,
+    get_betting_tips_store,
+)
 from fantasy_coach.config import get_repository
 from fantasy_coach.job_runs import JobRunStore
 from fantasy_coach.predictions import (
@@ -230,6 +236,7 @@ app.add_middleware(
 _store: PredictionStore | FirestorePredictionStore | None = None
 _repo: Repository | None = None
 _job_run_store: JobRunStore | None = None
+_betting_tips_store: BettingTipsStore | FirestoreBettingTipsStore | None = None
 
 # In-process cache for team profile responses: key=(team_id, season), value=(timestamp, data)
 _PROFILE_CACHE_TTL = 60  # seconds
@@ -256,6 +263,13 @@ def _get_repo() -> Repository:
     if _repo is None:
         _repo = get_repository()
     return _repo
+
+
+def _get_betting_tips_store() -> BettingTipsStore | FirestoreBettingTipsStore:
+    global _betting_tips_store
+    if _betting_tips_store is None:
+        _betting_tips_store = get_betting_tips_store()
+    return _betting_tips_store
 
 
 def _get_job_run_store() -> JobRunStore | None:
@@ -364,6 +378,39 @@ def get_predictions(
             ),
         )
     return _annotate_results(cached, season, round)
+
+
+@app.get(
+    "/betting-tips",
+    response_model=BettingTipsOut,
+    summary="Top betting tips for a season/round",
+    description=(
+        "Returns the precomputed 2-singles + 2-doubles + 2-trebles card for the "
+        "requested round. Tips combine cached model probabilities with bookmaker "
+        "odds (head-to-head from the nrl.com scrape; totals from the-odds-api "
+        "when configured). Computed twice a week by the Cloud Run Job; this "
+        "endpoint is a cache read only. Returns 503 with a retry hint when the "
+        "cache is empty. Picks are educational, not financial advice — gamble "
+        "responsibly."
+    ),
+)
+def get_betting_tips(
+    season: int = Query(..., description="NRL season year, e.g. 2026"),
+    round: int = Query(..., description="Round number, e.g. 7", alias="round"),
+) -> BettingTipsOut:
+    tips = _get_betting_tips_store().get(season, round)
+    if tips is None:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                f"No cached betting tips for season {season} round {round}. "
+                "The precompute job runs Tue 09:00 AEST and Thu 06:00 AEST. "
+                "Retry in a few minutes or trigger it manually with "
+                "`gcloud run jobs execute fantasy-coach-precompute`."
+            ),
+            headers={"Retry-After": "3600"},
+        )
+    return tips
 
 
 @app.get(

--- a/src/fantasy_coach/betting/__init__.py
+++ b/src/fantasy_coach/betting/__init__.py
@@ -1,0 +1,1 @@
+"""Betting Tips: turn cached PredictionOut + bookmaker odds into a weekly card."""

--- a/src/fantasy_coach/betting/generator.py
+++ b/src/fantasy_coach/betting/generator.py
@@ -1,0 +1,343 @@
+"""Turn cached predictions + bookmaker odds into a weekly tips card.
+
+Pure function — no I/O. The precompute job loads predictions from the
+``predictions`` store, optionally fetches totals lines via ``OddsApiClient``,
+and hands both to ``generate_tips``. The output is written to the
+``betting_tips`` store and served read-only via the API.
+
+Algorithm:
+
+1. Build leg candidates per prediction:
+   - H2H leg (always available when scraped nrl.com odds are populated).
+   - Totals leg (only when both the prediction has ``predictedTotal`` and a
+     ``TotalsLine`` is provided for the match).
+2. Filter: positive de-vigged edge AND model probability strong enough that
+   the leg is plausibly "almost guaranteed". Confidence band is folded into
+   the score but is not a hard gate — keeping it soft lets legacy predictions
+   (with ``confidenceBand=None``) still surface picks.
+3. Rank by ``modelProb × (1 + edge) × confidenceMultiplier``.
+4. Take top-2 singles, top-2 doubles, top-2 trebles, with each multi requiring
+   match-disjoint legs (legs from the same match are perfectly correlated).
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from fantasy_coach.betting.models import (
+    BettingTipsOut,
+    Tip,
+    TipLeg,
+    TotalsLine,
+)
+from fantasy_coach.bookmaker.lines import devig_two_way
+
+# Per-leg filters — calibrated by inspection: model_prob ≥ 0.55 means the
+# model meaningfully favours the side; edge ≥ 0.02 strips out picks the market
+# has already fully priced in. Both are tunable but should be raised together
+# — relaxing one without the other tends to surface noise.
+MIN_MODEL_PROB = 0.55
+MIN_EDGE = 0.02
+
+# Standard deviation of NRL match totals around their season mean. Used to
+# convert ``predictedTotal − line`` into a normal-CDF probability of the
+# selected side landing. 14 is a defensible NRL-specific value; tune from
+# empirical totals residuals once we have a few months of multitask predictions
+# to backtest. Quoted here as a constant so a single edit retunes all totals.
+TOTALS_STDEV = 14.0
+TOTALS_MIN_EDGE_PTS = 1.0  # require the model to disagree with the line by >1pt
+
+# Score-weight ramp for the confidenceBand field. Untiered predictions
+# (legacy / non-XGBoost artefacts) get a neutral 1.0.
+_CONFIDENCE_WEIGHTS: dict[str, float] = {"high": 1.5, "medium": 1.0, "low": 0.6}
+
+
+# ---------------------------------------------------------------------------
+# Internal candidate type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _LegCandidate:
+    match_id: int
+    home_name: str
+    away_name: str
+    kickoff: str
+    market: str  # "h2h" | "totals"
+    selection_code: str  # "home"|"away" | "over"|"under"
+    selection_label: str  # display string
+    line: float | None
+    decimal_odds: float
+    model_prob: float
+    implied_prob: float
+    bookmaker: str
+    confidence_band: str | None
+
+    @property
+    def edge(self) -> float:
+        return self.model_prob - self.implied_prob
+
+    @property
+    def score(self) -> float:
+        cband = self.confidence_band or ""
+        weight = _CONFIDENCE_WEIGHTS.get(cband, 1.0)
+        return self.model_prob * (1.0 + self.edge) * weight
+
+    def to_leg(self) -> TipLeg:
+        return TipLeg(
+            matchId=self.match_id,
+            homeName=self.home_name,
+            awayName=self.away_name,
+            kickoff=self.kickoff,
+            market=self.market,  # type: ignore[arg-type]
+            selectionCode=self.selection_code,  # type: ignore[arg-type]
+            selection=self.selection_label,
+            line=self.line,
+            decimalOdds=round(self.decimal_odds, 2),
+            modelProb=round(self.model_prob, 4),
+            impliedProb=round(self.implied_prob, 4),
+            edge=round(self.edge, 4),
+            bookmaker=self.bookmaker,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def generate_tips(
+    season: int,
+    round_: int,
+    predictions: list[Any],
+    *,
+    totals_lines: dict[tuple[str, str], TotalsLine] | None = None,
+    odds_snapshot_at: str | None = None,
+    now: datetime | None = None,
+) -> BettingTipsOut:
+    """Compute the 2-singles + 2-doubles + 2-trebles card for one round.
+
+    ``predictions`` are ``PredictionOut`` instances (kept loose-typed here to
+    avoid a circular import). ``totals_lines`` is keyed by
+    ``(home_nickname, away_nickname)`` matching the prediction's team names —
+    populated by ``OddsApiClient.fetch_totals`` when an API key is configured.
+
+    ``now`` is injectable for deterministic tests.
+    """
+    timestamp = (now or datetime.now(UTC)).isoformat()
+
+    candidates: list[_LegCandidate] = []
+    for pred in predictions:
+        h2h = _h2h_candidate(pred)
+        if h2h is not None and _passes_filters(h2h):
+            candidates.append(h2h)
+        if totals_lines:
+            tl = totals_lines.get((pred.home.name, pred.away.name))
+            if tl is not None:
+                tot = _totals_candidate(pred, tl)
+                if tot is not None and _passes_filters(tot):
+                    candidates.append(tot)
+
+    ranked = sorted(candidates, key=lambda c: c.score, reverse=True)
+
+    singles = [_tip_from_legs([c], "single") for c in ranked[:2]]
+    doubles = [_tip_from_legs(combo, "double") for combo in _best_multis(ranked, 2, 2)]
+    trebles = [_tip_from_legs(combo, "treble") for combo in _best_multis(ranked, 3, 2)]
+
+    return BettingTipsOut(
+        season=season,
+        round=round_,
+        generatedAt=timestamp,
+        oddsSnapshotAt=odds_snapshot_at,
+        singles=singles,
+        doubles=doubles,
+        trebles=trebles,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Candidate construction
+# ---------------------------------------------------------------------------
+
+
+def _h2h_candidate(pred: Any) -> _LegCandidate | None:
+    """Build the head-to-head leg candidate from a PredictionOut, if priced."""
+    home_odds = getattr(pred.home, "odds", None)
+    away_odds = getattr(pred.away, "odds", None)
+    if home_odds is None or away_odds is None or home_odds <= 1.0 or away_odds <= 1.0:
+        return None
+    try:
+        implied_home = devig_two_way(float(home_odds), float(away_odds))
+    except ValueError:
+        return None
+
+    home_prob = float(pred.homeWinProbability)
+    if home_prob >= 0.5:
+        selection_code = "home"
+        selection_label = pred.home.name
+        model_prob = home_prob
+        implied_prob = implied_home
+        decimal_odds = float(home_odds)
+    else:
+        selection_code = "away"
+        selection_label = pred.away.name
+        model_prob = 1.0 - home_prob
+        implied_prob = 1.0 - implied_home
+        decimal_odds = float(away_odds)
+
+    return _LegCandidate(
+        match_id=int(pred.matchId),
+        home_name=pred.home.name,
+        away_name=pred.away.name,
+        kickoff=pred.kickoff,
+        market="h2h",
+        selection_code=selection_code,
+        selection_label=selection_label,
+        line=None,
+        decimal_odds=decimal_odds,
+        model_prob=model_prob,
+        implied_prob=implied_prob,
+        bookmaker="nrl.com",
+        confidence_band=getattr(pred, "confidenceBand", None),
+    )
+
+
+def _totals_candidate(pred: Any, line: TotalsLine) -> _LegCandidate | None:
+    """Build the totals (over/under) leg, when the model has a totals prediction."""
+    predicted_total = getattr(pred, "predictedTotal", None)
+    if predicted_total is None:
+        return None
+
+    diff = float(predicted_total) - line.line
+    if abs(diff) < TOTALS_MIN_EDGE_PTS:
+        return None
+
+    # De-vig the bookmaker's over/under prices.
+    over_raw = 1.0 / line.overDecimalOdds
+    under_raw = 1.0 / line.underDecimalOdds
+    total_raw = over_raw + under_raw
+    if total_raw <= 0:
+        return None
+    implied_over = over_raw / total_raw
+    implied_under = under_raw / total_raw
+
+    if diff > 0:
+        model_prob = _phi(diff / TOTALS_STDEV)
+        return _LegCandidate(
+            match_id=int(pred.matchId),
+            home_name=pred.home.name,
+            away_name=pred.away.name,
+            kickoff=pred.kickoff,
+            market="totals",
+            selection_code="over",
+            selection_label=f"Over {line.line:g}",
+            line=line.line,
+            decimal_odds=line.overDecimalOdds,
+            model_prob=model_prob,
+            implied_prob=implied_over,
+            bookmaker=line.bookmaker,
+            confidence_band=getattr(pred, "confidenceBand", None),
+        )
+    model_prob = _phi(-diff / TOTALS_STDEV)
+    return _LegCandidate(
+        match_id=int(pred.matchId),
+        home_name=pred.home.name,
+        away_name=pred.away.name,
+        kickoff=pred.kickoff,
+        market="totals",
+        selection_code="under",
+        selection_label=f"Under {line.line:g}",
+        line=line.line,
+        decimal_odds=line.underDecimalOdds,
+        model_prob=model_prob,
+        implied_prob=implied_under,
+        bookmaker=line.bookmaker,
+        confidence_band=getattr(pred, "confidenceBand", None),
+    )
+
+
+def _passes_filters(cand: _LegCandidate) -> bool:
+    return cand.model_prob >= MIN_MODEL_PROB and cand.edge >= MIN_EDGE
+
+
+# ---------------------------------------------------------------------------
+# Multi assembly
+# ---------------------------------------------------------------------------
+
+
+def _best_multis(
+    candidates: list[_LegCandidate], n_legs: int, take: int
+) -> list[tuple[_LegCandidate, ...]]:
+    """Return up to ``take`` best n-leg multis with match-disjoint legs.
+
+    Uses a greedy selection over the sorted combinations: highest scoring
+    combo first, then the next-highest combo that isn't a permutation of an
+    already-picked set. We allow leg reuse *across* multi rows (a leg in
+    Double #1 may also appear in Treble #2) since each tip is independent
+    consumer-facing — strict no-reuse drastically thins the card when the
+    candidate pool is small.
+    """
+    if len(candidates) < n_legs:
+        return []
+    combos: list[tuple[tuple[_LegCandidate, ...], float]] = []
+    for combo in itertools.combinations(candidates, n_legs):
+        match_ids = {leg.match_id for leg in combo}
+        if len(match_ids) < n_legs:
+            continue  # two legs from the same match — perfectly correlated
+        prob = 1.0
+        edge_min = 1.0
+        for leg in combo:
+            prob *= leg.model_prob
+            edge_min = min(edge_min, leg.edge)
+        # Score: combined model prob × (1 + min edge). Picks "almost guaranteed"
+        # multis first while still requiring every leg to have positive value.
+        if edge_min < 0:
+            continue
+        combos.append((combo, prob * (1.0 + edge_min)))
+    combos.sort(key=lambda x: x[1], reverse=True)
+
+    chosen: list[tuple[_LegCandidate, ...]] = []
+    seen: set[frozenset[tuple[int, str]]] = set()
+    for combo, _ in combos:
+        key = frozenset((leg.match_id, leg.selection_code) for leg in combo)
+        if key in seen:
+            continue
+        chosen.append(combo)
+        seen.add(key)
+        if len(chosen) >= take:
+            break
+    return chosen
+
+
+def _tip_from_legs(candidates: tuple[_LegCandidate, ...] | list[_LegCandidate], kind: str) -> Tip:
+    legs = [c.to_leg() for c in candidates]
+    combined_odds = 1.0
+    combined_model = 1.0
+    combined_implied = 1.0
+    for c in candidates:
+        combined_odds *= c.decimal_odds
+        combined_model *= c.model_prob
+        combined_implied *= c.implied_prob
+    return Tip(
+        kind=kind,  # type: ignore[arg-type]
+        legs=legs,
+        combinedOdds=round(combined_odds, 2),
+        combinedModelProb=round(combined_model, 4),
+        combinedImpliedProb=round(combined_implied, 4),
+        edge=round(combined_model - combined_implied, 4),
+        suggestedUnits=1.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _phi(z: float) -> float:
+    """Standard-normal CDF without a scipy dep (Abramowitz & Stegun 26.2.17)."""
+    return 0.5 * (1.0 + math.erf(z / math.sqrt(2.0)))

--- a/src/fantasy_coach/betting/models.py
+++ b/src/fantasy_coach/betting/models.py
@@ -1,0 +1,90 @@
+"""Pydantic schemas for the Betting Tips feature.
+
+camelCase field names match the SPA's other typed responses (PredictionOut etc.).
+The N815 lint rule is suppressed module-wide via the field-level ``noqa: N815``
+markers, following the convention established in ``predictions.py``.
+
+Tips are produced by the precompute Job (Tue/Thu) and read back by the
+``/betting-tips`` endpoint — see ``betting.generator`` for the selection logic
+and ``betting.store`` for the cache layout.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+Market = Literal["h2h", "totals"]
+H2HSelection = Literal["home", "away"]
+TotalsSelection = Literal["over", "under"]
+
+
+class TipLeg(BaseModel):
+    """One leg inside a single, double, or treble.
+
+    ``selection`` is the human-readable side (team name for H2H, "Over 41.5"
+    for totals). ``selectionCode`` is the machine-readable enum the SPA can
+    use to render variant-specific iconography.
+    """
+
+    matchId: int  # noqa: N815
+    homeName: str  # noqa: N815
+    awayName: str  # noqa: N815
+    kickoff: str  # noqa: N815  ISO 8601
+    market: Market
+    selectionCode: H2HSelection | TotalsSelection  # noqa: N815
+    selection: str  # noqa: N815  display string, e.g. "Storm" or "Over 41.5"
+    line: float | None = None  # totals line; None for H2H
+    decimalOdds: float  # noqa: N815  bookmaker price for this leg
+    modelProb: float  # noqa: N815  model's probability the leg lands
+    impliedProb: float  # noqa: N815  de-vigged bookmaker probability
+    edge: float  # modelProb − impliedProb
+    bookmaker: str  # short label e.g. "nrl.com" or "TAB"
+
+
+class Tip(BaseModel):
+    """A single bet (1 leg) or multi (2+ legs)."""
+
+    kind: Literal["single", "double", "treble"]
+    legs: list[TipLeg]
+    combinedOdds: float  # noqa: N815  product of leg decimal odds
+    combinedModelProb: float  # noqa: N815  product of leg modelProbs (independence assumption)
+    combinedImpliedProb: float  # noqa: N815  product of leg impliedProbs
+    edge: float  # combinedModelProb − combinedImpliedProb
+    suggestedUnits: float  # noqa: N815  flat 1.0 for v1; future: Kelly fraction
+
+
+class BettingTipsOut(BaseModel):
+    """Top-level response for ``GET /betting-tips``.
+
+    Always 2 singles + 2 doubles + 2 trebles when the prediction pool is rich
+    enough. Sections fall short when there aren't enough qualifying legs — the
+    SPA renders a "not enough confident picks this round" empty state.
+    """
+
+    season: int
+    round: int
+    generatedAt: str  # noqa: N815  ISO 8601 UTC — when the tips were computed
+    oddsSnapshotAt: str | None = None  # noqa: N815  when external odds were fetched (totals only)
+    caveat: str = (
+        "Multi probabilities assume each leg lands independently. "
+        "Real outcomes are correlated, so true joint probabilities are usually lower."
+    )
+    singles: list[Tip]
+    doubles: list[Tip]
+    trebles: list[Tip]
+
+
+# ---------------------------------------------------------------------------
+# the-odds-api ingest shapes (internal — not part of the public response)
+# ---------------------------------------------------------------------------
+
+
+class TotalsLine(BaseModel):
+    """A single totals (over/under) line for a match, from the-odds-api."""
+
+    line: float  # e.g. 41.5
+    overDecimalOdds: float  # noqa: N815
+    underDecimalOdds: float  # noqa: N815
+    bookmaker: str

--- a/src/fantasy_coach/betting/odds_client.py
+++ b/src/fantasy_coach/betting/odds_client.py
@@ -1,0 +1,189 @@
+"""Thin httpx client for the-odds-api.com (NRL totals markets).
+
+Used only by the precompute Job. The API is **never called on the hot path**;
+results are computed once per precompute run, blended with cached predictions,
+and persisted to Firestore for the ``/betting-tips`` read-through.
+
+Free tier covers ``rugby_league_nrl`` with regions=``au`` and markets=``h2h,totals``
+at 500 requests/month — a Tue+Thu cadence uses ~8/month. The key is read from
+``FANTASY_COACH_ODDS_API_KEY`` (Secret Manager in production); without it the
+client is never constructed and the precompute step gracefully skips totals.
+
+Retries follow the same exponential-backoff shape as ``commentary.client``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterable
+
+import httpx
+
+from fantasy_coach.betting.models import TotalsLine
+
+logger = logging.getLogger(__name__)
+
+API_BASE_URL = "https://api.the-odds-api.com/v4"
+SPORT_KEY = "rugby_league_nrl"
+REGIONS = "au"
+MARKETS = "h2h,totals"
+
+_RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+
+# Map nrl.com team names to the-odds-api team names. the-odds-api uses long
+# canonical names ("Brisbane Broncos"); nrl.com uses short nicknames ("Broncos").
+# Built on first call from a small static map — small enough to keep in code.
+_TEAM_ALIASES: dict[str, frozenset[str]] = {
+    "Broncos": frozenset({"brisbane broncos", "broncos"}),
+    "Raiders": frozenset({"canberra raiders", "raiders"}),
+    "Bulldogs": frozenset({"canterbury bulldogs", "canterbury-bankstown bulldogs", "bulldogs"}),
+    "Sharks": frozenset({"cronulla sharks", "cronulla-sutherland sharks", "sharks"}),
+    "Dolphins": frozenset({"dolphins"}),
+    "Titans": frozenset({"gold coast titans", "titans"}),
+    "Sea Eagles": frozenset({"manly sea eagles", "manly warringah sea eagles", "sea eagles"}),
+    "Storm": frozenset({"melbourne storm", "storm"}),
+    "Knights": frozenset({"newcastle knights", "knights"}),
+    "Cowboys": frozenset({"north queensland cowboys", "cowboys"}),
+    "Eels": frozenset({"parramatta eels", "eels"}),
+    "Panthers": frozenset({"penrith panthers", "panthers"}),
+    "Rabbitohs": frozenset({"south sydney rabbitohs", "rabbitohs"}),
+    "Dragons": frozenset({"st george illawarra dragons", "dragons"}),
+    "Roosters": frozenset({"sydney roosters", "roosters"}),
+    "Warriors": frozenset({"new zealand warriors", "nz warriors", "warriors"}),
+    "Wests Tigers": frozenset({"wests tigers", "tigers"}),
+}
+
+
+def _match_team(api_team: str) -> str | None:
+    """Map a the-odds-api team name back to the nrl.com short nickname.
+
+    Returns None when the name doesn't fit any known NRL side — happens for
+    pre-season exhibitions or rep games that occasionally appear in the feed.
+    """
+    needle = api_team.strip().lower()
+    for nrl_name, aliases in _TEAM_ALIASES.items():
+        if needle in aliases:
+            return nrl_name
+    return None
+
+
+class OddsApiClient:
+    """Fetch NRL totals lines from the-odds-api.com.
+
+    Constructed only inside the precompute job. Tests pass ``transport`` to
+    override the HTTP layer with respx.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        max_retries: int = 3,
+        timeout: float = 10.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._max_retries = max_retries
+        self._timeout = timeout
+        self._transport = transport
+
+    def fetch_totals(self) -> dict[tuple[str, str], TotalsLine]:
+        """Return a ``{(home_nickname, away_nickname): TotalsLine}`` map.
+
+        Picks the first bookmaker that quotes a totals market for each event,
+        sorted by the order the-odds-api returns (typically by issue time).
+        Multi-bookmaker line shopping is a future enhancement.
+
+        Returns an empty dict on any error — totals are an enhancement, not a
+        blocker, so the caller can always fall back to H2H-only tips.
+        """
+        try:
+            data = self._get(
+                f"{API_BASE_URL}/sports/{SPORT_KEY}/odds",
+                params={
+                    "apiKey": self._api_key,
+                    "regions": REGIONS,
+                    "markets": MARKETS,
+                    "oddsFormat": "decimal",
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("odds-api fetch failed (non-fatal): %s", exc)
+            return {}
+
+        out: dict[tuple[str, str], TotalsLine] = {}
+        for event in data or []:
+            home_raw = event.get("home_team") or ""
+            away_raw = event.get("away_team") or ""
+            home = _match_team(home_raw)
+            away = _match_team(away_raw)
+            if home is None or away is None:
+                logger.debug("odds-api: skipping unknown teams %r vs %r", home_raw, away_raw)
+                continue
+            line = self._first_totals_line(event.get("bookmakers") or [])
+            if line is not None:
+                out[(home, away)] = line
+        logger.info("odds-api: fetched totals for %d matches", len(out))
+        return out
+
+    @staticmethod
+    def _first_totals_line(bookmakers: Iterable[dict]) -> TotalsLine | None:
+        """Extract the first complete (over+under) totals line from a bookmaker list.
+
+        Skips bookmakers that only quote one side — the de-vig math requires
+        both prices to be meaningful.
+        """
+        for bm in bookmakers:
+            for market in bm.get("markets") or []:
+                if market.get("key") != "totals":
+                    continue
+                over: dict | None = None
+                under: dict | None = None
+                for outcome in market.get("outcomes") or []:
+                    name = (outcome.get("name") or "").lower()
+                    if name == "over":
+                        over = outcome
+                    elif name == "under":
+                        under = outcome
+                if over and under and over.get("point") == under.get("point"):
+                    try:
+                        return TotalsLine(
+                            line=float(over["point"]),
+                            overDecimalOdds=float(over["price"]),
+                            underDecimalOdds=float(under["price"]),
+                            bookmaker=str(bm.get("title") or bm.get("key") or "unknown"),
+                        )
+                    except (KeyError, TypeError, ValueError):
+                        continue
+        return None
+
+    def _get(self, url: str, *, params: dict) -> list:
+        last_exc: Exception | None = None
+        for attempt in range(self._max_retries):
+            if attempt:
+                time.sleep(2**attempt)
+            client_kwargs: dict = {"timeout": self._timeout}
+            if self._transport is not None:
+                client_kwargs["transport"] = self._transport
+            try:
+                with httpx.Client(**client_kwargs) as client:
+                    resp = client.get(url, params=params)
+                if resp.status_code in _RETRYABLE_STATUS:
+                    last_exc = httpx.HTTPStatusError(
+                        f"HTTP {resp.status_code}",
+                        request=resp.request,
+                        response=resp,
+                    )
+                    logger.warning(
+                        "odds-api retry attempt=%d status=%d", attempt + 1, resp.status_code
+                    )
+                    continue
+                resp.raise_for_status()
+                return resp.json()
+            except (httpx.TimeoutException, httpx.ConnectError) as exc:
+                last_exc = exc
+                logger.warning("odds-api network error attempt=%d: %s", attempt + 1, exc)
+        raise RuntimeError(
+            f"odds-api request failed after {self._max_retries} attempts"
+        ) from last_exc

--- a/src/fantasy_coach/betting/store.py
+++ b/src/fantasy_coach/betting/store.py
@@ -1,0 +1,155 @@
+"""Storage backends for the betting-tips cache.
+
+Mirrors the prediction-cache layout: one document per ``(season, round)``,
+written by the precompute job and read by the ``/betting-tips`` endpoint.
+Picks SQLite vs Firestore via the same ``STORAGE_BACKEND`` env switch as
+``predictions.get_prediction_store`` so the API and Job share one knob.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from fantasy_coach.betting.models import BettingTipsOut
+
+logger = logging.getLogger(__name__)
+
+BETTING_TIPS_DB_ENV = "FANTASY_COACH_BETTING_TIPS_DB_PATH"
+DEFAULT_BETTING_TIPS_DB = "data/betting_tips.db"
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS betting_tips (
+    season     INTEGER NOT NULL,
+    round      INTEGER NOT NULL,
+    payload    TEXT    NOT NULL,
+    created_at TEXT    NOT NULL,
+    PRIMARY KEY (season, round)
+);
+"""
+
+# Tips are immutable between scheduled precompute runs (Tue/Thu) so a long
+# warm-cache TTL is safe. A forced refresh requires a Cloud Run instance
+# bounce — same constraint as the prediction cache.
+_TIPS_CACHE_TTL: float = 6 * 3600.0
+
+
+class BettingTipsStore:
+    """SQLite-backed cache. Used in local dev and tests."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        db_path = Path(path or os.getenv(BETTING_TIPS_DB_ENV, DEFAULT_BETTING_TIPS_DB))
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        # check_same_thread=False mirrors PredictionStore — the FastAPI
+        # threadpool reads from a different thread than module import.
+        self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(_CREATE_TABLE)
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def get(self, season: int, round_: int) -> BettingTipsOut | None:
+        row = self._conn.execute(
+            "SELECT payload FROM betting_tips WHERE season=? AND round=?",
+            (season, round_),
+        ).fetchone()
+        if not row:
+            return None
+        return BettingTipsOut(**json.loads(row["payload"]))
+
+    def put(self, tips: BettingTipsOut) -> None:
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT OR REPLACE INTO betting_tips (season, round, payload, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    tips.season,
+                    tips.round,
+                    tips.model_dump_json(),
+                    datetime.now(UTC).isoformat(),
+                ),
+            )
+
+
+class FirestoreBettingTipsStore:
+    """Firestore-backed cache. Production.
+
+    Doc ID: ``"{season}-{round}"`` inside the ``betting_tips`` collection.
+    Shape mirrors the predictions collection: one doc per round with the full
+    tips payload + a ``createdAt`` timestamp.
+    """
+
+    _COLLECTION = "betting_tips"
+
+    def __init__(
+        self,
+        client: Any = None,
+        project: str | None = None,
+        database: str = "(default)",
+    ) -> None:
+        if client is not None:
+            self._db = client
+        else:
+            from google.cloud import firestore  # noqa: PLC0415
+
+            self._db = firestore.Client(project=project, database=database)
+        self._cache: dict[tuple[int, int], tuple[float, BettingTipsOut]] = {}
+
+    def close(self) -> None:
+        return  # symmetry with BettingTipsStore — Firestore has no conn to close
+
+    def get(self, season: int, round_: int) -> BettingTipsOut | None:
+        key = (season, round_)
+        cached = self._cache.get(key)
+        if cached is not None:
+            ts, tips = cached
+            if time.monotonic() - ts < _TIPS_CACHE_TTL:
+                return tips
+            del self._cache[key]
+
+        snap = self._db.collection(self._COLLECTION).document(_doc_id(season, round_)).get()
+        if not snap.exists:
+            return None
+        data = snap.to_dict() or {}
+        payload = data.get("payload")
+        if not payload:
+            return None
+        tips = BettingTipsOut(**payload)
+        self._cache[key] = (time.monotonic(), tips)
+        return tips
+
+    def put(self, tips: BettingTipsOut) -> None:
+        self._db.collection(self._COLLECTION).document(_doc_id(tips.season, tips.round)).set(
+            {
+                "season": tips.season,
+                "round": tips.round,
+                "payload": tips.model_dump(),
+                "createdAt": datetime.now(UTC).isoformat(),
+            }
+        )
+        self._cache[(tips.season, tips.round)] = (time.monotonic(), tips)
+
+
+def _doc_id(season: int, round_: int) -> str:
+    return f"{season}-{round_}"
+
+
+def get_betting_tips_store() -> BettingTipsStore | FirestoreBettingTipsStore:
+    """Factory: pick the betting-tips store from ``STORAGE_BACKEND``.
+
+    Mirrors ``predictions.get_prediction_store`` so the API + Job share a
+    single switch. Defaults to SQLite for local dev.
+    """
+    backend = os.getenv("STORAGE_BACKEND", "sqlite").lower()
+    if backend == "firestore":
+        return FirestoreBettingTipsStore()
+    return BettingTipsStore()

--- a/tests/test_app_betting_tips.py
+++ b/tests/test_app_betting_tips.py
@@ -1,0 +1,87 @@
+"""Endpoint tests for ``GET /betting-tips``."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fantasy_coach import app as app_module
+from fantasy_coach.betting.models import BettingTipsOut, Tip, TipLeg
+
+
+class _FakeStore:
+    def __init__(self) -> None:
+        self.payload: BettingTipsOut | None = None
+
+    def get(self, season: int, round_: int) -> BettingTipsOut | None:
+        if self.payload and self.payload.season == season and self.payload.round == round_:
+            return self.payload
+        return None
+
+
+@pytest.fixture
+def fake_store(monkeypatch: pytest.MonkeyPatch) -> _FakeStore:
+    fake = _FakeStore()
+    # Force the lazy singleton path to use our fake.
+    monkeypatch.setattr(app_module, "_betting_tips_store", fake)
+    return fake
+
+
+def test_returns_503_when_cache_empty(fake_store: _FakeStore) -> None:
+    client = TestClient(app_module.app)
+    res = client.get("/betting-tips?season=2026&round=99")
+    assert res.status_code == 503
+    assert "Retry-After" in res.headers
+    assert res.headers["Retry-After"] == "3600"
+    body = res.json()
+    assert "season 2026 round 99" in body["detail"]
+
+
+def test_returns_200_with_payload_when_cache_hit(fake_store: _FakeStore) -> None:
+    fake_store.payload = BettingTipsOut(
+        season=2026,
+        round=7,
+        generatedAt="2026-04-29T12:00:00+00:00",
+        oddsSnapshotAt=None,
+        singles=[
+            Tip(
+                kind="single",
+                legs=[
+                    TipLeg(
+                        matchId=111,
+                        homeName="Storm",
+                        awayName="Eels",
+                        kickoff="2026-05-01T08:00:00+00:00",
+                        market="h2h",
+                        selectionCode="home",
+                        selection="Storm",
+                        line=None,
+                        decimalOdds=1.85,
+                        modelProb=0.72,
+                        impliedProb=0.52,
+                        edge=0.20,
+                        bookmaker="nrl.com",
+                    )
+                ],
+                combinedOdds=1.85,
+                combinedModelProb=0.72,
+                combinedImpliedProb=0.52,
+                edge=0.20,
+                suggestedUnits=1.0,
+            )
+        ],
+        doubles=[],
+        trebles=[],
+    )
+
+    client = TestClient(app_module.app)
+    res = client.get("/betting-tips?season=2026&round=7")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["season"] == 2026
+    assert body["round"] == 7
+    assert len(body["singles"]) == 1
+    leg = body["singles"][0]["legs"][0]
+    assert leg["selection"] == "Storm"
+    assert leg["market"] == "h2h"
+    assert "caveat" in body

--- a/tests/test_betting_generator.py
+++ b/tests/test_betting_generator.py
@@ -1,0 +1,272 @@
+"""Tests for ``betting.generator.generate_tips``."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from fantasy_coach.betting.generator import (
+    MIN_MODEL_PROB,
+    TOTALS_STDEV,
+    generate_tips,
+)
+from fantasy_coach.betting.models import BettingTipsOut, TotalsLine
+from fantasy_coach.predictions import PredictionOut, TeamInfo
+
+
+def _pred(
+    match_id: int,
+    *,
+    home_name: str,
+    away_name: str,
+    home_win_prob: float,
+    home_odds: float | None,
+    away_odds: float | None,
+    confidence_band: str | None = "high",
+    predicted_total: float | None = None,
+    kickoff: str = "2026-05-01T08:00:00+00:00",
+) -> PredictionOut:
+    return PredictionOut(
+        matchId=match_id,
+        home=TeamInfo(id=match_id * 10, name=home_name, odds=home_odds),
+        away=TeamInfo(id=match_id * 10 + 1, name=away_name, odds=away_odds),
+        kickoff=kickoff,
+        predictedWinner="home" if home_win_prob >= 0.5 else "away",
+        homeWinProbability=home_win_prob,
+        modelVersion="abc123",
+        featureHash="def456",
+        confidenceBand=confidence_band,
+        predictedTotal=predicted_total,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Singles
+# ---------------------------------------------------------------------------
+
+
+def test_h2h_single_picked_when_model_beats_market() -> None:
+    # Market implies ~50% (1.95 / 1.95 de-vigged ≈ 0.50); model says 0.70 → edge 0.20.
+    preds = [
+        _pred(
+            1,
+            home_name="Storm",
+            away_name="Eels",
+            home_win_prob=0.70,
+            home_odds=1.95,
+            away_odds=1.95,
+        )
+    ]
+    out = generate_tips(2026, 7, preds, now=datetime(2026, 5, 1, tzinfo=UTC))
+    assert isinstance(out, BettingTipsOut)
+    assert len(out.singles) == 1
+    leg = out.singles[0].legs[0]
+    assert leg.market == "h2h"
+    assert leg.selection == "Storm"
+    assert leg.modelProb == pytest.approx(0.70)
+    assert leg.edge > 0.15
+
+
+def test_h2h_rejects_when_model_only_marginally_above_implied() -> None:
+    # Model 0.55, market implies 0.54 → edge 0.01 < MIN_EDGE.
+    preds = [
+        _pred(
+            1,
+            home_name="Storm",
+            away_name="Eels",
+            home_win_prob=0.55,
+            home_odds=1.85,
+            away_odds=2.10,
+        )
+    ]
+    out = generate_tips(2026, 7, preds)
+    assert out.singles == []
+
+
+def test_h2h_rejects_when_model_prob_below_threshold() -> None:
+    # Model 0.54 < 0.55 floor — even with edge, skip.
+    preds = [
+        _pred(
+            1,
+            home_name="Storm",
+            away_name="Eels",
+            home_win_prob=0.54,
+            home_odds=3.0,
+            away_odds=1.40,
+        )
+    ]
+    assert MIN_MODEL_PROB > 0.54  # invariant the test depends on
+    out = generate_tips(2026, 7, preds)
+    assert out.singles == []
+
+
+def test_picks_away_side_when_model_favours_away() -> None:
+    # home_win_prob 0.30 → away_prob 0.70; away decimal odds 1.95 (implied ~0.50).
+    preds = [
+        _pred(
+            1,
+            home_name="Wests Tigers",
+            away_name="Panthers",
+            home_win_prob=0.30,
+            home_odds=2.20,
+            away_odds=1.95,
+        )
+    ]
+    out = generate_tips(2026, 7, preds)
+    assert len(out.singles) == 1
+    leg = out.singles[0].legs[0]
+    assert leg.selectionCode == "away"
+    assert leg.selection == "Panthers"
+
+
+def test_skips_match_without_odds() -> None:
+    preds = [
+        _pred(
+            1,
+            home_name="Storm",
+            away_name="Eels",
+            home_win_prob=0.80,
+            home_odds=None,
+            away_odds=None,
+        )
+    ]
+    assert generate_tips(2026, 7, preds).singles == []
+
+
+# ---------------------------------------------------------------------------
+# Multis
+# ---------------------------------------------------------------------------
+
+
+def _strong_h2h_pred(
+    match_id: int, home_name: str, prob: float = 0.72, home_odds: float = 1.85
+) -> PredictionOut:
+    return _pred(
+        match_id,
+        home_name=home_name,
+        away_name=f"Opp{match_id}",
+        home_win_prob=prob,
+        home_odds=home_odds,
+        away_odds=2.05,
+    )
+
+
+def test_double_uses_two_different_matches() -> None:
+    preds = [_strong_h2h_pred(i, name) for i, name in enumerate(["A", "B", "C"], start=1)]
+    out = generate_tips(2026, 7, preds)
+    assert len(out.doubles) >= 1
+    d = out.doubles[0]
+    assert d.kind == "double"
+    assert len(d.legs) == 2
+    match_ids = {leg.matchId for leg in d.legs}
+    assert len(match_ids) == 2
+
+
+def test_treble_uses_three_different_matches_and_correct_combined_odds() -> None:
+    preds = [_strong_h2h_pred(i, name) for i, name in enumerate(["A", "B", "C", "D"], start=1)]
+    out = generate_tips(2026, 7, preds)
+    assert len(out.trebles) >= 1
+    t = out.trebles[0]
+    assert t.kind == "treble"
+    assert len(t.legs) == 3
+    assert len({leg.matchId for leg in t.legs}) == 3
+    expected_odds = 1.0
+    expected_model = 1.0
+    for leg in t.legs:
+        expected_odds *= leg.decimalOdds
+        expected_model *= leg.modelProb
+    assert t.combinedOdds == pytest.approx(round(expected_odds, 2), abs=0.02)
+    assert t.combinedModelProb == pytest.approx(round(expected_model, 4), abs=0.001)
+
+
+def test_no_trebles_when_only_two_qualifying_picks() -> None:
+    preds = [_strong_h2h_pred(1, "A"), _strong_h2h_pred(2, "B")]
+    out = generate_tips(2026, 7, preds)
+    assert out.trebles == []
+
+
+# ---------------------------------------------------------------------------
+# Totals
+# ---------------------------------------------------------------------------
+
+
+def test_totals_leg_added_when_model_disagrees_with_line() -> None:
+    pred = _pred(
+        1,
+        home_name="Storm",
+        away_name="Eels",
+        home_win_prob=0.55,
+        home_odds=1.85,
+        away_odds=2.10,
+        predicted_total=48.0,
+    )
+    line = TotalsLine(
+        line=40.0,
+        overDecimalOdds=1.90,
+        underDecimalOdds=1.90,
+        bookmaker="TAB",
+    )
+    out = generate_tips(2026, 7, [pred], totals_lines={("Storm", "Eels"): line})
+    totals_legs = [s.legs[0] for s in out.singles if s.legs[0].market == "totals"]
+    assert len(totals_legs) == 1
+    leg = totals_legs[0]
+    assert leg.selectionCode == "over"
+    assert leg.line == 40.0
+    assert leg.bookmaker == "TAB"
+    # Phi((48 - 40) / 14) ≈ 0.716
+    from math import erf, sqrt
+
+    expected = 0.5 * (1.0 + erf(8.0 / TOTALS_STDEV / sqrt(2.0)))
+    assert leg.modelProb == pytest.approx(round(expected, 4), abs=1e-3)
+
+
+def test_totals_skipped_when_predicted_total_close_to_line() -> None:
+    pred = _pred(
+        1,
+        home_name="Storm",
+        away_name="Eels",
+        home_win_prob=0.40,  # low — no H2H pick to mask the test
+        home_odds=2.50,
+        away_odds=1.55,
+        predicted_total=40.3,
+    )
+    line = TotalsLine(line=40.0, overDecimalOdds=1.90, underDecimalOdds=1.90, bookmaker="TAB")
+    out = generate_tips(2026, 7, [pred], totals_lines={("Storm", "Eels"): line})
+    totals_legs = [s.legs[0] for s in out.singles if s.legs[0].market == "totals"]
+    assert totals_legs == []
+
+
+def test_totals_skipped_when_prediction_lacks_predicted_total() -> None:
+    pred = _pred(
+        1,
+        home_name="Storm",
+        away_name="Eels",
+        home_win_prob=0.40,
+        home_odds=2.50,
+        away_odds=1.55,
+        predicted_total=None,
+    )
+    line = TotalsLine(line=40.0, overDecimalOdds=1.90, underDecimalOdds=1.90, bookmaker="TAB")
+    out = generate_tips(2026, 7, [pred], totals_lines={("Storm", "Eels"): line})
+    totals_legs = [s.legs[0] for s in out.singles if s.legs[0].market == "totals"]
+    assert totals_legs == []
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+
+def test_empty_predictions_returns_empty_card() -> None:
+    out = generate_tips(2026, 7, [])
+    assert out.singles == []
+    assert out.doubles == []
+    assert out.trebles == []
+    assert out.season == 2026
+    assert out.round == 7
+
+
+def test_caveat_string_present() -> None:
+    out = generate_tips(2026, 7, [])
+    assert "independent" in out.caveat.lower()

--- a/tests/test_betting_odds_client.py
+++ b/tests/test_betting_odds_client.py
@@ -1,0 +1,128 @@
+"""Tests for ``betting.odds_client.OddsApiClient``."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from fantasy_coach.betting import odds_client
+from fantasy_coach.betting.odds_client import API_BASE_URL, SPORT_KEY, OddsApiClient
+
+
+@pytest.fixture(autouse=True)
+def fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Don't actually sleep between retries during tests."""
+    monkeypatch.setattr(odds_client.time, "sleep", lambda _s: None)
+
+
+def _sample_event(home: str, away: str, line: float = 40.5) -> dict:
+    return {
+        "id": "abc",
+        "home_team": home,
+        "away_team": away,
+        "bookmakers": [
+            {
+                "key": "tab",
+                "title": "TAB",
+                "markets": [
+                    {
+                        "key": "totals",
+                        "outcomes": [
+                            {"name": "Over", "point": line, "price": 1.90},
+                            {"name": "Under", "point": line, "price": 1.90},
+                        ],
+                    },
+                ],
+            }
+        ],
+    }
+
+
+@respx.mock
+def test_fetch_totals_returns_keyed_map() -> None:
+    payload = [_sample_event("Melbourne Storm", "Parramatta Eels", 41.5)]
+    respx.get(f"{API_BASE_URL}/sports/{SPORT_KEY}/odds").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+
+    out = OddsApiClient(api_key="secret").fetch_totals()
+
+    assert ("Storm", "Eels") in out
+    line = out[("Storm", "Eels")]
+    assert line.line == 41.5
+    assert line.overDecimalOdds == 1.90
+    assert line.underDecimalOdds == 1.90
+    assert line.bookmaker == "TAB"
+
+
+@respx.mock
+def test_fetch_totals_sends_expected_query_params() -> None:
+    route = respx.get(f"{API_BASE_URL}/sports/{SPORT_KEY}/odds").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+
+    OddsApiClient(api_key="secret").fetch_totals()
+
+    sent = route.calls.last.request
+    assert "apiKey=secret" in sent.url.query.decode()
+    assert "regions=au" in sent.url.query.decode()
+    assert "markets=h2h%2Ctotals" in sent.url.query.decode()  # comma is percent-encoded
+
+
+@respx.mock
+def test_fetch_totals_skips_unknown_teams() -> None:
+    payload = [_sample_event("Some Touring Side", "Another Touring Side")]
+    respx.get(f"{API_BASE_URL}/sports/{SPORT_KEY}/odds").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+
+    assert OddsApiClient(api_key="secret").fetch_totals() == {}
+
+
+@respx.mock
+def test_fetch_totals_returns_empty_on_persistent_5xx() -> None:
+    """Non-fatal — caller falls back to H2H-only card."""
+    respx.get(f"{API_BASE_URL}/sports/{SPORT_KEY}/odds").mock(return_value=httpx.Response(503))
+
+    out = OddsApiClient(api_key="secret", max_retries=2).fetch_totals()
+
+    assert out == {}
+
+
+@respx.mock
+def test_fetch_totals_retries_on_transient_5xx_then_succeeds() -> None:
+    payload = [_sample_event("Penrith Panthers", "Sydney Roosters", 39.5)]
+    route = respx.get(f"{API_BASE_URL}/sports/{SPORT_KEY}/odds").mock(
+        side_effect=[
+            httpx.Response(503),
+            httpx.Response(200, json=payload),
+        ]
+    )
+
+    out = OddsApiClient(api_key="secret", max_retries=3).fetch_totals()
+
+    assert ("Panthers", "Roosters") in out
+    assert route.call_count == 2
+
+
+@respx.mock
+def test_skips_bookmaker_without_totals_market() -> None:
+    payload = [
+        {
+            "home_team": "Brisbane Broncos",
+            "away_team": "Gold Coast Titans",
+            "bookmakers": [
+                {
+                    "key": "x",
+                    "title": "X",
+                    "markets": [{"key": "h2h", "outcomes": [{"name": "Broncos", "price": 1.50}]}],
+                }
+            ],
+        }
+    ]
+    respx.get(f"{API_BASE_URL}/sports/{SPORT_KEY}/odds").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+
+    assert OddsApiClient(api_key="k").fetch_totals() == {}

--- a/tests/test_betting_store.py
+++ b/tests/test_betting_store.py
@@ -1,0 +1,81 @@
+"""Tests for the SQLite-backed ``BettingTipsStore``.
+
+Firestore variant is covered indirectly via ``test_app_betting_tips`` which
+substitutes a fake store. The Firestore client is unmockable here without
+adding ``mock-firestore`` to the dev deps.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fantasy_coach.betting.models import BettingTipsOut, Tip, TipLeg
+from fantasy_coach.betting.store import BettingTipsStore
+
+
+def _sample_tips(season: int = 2026, round_: int = 7) -> BettingTipsOut:
+    leg = TipLeg(
+        matchId=111,
+        homeName="Storm",
+        awayName="Eels",
+        kickoff="2026-05-01T08:00:00+00:00",
+        market="h2h",
+        selectionCode="home",
+        selection="Storm",
+        line=None,
+        decimalOdds=1.85,
+        modelProb=0.72,
+        impliedProb=0.52,
+        edge=0.20,
+        bookmaker="nrl.com",
+    )
+    single = Tip(
+        kind="single",
+        legs=[leg],
+        combinedOdds=1.85,
+        combinedModelProb=0.72,
+        combinedImpliedProb=0.52,
+        edge=0.20,
+        suggestedUnits=1.0,
+    )
+    return BettingTipsOut(
+        season=season,
+        round=round_,
+        generatedAt="2026-04-29T12:00:00+00:00",
+        oddsSnapshotAt=None,
+        singles=[single],
+        doubles=[],
+        trebles=[],
+    )
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> BettingTipsStore:
+    return BettingTipsStore(path=tmp_path / "tips.db")
+
+
+def test_get_returns_none_for_missing_round(store: BettingTipsStore) -> None:
+    assert store.get(2026, 7) is None
+
+
+def test_put_and_get_roundtrip(store: BettingTipsStore) -> None:
+    tips = _sample_tips()
+    store.put(tips)
+    loaded = store.get(2026, 7)
+    assert loaded is not None
+    assert loaded.season == 2026
+    assert loaded.round == 7
+    assert len(loaded.singles) == 1
+    assert loaded.singles[0].legs[0].selection == "Storm"
+
+
+def test_put_replaces_existing_row(store: BettingTipsStore) -> None:
+    store.put(_sample_tips())
+    second = _sample_tips()
+    second.singles[0].legs[0].selection = "Eels"
+    store.put(second)
+    loaded = store.get(2026, 7)
+    assert loaded is not None
+    assert loaded.singles[0].legs[0].selection == "Eels"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ type Toast = { title: string; body: string; href?: string };
 
 const NAV_ITEMS: { to: string; label: string }[] = [
   { to: "/predictions", label: "Predictions" },
+  { to: "/betting-tips", label: "Betting Tips" },
   { to: "/ladder", label: "Ladder" },
   { to: "/leaderboard", label: "Leaderboard" },
   { to: "/groups", label: "Groups" },

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,5 +1,6 @@
 import { getFirebaseAuth, API_BASE_URL } from "./firebase";
 import type {
+  BettingTipsResponse,
   DashboardOut,
   JobRunDetail,
   JobRunListItem,
@@ -56,6 +57,15 @@ export async function getJobRuns(limit = 20): Promise<JobRunListItem[]> {
 
 export async function getJobRun(runId: string): Promise<JobRunDetail> {
   return apiFetch<JobRunDetail>(`/job-runs/${encodeURIComponent(runId)}`);
+}
+
+export async function getBettingTips(
+  season: number,
+  round: number,
+): Promise<BettingTipsResponse> {
+  return apiFetch<BettingTipsResponse>(
+    `/betting-tips?season=${season}&round=${round}`,
+  );
 }
 
 export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {

--- a/web/src/components/ResponsibleGamblingBanner.tsx
+++ b/web/src/components/ResponsibleGamblingBanner.tsx
@@ -1,0 +1,12 @@
+export function ResponsibleGamblingBanner() {
+  return (
+    <aside className="gamble-banner" role="note" aria-label="Responsible gambling notice">
+      <strong>Model picks, not financial advice.</strong>
+      <p>
+        These are our model&apos;s highest-confidence picks based on statistical analysis —
+        they are not guaranteed outcomes. Gamble responsibly. 18+. If gambling is a problem,
+        call <a href="tel:1800858858">1800 858 858</a> (Gambling Help Online).
+      </p>
+    </aside>
+  );
+}

--- a/web/src/components/TipCard.tsx
+++ b/web/src/components/TipCard.tsx
@@ -1,0 +1,80 @@
+import type { Tip, TipLeg } from "../types";
+
+function formatKickoff(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatOdds(odds: number): string {
+  return `$${odds.toFixed(2)}`;
+}
+
+function formatPct(p: number): string {
+  return `${(p * 100).toFixed(1)}%`;
+}
+
+function legSubtitle(leg: TipLeg): string {
+  if (leg.market === "h2h") {
+    return `${leg.homeName} v ${leg.awayName} — Head-to-head`;
+  }
+  return `${leg.homeName} v ${leg.awayName} — Total points`;
+}
+
+export function TipCard({ tip, index }: { tip: Tip; index: number }) {
+  const kindLabel = tip.kind.charAt(0).toUpperCase() + tip.kind.slice(1);
+  const edgeClass = tip.edge >= 0.15 ? "tip-edge tip-edge--strong" : "tip-edge";
+
+  return (
+    <article className="tip-card" aria-label={`${kindLabel} pick #${index + 1}`}>
+      <header className="tip-card-head">
+        <span className="tip-kind">
+          {kindLabel} #{index + 1}
+        </span>
+        <span className={edgeClass}>+{(tip.edge * 100).toFixed(1)}% edge</span>
+      </header>
+
+      <ol className="tip-legs">
+        {tip.legs.map((leg, i) => (
+          <li key={`${leg.matchId}-${leg.market}-${i}`} className="tip-leg">
+            <div className="tip-leg-meta">
+              <span className="tip-leg-subtitle">{legSubtitle(leg)}</span>
+              <time className="tip-leg-kickoff" dateTime={leg.kickoff}>
+                {formatKickoff(leg.kickoff)}
+              </time>
+            </div>
+            <div className="tip-leg-pick">
+              <strong className="tip-leg-selection">{leg.selection}</strong>
+              <span className="tip-leg-price">{formatOdds(leg.decimalOdds)}</span>
+            </div>
+            <div className="tip-leg-stats">
+              <span>Model: {formatPct(leg.modelProb)}</span>
+              <span>Market: {formatPct(leg.impliedProb)}</span>
+              <span className="muted">via {leg.bookmaker}</span>
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      <footer className="tip-card-foot">
+        <div className="tip-totals">
+          <span>
+            Combined odds <strong>{formatOdds(tip.combinedOdds)}</strong>
+          </span>
+          <span>
+            Model joint prob <strong>{formatPct(tip.combinedModelProb)}</strong>
+          </span>
+        </div>
+        <span className="tip-stake">
+          Suggested stake: <strong>{tip.suggestedUnits.toFixed(1)}u</strong>
+        </span>
+      </footer>
+    </article>
+  );
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,6 +4,7 @@ import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 import Accuracy from "./routes/Accuracy";
 import App from "./App";
+import BettingTips from "./routes/BettingTips";
 import GroupDetail from "./routes/GroupDetail";
 import Groups from "./routes/Groups";
 import Home from "./routes/Home";
@@ -24,6 +25,7 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <Home /> },
       { path: "predictions", element: <Predictions /> },
+      { path: "betting-tips", element: <BettingTips /> },
       { path: "round/:season/:round", element: <Round /> },
       { path: "round/:season/:round/:matchId", element: <MatchDetail /> },
       { path: "scoreboard", element: <Scoreboard /> },

--- a/web/src/routes/BettingTips.tsx
+++ b/web/src/routes/BettingTips.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from "react";
+
+import { ApiError, NotSignedInError, getBettingTips, getDashboard } from "../api";
+import { useAuth } from "../auth";
+import { ResponsibleGamblingBanner } from "../components/ResponsibleGamblingBanner";
+import { SignInRequired } from "../components/SignInRequired";
+import { TipCard } from "../components/TipCard";
+import type { BettingTipsResponse, Tip } from "../types";
+
+type Status =
+  | { kind: "loading" }
+  | { kind: "ok"; data: BettingTipsResponse }
+  | { kind: "unavailable" }
+  | { kind: "error"; message: string };
+
+// Detect "season + round" we should fetch. The /me/dashboard endpoint owns the
+// authoritative current-round logic; we hit that first, then fall back to a
+// best-guess for unauthenticated edge cases (which shouldn't happen since the
+// page is auth-gated, but keeps the type story tidy).
+async function pickCurrentRound(
+  fetchDashboard: () => Promise<{ season: number; currentRound: number | null }>,
+): Promise<{ season: number; round: number } | null> {
+  try {
+    const d = await fetchDashboard();
+    if (d.currentRound) return { season: d.season, round: d.currentRound };
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+function Section({ title, tips }: { title: string; tips: Tip[] }) {
+  return (
+    <section className="tips-section">
+      <h2>{title}</h2>
+      {tips.length === 0 ? (
+        <p className="muted">
+          Not enough confident picks this round — check back after the Thursday refresh.
+        </p>
+      ) : (
+        <div className="tips-grid">
+          {tips.map((t, i) => (
+            <TipCard key={`${title}-${i}`} tip={t} index={i} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+const CURRENT_SEASON = new Date().getUTCFullYear();
+
+export default function BettingTips() {
+  const { user, loading: authLoading } = useAuth();
+  const [status, setStatus] = useState<Status>({ kind: "loading" });
+
+  useEffect(() => {
+    document.title = "Betting Tips — Fantasy Coach";
+  }, []);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) return;
+
+    let cancelled = false;
+    setStatus({ kind: "loading" });
+
+    (async () => {
+      // /me/dashboard is the authoritative source for "what's the current round".
+      const target = await pickCurrentRound(() =>
+        getDashboard(CURRENT_SEASON).then((d) => ({
+          season: d.season,
+          currentRound: d.currentRound,
+        })),
+      );
+
+      if (cancelled) return;
+      if (!target) {
+        setStatus({ kind: "unavailable" });
+        return;
+      }
+
+      try {
+        const data = await getBettingTips(target.season, target.round);
+        if (!cancelled) setStatus({ kind: "ok", data });
+      } catch (err) {
+        if (cancelled) return;
+        if (err instanceof NotSignedInError) {
+          setStatus({ kind: "error", message: "Sign in required." });
+        } else if (err instanceof ApiError && err.status === 503) {
+          setStatus({ kind: "unavailable" });
+        } else if (err instanceof ApiError) {
+          setStatus({
+            kind: "error",
+            message: `Couldn't load betting tips (HTTP ${err.status}).`,
+          });
+        } else {
+          setStatus({ kind: "error", message: "Couldn't reach the API." });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, user]);
+
+  if (authLoading) return <p>Loading…</p>;
+  if (!user) return <SignInRequired message="Sign in to see this week's betting tips." />;
+
+  return (
+    <section className="betting-tips-page">
+      <ResponsibleGamblingBanner />
+
+      <header className="round-header">
+        <h1>Betting Tips</h1>
+      </header>
+
+      {status.kind === "loading" && (
+        <div className="tips-grid" aria-busy="true">
+          {Array.from({ length: 3 }, (_, i) => (
+            <div key={i} className="tip-card-skeleton" aria-hidden="true" />
+          ))}
+        </div>
+      )}
+
+      {status.kind === "unavailable" && (
+        <div className="sign-in-required" role="status">
+          <p>
+            Tips for this week aren&apos;t ready yet. The model refreshes them every
+            Tuesday morning and Thursday morning (Sydney time) — please check back
+            shortly.
+          </p>
+        </div>
+      )}
+
+      {status.kind === "error" && (
+        <div className="error-box" role="alert">
+          {status.message}
+        </div>
+      )}
+
+      {status.kind === "ok" && (
+        <>
+          <p className="tips-meta muted">
+            Round {status.data.round}, {status.data.season} · Generated{" "}
+            {new Date(status.data.generatedAt).toLocaleString()}
+            {status.data.oddsSnapshotAt
+              ? ` · Totals odds refreshed ${new Date(status.data.oddsSnapshotAt).toLocaleString()}`
+              : ""}
+          </p>
+          <p className="tips-caveat muted">{status.data.caveat}</p>
+
+          <Section title="Singles" tips={status.data.singles} />
+          <Section title="Doubles" tips={status.data.doubles} />
+          <Section title="Trebles" tips={status.data.trebles} />
+        </>
+      )}
+    </section>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2375,3 +2375,190 @@ a:focus-visible {
 .back-link:hover {
   color: var(--color-text);
 }
+
+/* ── Betting Tips ──────────────────────────────────────────────────────── */
+
+.betting-tips-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.gamble-banner {
+  border-left: 4px solid var(--color-error);
+  background: var(--color-error-bg);
+  color: var(--color-error-text);
+  padding: 0.9rem 1.1rem;
+  border-radius: var(--radius-md, 6px);
+}
+
+.gamble-banner strong {
+  display: block;
+  margin-bottom: 0.25rem;
+  font-size: 0.95rem;
+}
+
+.gamble-banner p {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+
+.gamble-banner a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.tips-meta,
+.tips-caveat {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.tips-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tips-section h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+}
+
+.tips-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tip-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tip-card-skeleton {
+  height: 11rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(
+    90deg,
+    var(--color-border) 25%,
+    var(--color-border-subtle) 50%,
+    var(--color-border) 75%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.4s ease infinite;
+}
+
+.tip-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.tip-kind {
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+}
+
+.tip-edge {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  padding: 0.15rem 0.55rem;
+  border-radius: var(--radius-full);
+  background: var(--color-border);
+}
+
+.tip-edge--strong {
+  background: var(--color-primary);
+  color: var(--color-bg);
+}
+
+.tip-legs {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.tip-leg {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm, 4px);
+}
+
+.tip-leg-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+  gap: 0.5rem;
+}
+
+.tip-leg-kickoff {
+  font-variant-numeric: tabular-nums;
+}
+
+.tip-leg-pick {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.tip-leg-selection {
+  font-size: 1.05rem;
+}
+
+.tip-leg-price {
+  font-weight: 700;
+  font-size: 1rem;
+  background: var(--color-primary);
+  color: white;
+  padding: 0.2rem 0.6rem;
+  border-radius: var(--radius-md, 6px);
+}
+
+.tip-leg-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.9rem;
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+}
+
+.tip-card-foot {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  border-top: 1px solid var(--color-border-subtle);
+  padding-top: 0.6rem;
+  font-size: 0.9rem;
+}
+
+.tip-totals {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.25rem;
+}
+
+.tip-stake {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -234,6 +234,50 @@ export type JobRunDetail = JobRunListItem & {
   changes: JobRunChange[];
 };
 
+// ---------------------------------------------------------------------------
+// Betting tips
+// ---------------------------------------------------------------------------
+
+export type TipMarket = "h2h" | "totals";
+export type TipKind = "single" | "double" | "treble";
+
+export type TipLeg = {
+  matchId: number;
+  homeName: string;
+  awayName: string;
+  kickoff: string; // ISO 8601 UTC
+  market: TipMarket;
+  selectionCode: "home" | "away" | "over" | "under";
+  selection: string; // display string, e.g. "Storm" or "Over 41.5"
+  line: number | null;
+  decimalOdds: number;
+  modelProb: number;
+  impliedProb: number;
+  edge: number;
+  bookmaker: string;
+};
+
+export type Tip = {
+  kind: TipKind;
+  legs: TipLeg[];
+  combinedOdds: number;
+  combinedModelProb: number;
+  combinedImpliedProb: number;
+  edge: number;
+  suggestedUnits: number;
+};
+
+export type BettingTipsResponse = {
+  season: number;
+  round: number;
+  generatedAt: string;
+  oddsSnapshotAt: string | null;
+  caveat: string;
+  singles: Tip[];
+  doubles: Tip[];
+  trebles: Tip[];
+};
+
 export type DashboardOut = {
   season: number;
   currentRound: number | null;


### PR DESCRIPTION
Closes #280.

## Summary

- New `/betting-tips` route surfaces the model's 2 best singles + 2 doubles + 2 trebles for the upcoming round, accessed from a new **Betting Tips** sidebar entry.
- Selection logic combines model `homeWinProbability` / `predictedTotal` with bookmaker odds (head-to-head from the existing nrl.com scrape; totals from the-odds-api when configured), filtered to picks with positive de-vigged edge and ranked `prob × (1 + edge) × confidenceWeight`. Multis use match-disjoint legs.
- API is read-only — tips are computed by the precompute Cloud Run Job (Tue/Thu) and cached in a new `betting_tips` collection that mirrors `predictions`. Cache miss returns `503` with `Retry-After: 3600`, matching the existing hot-path policy from #65.
- Prominent responsible-gambling banner: "model picks, not advice" framing, 18+, helpline link. No "guaranteed" language anywhere.

## What's new

**Backend**

- `src/fantasy_coach/betting/` — package with `models.py`, `odds_client.py` (httpx + respx-testable retries, gated on `FANTASY_COACH_ODDS_API_KEY`), `generator.py` (pure function), `store.py` (SQLite + Firestore, 6h TTL).
- `GET /betting-tips?season&round` in `app.py`.
- Precompute hook in `_run_precompute` after `refresh_stale_matches` — non-fatal try/except. Logs `Betting tips: wrote N singles, ...` on success.
- 24 new tests (respx odds client, synthetic-fixture generator, store roundtrip, endpoint 200/503).

**Frontend**

- `web/src/routes/BettingTips.tsx`, `components/TipCard.tsx`, `components/ResponsibleGamblingBanner.tsx`.
- Sidebar nav entry + main.tsx route registration.
- Visual style matches `MatchCard` (CSS variables, no Tailwind).

**Docs / env**

- `.env.example` + `docs/secrets.md` document the optional `FANTASY_COACH_ODDS_API_KEY` and the paired platform-infra changes needed to activate it in production.

## Ships standalone, totals enrichment is paired-PR

The branch is **fully functional without any platform-infra work** — the H2H card uses scraped nrl.com odds that already live on `PredictionOut.home.odds`. Totals legs activate later when:

1. `lopeztech/platform-infra` adds `google_secret_manager_secret.odds_api_key` + `roles/secretmanager.secretAccessor` IAM bindings on both runtime SAs, with `lifecycle.ignore_changes` updated.
2. `.github/workflows/deploy.yml` adds `--set-secrets FANTASY_COACH_ODDS_API_KEY=odds-api-key:latest` to both Cloud Run service and Job.
3. The production model becomes multi-task (so `predictedTotal` is populated).

Until then, totals lines simply never fire and the singles/doubles/trebles come from H2H only.

## Test plan

- [x] `make ci` — 932 passed, 4 skipped (pre-existing optional-dep skips), 8m35s.
- [x] `cd web && npm run build` — clean (tsc + vite).
- [ ] Post-deploy: precompute logs show `Betting tips: wrote N singles, M doubles, K trebles` on next Tue/Thu run.
- [ ] Post-deploy: `GET /betting-tips?season=2026&round=<n>` returns 200 with a valid Firebase token, 401 without.
- [ ] Post-deploy: SPA `/betting-tips` renders behind auth; banner above the fold on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)