### PR TITLE
feat(#280): inject FANTASY_COACH_ODDS_API_KEY into precompute Job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,8 +113,13 @@ jobs:
             --region "${REGION}" \
             --image "${IMAGE}" \
             --set-env-vars "FIREBASE_PROJECT_ID=${PROJECT_ID},STORAGE_BACKEND=firestore,FANTASY_COACH_MODEL_PATH=/tmp/model.joblib,FANTASY_COACH_MODEL_GCS_URI=gs://${PROJECT_ID}-models/logistic/latest.joblib" \
+            --set-secrets "FANTASY_COACH_ODDS_API_KEY=odds-api-key:latest" \
             --quiet || \
           echo "Job '${JOB}' not found — skipping (platform-infra#65 not applied yet)."
+          # --set-secrets injects the-odds-api.com key from Secret Manager so
+          # the precompute job can fetch NRL totals (over/under) lines for
+          # Betting Tips (#280). The IAM grant on the secret lives in
+          # platform-infra/projects/fantasy-coach/odds_api_secret.tf.
 
       - name: Update retrain Job image
         env:


### PR DESCRIPTION
Paired with [lopeztech/platform-infra#61](https://github.com/lopeztech/platform-infra/pull/61) — that PR must merge + apply **first** or this workflow's first run will fail with permission-denied on the secret.

## Summary

- `deploy.yml` adds `--set-secrets "FANTASY_COACH_ODDS_API_KEY=odds-api-key:latest"` to the precompute Cloud Run Job update step.
- Once both PRs are merged, the next push to main rolls a Job revision that can read the key. After that, the next Tuesday/Thursday precompute run will produce a Betting Tips card with totals (over/under) legs in addition to the head-to-head ones it already does.

## Test plan

- [ ] Land #61 (platform-infra) first.
- [ ] Merge this PR; the Deploy to Cloud Run workflow rolls a new Job revision without errors.
- [ ] `gcloud run jobs describe fantasy-coach-precompute --region=australia-southeast1 --format='value(spec.template.spec.taskSpec.containers[0].env)'` shows the secret reference.
- [ ] Next scheduled precompute logs `Betting tips: wrote N singles, M doubles, K trebles` and the Firestore `betting_tips/{season}-{round}` doc includes at least one `market: totals` leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)