### PR TITLE
fix: drop duplicate betting-tips block in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,15 +48,6 @@ FIREBASE_PROJECT_ID=your-firebase-project-id
 # FANTASY_COACH_ODDS_API_KEY=
 
 # ---------------------------------------------------------------------------
-# Betting tips — the-odds-api.com (optional)
-# ---------------------------------------------------------------------------
-# When set, the precompute Job fetches NRL totals (over/under) lines and adds
-# them to the weekly Betting Tips card. Unset = H2H-only card from scraped
-# nrl.com odds. Free tier is 500 req/month — Tue+Thu precompute uses ~8/month.
-# Matches the Secret Manager secret "odds-api-key".
-# FANTASY_COACH_ODDS_API_KEY=
-
-# ---------------------------------------------------------------------------
 # Push notifications (FCM) — #172
 # ---------------------------------------------------------------------------
 # VAPID key for Firebase Cloud Messaging (web push). Generate in:


### PR DESCRIPTION
## Summary

- #281 was rebased through an in-flight Gemini-model bump, and the squash merge produced two adjacent copies of the `FANTASY_COACH_ODDS_API_KEY` documentation block in `.env.example`.
- This drops the second copy. Documentation-only — no code change.

## Test plan

- [x] `git diff` on main shows the file ends with a single Betting Tips block followed by the Push Notifications block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)