### PR TITLE
fix(#280): correct the-odds-api sport key + redact key from httpx logs

### DIFF
--- a/src/fantasy_coach/betting/odds_client.py
+++ b/src/fantasy_coach/betting/odds_client.py
@@ -25,9 +25,20 @@ from fantasy_coach.betting.models import TotalsLine
 logger = logging.getLogger(__name__)
 
 API_BASE_URL = "https://api.the-odds-api.com/v4"
-SPORT_KEY = "rugby_league_nrl"
+# the-odds-api sport key. Confirmed against the public sports listing: the
+# slug is a single word "rugbyleague" — using "rugby_league_nrl" returns 404.
+SPORT_KEY = "rugbyleague_nrl"
 REGIONS = "au"
 MARKETS = "h2h,totals"
+
+# Raise httpx's INFO-level logger to WARNING. The default INFO log writes the
+# full request URL on every call, which includes the API key in this client's
+# query string ("?apiKey=...&regions=au..."). Without this, every odds-api
+# call leaks the secret into Cloud Logging. We can't move the key into a
+# header — the-odds-api only accepts the key via query string. WARNING is a
+# safe global setting (no other httpx caller in this codebase relies on the
+# INFO line for behaviour).
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 _RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
 

--- a/tests/test_betting_odds_client.py
+++ b/tests/test_betting_odds_client.py
@@ -10,6 +10,11 @@ from fantasy_coach.betting import odds_client
 from fantasy_coach.betting.odds_client import API_BASE_URL, SPORT_KEY, OddsApiClient
 
 
+def test_sport_key_matches_the_odds_api_slug() -> None:
+    """Regression: must be 'rugbyleague_nrl' — earlier 'rugby_league_nrl' 404'd."""
+    assert SPORT_KEY == "rugbyleague_nrl"
+
+
 @pytest.fixture(autouse=True)
 def fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
     """Don't actually sleep between retries during tests."""


### PR DESCRIPTION
Two issues from the first manual precompute run after #283 deployed:

## 1. Sport key was wrong (totals never fetched)

`SPORT_KEY` was `rugby_league_nrl`; the-odds-api's actual slug is `rugbyleague_nrl` (single word "rugbyleague"). Every call returned `404 Not Found`, so the tips card has been H2H-only since launch.

Added a regression test pinning the string.

## 2. httpx INFO logger leaked the API key into Cloud Logging

`httpx` logs the full request URL on every call. The-odds-api only accepts the API key via `?apiKey=...` (no Bearer header), so each request leaked the secret. Raise the httpx logger to `WARNING` in `odds_client` to suppress URL logging.

**The previously-leaked key value must be rotated out-of-band** (`gcloud secrets versions add odds-api-key`). The `:latest` alias means the next precompute run picks up the new version automatically.

## Test plan

- [x] `uv run pytest tests/test_betting_odds_client.py` — 7 passed.
- [ ] After merge + key rotation, manual `gcloud run jobs execute fantasy-coach-precompute` shows no `apiKey=` in Cloud Logging.
- [ ] Same run produces `betting_tips/{season}-{round}` with at least one `market: totals` leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)