### PR TITLE
chore(deploy): rotate watch-team-lists + scrape-injuries Job images (#267)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,6 +139,40 @@ jobs:
             --quiet || \
           echo "Job '${JOB}' not found — skipping (platform-infra fantasy-coach#107 not applied yet)."
 
+      - name: Update watch-team-lists Job image
+        env:
+          PROJECT_ID: ${{ secrets.FANTASY_COACH_PROJECT_ID }}
+          JOB: fantasy-coach-watch-team-lists
+        # Provisioned by platform-infra fantasy-coach#267 (injury.tf). Same
+        # rotation pattern as precompute/retrain: TF owns Job shape (command,
+        # SA, resources) and ignore_changes-es image + env; this workflow
+        # owns the image tag + runtime env vars.
+        run: |
+          gcloud run jobs update "${JOB}" \
+            --project "${PROJECT_ID}" \
+            --region "${REGION}" \
+            --image "${IMAGE}" \
+            --set-env-vars "FIREBASE_PROJECT_ID=${PROJECT_ID},STORAGE_BACKEND=firestore" \
+            --quiet || \
+          echo "Job '${JOB}' not found — skipping (platform-infra fantasy-coach#267 not applied yet)."
+
+      - name: Update scrape-injuries Job image
+        env:
+          PROJECT_ID: ${{ secrets.FANTASY_COACH_PROJECT_ID }}
+          JOB: fantasy-coach-scrape-injuries
+        # Provisioned by platform-infra fantasy-coach#267 (injury.tf). The
+        # Job is invoked manually with `--args=--season=...,--round=...`
+        # for now; Gemini parses NRL.com injury-list prose using the runtime
+        # SA's aiplatform.user grant.
+        run: |
+          gcloud run jobs update "${JOB}" \
+            --project "${PROJECT_ID}" \
+            --region "${REGION}" \
+            --image "${IMAGE}" \
+            --set-env-vars "FIREBASE_PROJECT_ID=${PROJECT_ID},STORAGE_BACKEND=firestore" \
+            --quiet || \
+          echo "Job '${JOB}' not found — skipping (platform-infra fantasy-coach#267 not applied yet)."
+
       # The external /healthz smoke test has been dropped: `gcloud auth
       # print-identity-token` doesn't work with WIF-federated credentials
       # (they're OAuth2 access tokens, not OIDC ID tokens), and Cloud Run's


### PR DESCRIPTION
## Summary

- platform-infra fantasy-coach#62 created `fantasy-coach-watch-team-lists` + `fantasy-coach-scrape-injuries` Cloud Run Jobs. Without this patch they stay on TF's placeholder `cloudrun/container/hello` image and every execution fails with "Application exec likely failed".
- Adds two more `gcloud run jobs update` steps to `deploy.yml`, mirroring the precompute + retrain pattern (`--image`, `--set-env-vars FIREBASE_PROJECT_ID + STORAGE_BACKEND=firestore`).
- Once this merges and the deploy fires, the two new Jobs will carry the real `api:<sha>` image and the `gcloud run jobs execute` smoke tests for #267 can pass.

Refs #267 (the injury pipeline scheduling). PR D (#269) is unblocked once both Jobs have a successful first execution.

## Test plan

- [ ] CI lint + tests pass.
- [ ] Deploy workflow runs the two new rotation steps without error.
- [ ] After deploy: `gcloud run jobs execute fantasy-coach-watch-team-lists --region=australia-southeast1 --wait` completes with exit 0 (no-op when no kickoff is imminent).
- [ ] `gcloud run jobs execute fantasy-coach-scrape-injuries --region=australia-southeast1 --wait --args=--season=2026,--round=<current>` parses an article and writes rows to `injury_reports`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)