### PR TITLE
Add injury-severity feature from scraped NRL injury list (#269)

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -423,9 +423,58 @@ so the logistic can learn to down-weight the adjusted versions when they are noi
 - **Bookmaker odds** — high-signal but not a feature we can train on
   historically (odds drop out of the fixtures payload after kickoff). See
   issues #13 (benchmark vs closing lines) and #26 (live odds feature).
-- **Team-list / injury status** — issues #24 (parsing) and #27 (modelling).
 - **Player-level stats** — kept out of the baseline. Will come in once
   XGBoost (#25) makes nonlinear interactions worth modelling.
+
+(Team-list availability shipped under #27 as `key_absence_diff` /
+`player_strength_diff`; structured injury *health* status shipped under #269 —
+see "Injury severity feature" below.)
+
+### Injury severity feature (#208 / #269)
+
+The availability features (`key_absence_diff`, `player_strength_diff`) only know
+whether a player is on the team list — binary in-or-out. The injury feature adds
+*health status* the team list can't express, sourced from the scraped weekly NRL
+injury list (`injury_reports`) — parsed from prose by Gemini and backfilled
+historically via the Wayback Machine (#268), which lives outside the walk-forward
+match history.
+
+| Feature | Definition | Why |
+|---------|-----------|-----|
+| `injury_severity_diff` | Per team, a **position-weighted count** of currently-listed players: Σ `status_weight × POSITION_WEIGHTS[pos]` over active reports (OUT/SUSPENDED 1.0, TEST 0.5, 21-man-squad 0.25; RETURNING excluded). The injured player's position comes from the walk-forward `player_ratings` book. Home − away, clamped to ±`INJURY_SEVERITY_DIFF_CAP` (50). | Carrying multiple injured spine players is a real strength signal the team list misses (an injured player named on the list still counts as "available" there). |
+| `missing_injury_data` | 1.0 when no injury list was scraped for this `(season, round)`. | Mirrors the other `missing_*` flags so the model learns a separate intercept for "no injury signal" rather than reading a quiet week as a zeroed-out one. A scraped week with no injuries for these teams is **not** missing. |
+
+**Why a count, not a severity × duration.** #269 originally specified
+`Σ status_weight × weeks_out` plus a returning-player count and a late-withdrawal
+count. A walk-forward ablation (2024–2025, `scripts/ab_injury_backtest.py`) killed
+all three:
+
+- The full 4-feature set **degraded** the model (−1.4pp accuracy, +0.008 log-loss).
+- The Gemini-estimated `weeks_out` was the culprit — dropping it (a binary count)
+  flipped the result to net-positive. The returning count was net-harmful (the
+  "rust" hypothesis didn't hold) and `late_withdrawal_diff` is ~always 0.0
+  historically (the kickoff-hour watcher only runs live), so both were cut.
+- Final position-weighted binary severity: **+0.7pp accuracy, −0.0016 log-loss,
+  −0.0008 Brier** — net-positive on all three, clearing #208's acceptance gate.
+
+The returning and late-withdrawal data is still collected (`injury_reports`
+RETURNING rows; the `watch-team-lists` watcher's `late_team_changes`) for a future
+revisit once live late-change history accumulates.
+
+**Plumbing.** The data is supplied to `FeatureBuilder` via an `InjuryIndex`
+(keyed by `(season, round, team_id)`). Because the evaluation harness and training
+CLIs build `FeatureBuilder` instances deep inside predictor classes that never see
+a repo, the index is set as a process-level "active" index for the duration of a
+`train-xgboost` / `evaluate` run (`active_injury_index(...)`);
+`compute_predictions` instead passes it explicitly for the round being served. A
+*single* static index over all scraped reports is leakage-safe for walk-forward:
+scoring round R only reads `(season, R, team)` keys, whose reports were scraped
+before R's kickoff. When no index is set the features are neutral
+(`missing_injury_data = 1.0`), so the default/library path is unchanged.
+
+**Retrain.** These two names are appended to `FEATURE_NAMES`, which bumps the
+`load_model` schema check — the production XGBoost artefact must be retrained and
+re-uploaded to GCS (per the "retrain when FEATURE_NAMES changes" rule).
 
 ## Glicko-2 rating system (#162)
 

--- a/scripts/ab_injury_backtest.py
+++ b/scripts/ab_injury_backtest.py
@@ -1,0 +1,63 @@
+"""A/B walk-forward backtest for the #269 injury features.
+
+Runs the XGBoost predictor over the same seasons on the same DB twice — once
+with the scraped injury index active, once without — and prints the metric
+delta. This is the acceptance gate for #269: the injury features only ship if
+the WITH arm beats the WITHOUT arm on log-loss / Brier.
+
+    uv run python scripts/ab_injury_backtest.py --db data/nrl.db --seasons 2024,2025
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from fantasy_coach.evaluation.harness import walk_forward_from_repo
+from fantasy_coach.evaluation.predictors import XGBoostPredictor
+from fantasy_coach.feature_engineering import InjuryIndex, active_injury_index
+from fantasy_coach.storage import SQLiteRepository
+from fantasy_coach.storage.injury import SQLiteInjuryReportRepository
+
+
+def _load_index(conn, seasons: list[int]) -> InjuryIndex:
+    repo = SQLiteInjuryReportRepository(conn)
+    reports = []
+    for s in seasons:
+        reports.extend(repo.list_reports(season=s))
+    return InjuryIndex.from_records(reports)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", default="data/nrl.db")
+    ap.add_argument("--seasons", default="2024,2025")
+    args = ap.parse_args()
+    seasons = [int(s) for s in args.seasons.split(",") if s.strip()]
+
+    repo = SQLiteRepository(args.db)
+    try:
+        idx = _load_index(repo._conn, seasons)
+        print(f"injury index: {len(idx.rounds_with_data)} (season,round) keys with reports")
+
+        # WITHOUT injury features (active index = None).
+        with active_injury_index(None):
+            without = walk_forward_from_repo(repo, seasons, XGBoostPredictor)
+
+        # WITH injury features.
+        with active_injury_index(idx):
+            with_inj = walk_forward_from_repo(repo, seasons, XGBoostPredictor)
+    finally:
+        repo.close()
+
+    mw, mi = without.metrics(), with_inj.metrics()
+    print(f"\nseasons={seasons}  n={without.n}")
+    print(f"{'metric':<10}{'without':>12}{'with':>12}{'delta':>12}")
+    for k in ("accuracy", "log_loss", "brier"):
+        d = mi[k] - mw[k]
+        print(f"{k:<10}{mw[k]:>12.4f}{mi[k]:>12.4f}{d:>+12.4f}")
+    print("\nlog_loss/brier: lower is better (negative delta = injury helps)")
+    print("accuracy: higher is better (positive delta = injury helps)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fantasy_coach/__main__.py
+++ b/src/fantasy_coach/__main__.py
@@ -658,6 +658,28 @@ def _run_train_logistic(args: argparse.Namespace) -> int:
     return 0
 
 
+def _load_injury_index_for_seasons(conn: Any, seasons: list[int]) -> Any:
+    """Build an InjuryIndex from the SQLite injury store for the given seasons.
+
+    Returns None on any failure (⇒ neutral injury features) so training/eval
+    never hard-fails just because the injury tables are empty or absent.
+    """
+    from fantasy_coach.feature_engineering import InjuryIndex  # noqa: PLC0415
+    from fantasy_coach.storage.injury import SQLiteInjuryReportRepository  # noqa: PLC0415
+
+    try:
+        repo = SQLiteInjuryReportRepository(conn)
+        reports: list[Any] = []
+        for s in seasons:
+            reports.extend(repo.list_reports(season=s))
+        if not reports:
+            return None
+        return InjuryIndex.from_records(reports)
+    except Exception as exc:  # noqa: BLE001
+        print(f"injury index unavailable ({exc}); training with neutral injury features")
+        return None
+
+
 def _run_train_xgboost(args: argparse.Namespace) -> int:
     """Train XGBoost + write artefact at the same joblib shape as logistic.
 
@@ -665,6 +687,7 @@ def _run_train_xgboost(args: argparse.Namespace) -> int:
     artefacts at the GCS path the Job pulls from is the only step needed
     to promote XGBoost to production (#136).
     """
+    from fantasy_coach.feature_engineering import active_injury_index  # noqa: PLC0415
     from fantasy_coach.models.xgboost_model import (  # noqa: PLC0415
         save_model as save_xgb,
     )
@@ -677,12 +700,17 @@ def _run_train_xgboost(args: argparse.Namespace) -> int:
         matches = []
         for season in args.season:
             matches.extend(repo.list_matches(season))
+        # Build the injury index from the same DB before closing the connection.
+        injury_index = _load_injury_index_for_seasons(repo._conn, list(args.season))
     finally:
         repo.close()
 
-    frame = build_training_frame(matches)
-    result = train_xgboost(frame, test_fraction=args.test_fraction)
+    with active_injury_index(injury_index):
+        frame = build_training_frame(matches)
+        result = train_xgboost(frame, test_fraction=args.test_fraction)
     save_xgb(result, args.out)
+    if injury_index is not None:
+        print(f"injury index active: {len(injury_index.rounds_with_data)} rounds with reports")
 
     print(
         f"Trained on {result.n_train} matches, tested on {result.n_test}. "
@@ -718,11 +746,17 @@ def _run_evaluate(args: argparse.Namespace) -> int:
         else:
             factories[name] = _BUILTIN_PREDICTORS[name]
 
+    from fantasy_coach.feature_engineering import active_injury_index  # noqa: PLC0415
+
     repo = SQLiteRepository(args.db)
     try:
+        injury_index = _load_injury_index_for_seasons(repo._conn, seasons)
+        if injury_index is not None:
+            print(f"injury index active: {len(injury_index.rounds_with_data)} rounds with reports")
         results = []
-        for model_name in args.model:
-            results.append(walk_forward_from_repo(repo, seasons, factories[model_name]))
+        with active_injury_index(injury_index):
+            for model_name in args.model:
+                results.append(walk_forward_from_repo(repo, seasons, factories[model_name]))
 
         clv_reports = None
         if args.profit:
@@ -903,6 +937,18 @@ def _run_precompute(args: argparse.Namespace) -> int:
         conn = getattr(repo, "_conn", None)
         team_list_repo = SQLiteTeamListRepository(conn) if conn is not None else None
 
+    # Injury feed for the #269 severity feature. Same backend switch as team
+    # lists. Non-fatal on wiring failure — compute_predictions treats a None
+    # repo as "no injury data" (missing_injury_data=1.0).
+    from fantasy_coach.storage.injury import get_injury_report_repository  # noqa: PLC0415
+
+    _inj_conn = getattr(repo, "_conn", None)
+    try:
+        injury_repo: Any = get_injury_report_repository(sqlite_conn=_inj_conn)
+    except Exception as _inj_e:  # noqa: BLE001
+        print(f"injury repo unavailable ({_inj_e}); predictions will set missing_injury_data=1")
+        injury_repo = None
+
     # Start RSS sampler and cProfile when --profile / FANTASY_COACH_PROFILE=1.
     _rss_stop = None
     _profiler = None
@@ -937,6 +983,7 @@ def _run_precompute(args: argparse.Namespace) -> int:
             force=not args.no_force,
             team_list_repo=team_list_repo,
             weather_forecasts=weather_forecasts,
+            injury_repo=injury_repo,
         )
         # Refresh any previously-scraped matches whose outcomes should be
         # known by now but weren't captured — the precompute flow only

--- a/src/fantasy_coach/feature_engineering.py
+++ b/src/fantasy_coach/feature_engineering.py
@@ -31,7 +31,8 @@ from __future__ import annotations
 
 import math
 from collections import Counter, defaultdict, deque
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -39,6 +40,7 @@ import numpy as np
 
 from fantasy_coach.bookmaker.lines import devig_two_way
 from fantasy_coach.features import MatchRow, PlayerMatchStat, PlayerRow, TeamStat
+from fantasy_coach.injury import InjuryReport, InjuryStatus
 from fantasy_coach.models.elo import Elo
 from fantasy_coach.models.elo_mov import EloMOV
 from fantasy_coach.models.player_ratings import POSITION_GROUPS, PlayerRatings
@@ -265,6 +267,31 @@ FEATURE_NAMES = (
     "team_fatigue_index_diff",
     "spine_fatigue_index_diff",
     "cumulative_origin_minutes_diff",
+    # Structured injury intelligence (#208 / #269). Sourced from the scraped
+    # weekly NRL injury list (``injury_reports``) rather than the match team
+    # list, so it captures *health status* the binary in-or-out availability
+    # features (``key_absence_diff`` / ``player_strength_diff``) cannot.
+    #
+    # injury_severity_diff: per team, a position-weighted *count* of currently
+    #   listed players (Σ ``status_weight × POSITION_WEIGHTS[pos]`` over the
+    #   team's active reports — OUT/SUSPENDED full weight, TEST half, 21-man
+    #   quarter; RETURNING excluded). Home minus away, clamped to
+    #   ±INJURY_SEVERITY_DIFF_CAP. Deliberately ignores the source's
+    #   ``weeks_out`` estimate: a #269 ablation showed the (noisy, Gemini-
+    #   parsed) duration *worsened* log-loss/Brier, while the binary count
+    #   improved accuracy, log-loss, and Brier together.
+    # missing_injury_data: 1.0 when no injury list was available for this
+    #   (season, round) — mirrors the ``missing_*`` pattern so the model
+    #   learns a separate intercept for "no injury signal" rather than reading
+    #   a quiet week as a zeroed-out one.
+    #
+    # The returning-player and late-withdrawal signals #269 also proposed are
+    # deferred: the same ablation found returning-count net-harmful (the "rust"
+    # hypothesis didn't hold) and late-withdrawals carry no historical training
+    # signal (the kickoff-hour watcher only runs live). Their data is still
+    # collected for a future revisit.
+    "injury_severity_diff",
+    "missing_injury_data",
 )
 
 # Plain-English rationale in docs/model.md. These are expert-prior weights:
@@ -281,6 +308,23 @@ FEATURE_NAMES = (
 # the same audit showed loses head-to-head with the market 43.4% vs 56.6%.
 # 1000 ≈ ½σ; preserves the directional signal while bounding leverage.
 PLAYER_STRENGTH_DIFF_CAP = 1000.0
+
+# Injury-severity status weights (#269). A confirmed OUT or a suspension costs
+# the full availability of the player; a fitness TEST is a coin-flip so it
+# carries half; a 21-man-squad listing is a fringe selection so a quarter.
+# RETURNING is 0.0 — it isn't an absence, and a #269 ablation found a
+# returning-player count net-harmful, so it doesn't feed severity.
+INJURY_STATUS_WEIGHTS: dict[InjuryStatus, float] = {
+    InjuryStatus.OUT: 1.0,
+    InjuryStatus.SUSPENDED: 1.0,
+    InjuryStatus.TEST: 0.5,
+    InjuryStatus.SQUAD_21: 0.25,
+    InjuryStatus.RETURNING: 0.0,
+}
+# Bound |injury_severity_diff| so a pile-up of injuries on one side can't
+# dominate the model — mirrors player_strength_diff's cap. A position-weighted
+# count rarely approaches this; it only guards pathological scrapes.
+INJURY_SEVERITY_DIFF_CAP = 50.0
 
 POSITION_WEIGHTS: dict[str, float] = {
     "Halfback": 3.0,
@@ -366,6 +410,69 @@ class TrainingFrame:
     feature_names: tuple[str, ...] = FEATURE_NAMES
 
 
+# Process-level "active" injury index (#269). The walk-forward evaluation
+# harness and the training CLIs build hundreds of FeatureBuilder instances
+# nested deep inside predictor classes that only receive match lists, never a
+# repo. Threading the index through every one is impractical, so the CLI entry
+# points set it here for the duration of a run and FeatureBuilder falls back to
+# it when no index is passed explicitly. A *single* static index over all
+# scraped reports is leakage-safe for walk-forward: scoring round R only ever
+# looks up (season, R, team) keys, whose reports were scraped before round R's
+# kickoff — later rounds' reports sit in the index but are never read for R.
+# Defaults to None (neutral injury features), so tests and library callers are
+# unaffected.
+_ACTIVE_INJURY_INDEX: InjuryIndex | None = None
+
+
+def set_active_injury_index(index: InjuryIndex | None) -> None:
+    """Set the process-level injury index FeatureBuilder falls back to."""
+    global _ACTIVE_INJURY_INDEX
+    _ACTIVE_INJURY_INDEX = index
+
+
+@contextmanager
+def active_injury_index(index: InjuryIndex | None) -> Iterator[None]:
+    """Scope an active injury index to a ``with`` block, restoring the prior one."""
+    global _ACTIVE_INJURY_INDEX
+    prev = _ACTIVE_INJURY_INDEX
+    _ACTIVE_INJURY_INDEX = index
+    try:
+        yield
+    finally:
+        _ACTIVE_INJURY_INDEX = prev
+
+
+@dataclass(frozen=True)
+class InjuryIndex:
+    """Pre-loaded lookup of scraped injury reports for feature building.
+
+    The injury feature pulls from the scraped ``injury_reports`` store, which
+    lives outside the walk-forward match history — so, unlike Elo or rolling
+    form, it can't be rebuilt incrementally in ``record()``; it has to be
+    supplied. This index is built once and handed to ``FeatureBuilder``.
+
+    - ``reports`` is keyed by ``(season, round, team_id)``.
+    - ``rounds_with_data`` is the set of ``(season, round)`` for which an
+      injury list was actually scraped, so the feature can tell a genuinely
+      quiet week (data present, no injuries) apart from a missing one.
+
+    When a ``FeatureBuilder`` has no index, the injury features emit neutral
+    0.0 with ``missing_injury_data = 1.0``.
+    """
+
+    reports: dict[tuple[int, int, int], list[InjuryReport]]
+    rounds_with_data: frozenset[tuple[int, int]]
+
+    @classmethod
+    def from_records(cls, reports: Iterable[InjuryReport]) -> InjuryIndex:
+        by_team: dict[tuple[int, int, int], list[InjuryReport]] = defaultdict(list)
+        rounds: set[tuple[int, int]] = set()
+        for r in reports:
+            by_team[(r.season, r.round, r.team_id)].append(r)
+            rounds.add((r.season, r.round))
+        return cls(reports=dict(by_team), rounds_with_data=frozenset(rounds))
+
+
 class FeatureBuilder:
     """Stateful per-match feature computation.
 
@@ -379,7 +486,14 @@ class FeatureBuilder:
         elo: Elo | None = None,
         *,
         player_ratings: PlayerRatings | None = None,
+        injury_index: InjuryIndex | None = None,
     ) -> None:
+        # Scraped injury intelligence (#269). Optional: falls back to the
+        # process-level active index (set by the training/eval CLIs) and is
+        # None ⇒ the injury features emit neutral 0.0 with
+        # missing_injury_data=1.0. Not rebuilt in record() — it's external
+        # data, supplied at construction.
+        self.injury_index = injury_index if injury_index is not None else _ACTIVE_INJURY_INDEX
         # EloMOV promoted over plain Elo in #106: +2.36pp accuracy on the
         # 2024–2025 walk-forward baseline (plain Elo still available via Elo()).
         self.elo = elo or EloMOV()
@@ -584,6 +698,20 @@ class FeatureBuilder:
         origin_min_h = self._cumulative_origin_minutes(match.home.players, match.start_time)
         origin_min_a = self._cumulative_origin_minutes(match.away.players, match.start_time)
 
+        # Structured injury severity feature (#269).
+        inj_sev_h = self._injury_severity(match.season, match.round, h_id)
+        inj_sev_a = self._injury_severity(match.season, match.round, a_id)
+        injury_severity_diff = max(
+            -INJURY_SEVERITY_DIFF_CAP, min(INJURY_SEVERITY_DIFF_CAP, inj_sev_h - inj_sev_a)
+        )
+        # 1.0 only when the week's injury list was genuinely unavailable — a
+        # scraped week with no injuries for these teams still counts as data.
+        has_injury_data = (
+            self.injury_index is not None
+            and (match.season, match.round) in self.injury_index.rounds_with_data
+        )
+        missing_injury_data = 0.0 if has_injury_data else 1.0
+
         return [
             elo_diff,
             form_pf_h - form_pf_a,
@@ -649,7 +777,35 @@ class FeatureBuilder:
             fat_h - fat_a,
             sfat_h - sfat_a,
             origin_min_h - origin_min_a,
+            injury_severity_diff,
+            missing_injury_data,
         ]
+
+    def _injury_severity(self, season: int, round_: int, team_id: int) -> float:
+        """Position-weighted *count* of a team's currently-listed players.
+
+        Σ ``status_weight × POSITION_WEIGHTS[pos]`` over the team's active
+        injury reports for the round, excluding RETURNING. Binary on purpose —
+        the source's ``weeks_out`` estimate is dropped (a #269 ablation showed
+        it hurt calibration). The injured player's position is resolved from
+        the walk-forward ``player_ratings`` book (their most-common starting
+        slot), defaulting to weight 1.0 when unknown. 0.0 when no index is set
+        or the team has no reports for the round.
+        """
+        idx = self.injury_index
+        if idx is None:
+            return 0.0
+        reports = idx.reports.get((season, round_, team_id))
+        if not reports:
+            return 0.0
+        severity = 0.0
+        for r in reports:
+            status_weight = INJURY_STATUS_WEIGHTS.get(r.status, 0.0)
+            if status_weight == 0.0:  # RETURNING / unknown
+                continue
+            pos = self.player_ratings.position(r.player_id)
+            severity += status_weight * POSITION_WEIGHTS.get(pos or "", 1.0)
+        return severity
 
     def _ladder_features(
         self, round_: int, h_id: int, a_id: int
@@ -1154,11 +1310,15 @@ def build_training_frame(
     *,
     elo: Elo | None = None,
     drop_draws: bool = True,
+    injury_index: InjuryIndex | None = None,
 ) -> TrainingFrame:
     """Compute features for every completed match in chronological order.
 
     Draws are dropped by default — logistic regression wants binary targets
     and NRL has very few draws, so excluding them is cleaner than relabelling.
+
+    ``injury_index`` supplies the scraped injury / late-withdrawal data for the
+    #269 features; ``None`` leaves them neutral (missing_injury_data=1.0).
     """
 
     completed = sorted(
@@ -1166,7 +1326,7 @@ def build_training_frame(
         key=lambda m: (m.start_time, m.match_id),
     )
 
-    builder = FeatureBuilder(elo=elo)
+    builder = FeatureBuilder(elo=elo, injury_index=injury_index)
     rows: list[list[float]] = []
     targets: list[int] = []
     match_ids: list[int] = []

--- a/src/fantasy_coach/predictions.py
+++ b/src/fantasy_coach/predictions.py
@@ -871,10 +871,33 @@ def _confidence_band(spread: float, ood_similarity: float) -> str:
     return "low"
 
 
-def _build_inference_state(history: list[MatchRow]) -> Any:
+def _load_injury_index(injury_repo: Any, season: int, round_: int) -> Any:
+    """Build an ``InjuryIndex`` for the round being predicted.
+
+    Only the target round's reports matter at inference — historical matches
+    are ``record()``-ed for walk-forward state but never feature-rowed, so
+    their injury data is never read. Returns ``None`` (⇒ neutral injury
+    features, missing_injury_data=1.0) when no injury repo is wired or the
+    lookup fails, so a Firestore hiccup degrades gracefully rather than
+    breaking the whole precompute.
+    """
+    if injury_repo is None:
+        return None
+    from fantasy_coach.feature_engineering import InjuryIndex  # noqa: PLC0415
+
+    try:
+        reports = injury_repo.list_reports(season=season, round=round_)
+    except Exception:
+        logger.exception("injury index: list_reports failed for %d r%d", season, round_)
+        return None
+    logger.info("injury index: %d reports for %d r%d", len(reports), season, round_)
+    return InjuryIndex.from_records(reports)
+
+
+def _build_inference_state(history: list[MatchRow], injury_index: Any = None) -> Any:
     from fantasy_coach.feature_engineering import FeatureBuilder  # noqa: PLC0415
 
-    builder = FeatureBuilder()
+    builder = FeatureBuilder(injury_index=injury_index)
     for match in sorted(history, key=lambda m: (m.start_time, m.match_id)):
         if match.home.score is None or match.away.score is None:
             continue
@@ -961,6 +984,7 @@ def compute_predictions(
     force: bool = False,
     team_list_repo: Any = None,
     weather_forecasts: dict[int, Any] | None = None,
+    injury_repo: Any = None,
 ) -> list[PredictionOut]:
     """Return predictions for season/round; compute and cache them on miss.
 
@@ -1052,7 +1076,8 @@ def compute_predictions(
             if m.season < season or (m.season == season and m.round < round_):
                 history.append(m)
 
-    builder = _build_inference_state(history)
+    injury_index = _load_injury_index(injury_repo, season, round_)
+    builder = _build_inference_state(history, injury_index)
 
     import numpy as np  # noqa: PLC0415
 

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -1087,3 +1087,181 @@ def test_fatigue_decays_over_time() -> None:
     )
     # Fatigue from 7 days ago > fatigue from 60 days ago.
     assert row_recent["team_fatigue_index_diff"] > row_old["team_fatigue_index_diff"]
+
+
+# ---------------------------------------------------------------------------
+# Injury severity feature (#269)
+# ---------------------------------------------------------------------------
+
+
+def _injury_row(builder, match):
+    """Return the match's feature row as a {name: value} dict."""
+    return dict(zip(FEATURE_NAMES, builder.feature_row(match), strict=True))
+
+
+def _report(player_id, team_id, status, *, season=2025, round=1):
+    from fantasy_coach.injury import InjuryReport
+
+    return InjuryReport(
+        player_id=player_id,
+        season=season,
+        round=round,
+        team_id=team_id,
+        status=status,
+        weeks_out=None,
+        body_part=None,
+        source="test",
+        scraped_at=datetime(2025, 2, 25, tzinfo=UTC),
+    )
+
+
+def test_injury_features_neutral_without_index() -> None:
+    from fantasy_coach.feature_engineering import FeatureBuilder
+
+    match = _make_match_with_players([_player(1, "Halfback")], [_player(2, "Prop")])
+    row = _injury_row(FeatureBuilder(), match)
+    assert row["injury_severity_diff"] == 0.0
+    assert row["missing_injury_data"] == 1.0
+
+
+def test_injury_severity_status_weighted_and_binary() -> None:
+    from fantasy_coach.feature_engineering import FeatureBuilder, InjuryIndex
+    from fantasy_coach.injury import InjuryStatus
+
+    # Positions unknown (players never recorded) ⇒ weight 1.0 each. Home has one
+    # OUT (1.0), away one TEST (0.5). Severity is a count — weeks_out ignored.
+    idx = InjuryIndex.from_records(
+        [_report(101, 10, InjuryStatus.OUT), _report(201, 20, InjuryStatus.TEST)]
+    )
+    match = _make_match_with_players([_player(1, "Halfback")], [_player(2, "Prop")])
+    row = _injury_row(FeatureBuilder(injury_index=idx), match)
+    assert row["injury_severity_diff"] == pytest.approx(0.5)
+    assert row["missing_injury_data"] == 0.0
+
+
+def test_injury_severity_ignores_weeks_out() -> None:
+    from fantasy_coach.feature_engineering import FeatureBuilder, InjuryIndex
+    from fantasy_coach.injury import InjuryReport, InjuryStatus
+
+    def out(pid, team, weeks):
+        return InjuryReport(
+            player_id=pid,
+            season=2025,
+            round=1,
+            team_id=team,
+            status=InjuryStatus.OUT,
+            weeks_out=weeks,
+            body_part=None,
+            source="t",
+            scraped_at=datetime(2025, 2, 25, tzinfo=UTC),
+        )
+
+    # Same player count, wildly different weeks_out → identical severity.
+    short = InjuryIndex.from_records([out(101, 10, 1)])
+    long = InjuryIndex.from_records([out(101, 10, 26)])
+    match = _make_match_with_players([_player(1, "Halfback")], [_player(2, "Prop")])
+    s = _injury_row(FeatureBuilder(injury_index=short), match)["injury_severity_diff"]
+    long_ = _injury_row(FeatureBuilder(injury_index=long), match)["injury_severity_diff"]
+    assert s == pytest.approx(long_)
+
+
+def test_injury_severity_position_weighted() -> None:
+    from fantasy_coach.feature_engineering import (
+        POSITION_WEIGHTS,
+        FeatureBuilder,
+        InjuryIndex,
+    )
+    from fantasy_coach.injury import InjuryStatus
+
+    # Teach the builder that player 101 is a Halfback by recording a prior match
+    # where they started there, then rule them OUT in a later round.
+    prior = _make_match_with_players(
+        [_player(101, "Halfback"), _player(102, "Prop")],
+        [_player(201, "Hooker"), _player(202, "Lock")],
+        match_id=1,
+    )
+    idx = InjuryIndex.from_records([_report(101, 10, InjuryStatus.OUT, round=2)])
+    later = MatchRow(
+        match_id=2,
+        season=2025,
+        round=2,
+        start_time=datetime(2025, 3, 10, tzinfo=UTC),
+        match_state="Upcoming",
+        venue=None,
+        venue_city=None,
+        weather=None,
+        home=TeamRow(
+            team_id=10, name="H", nick_name="H", score=None, players=[_player(102, "Prop")]
+        ),
+        away=TeamRow(
+            team_id=20, name="A", nick_name="A", score=None, players=[_player(201, "Hooker")]
+        ),
+        team_stats=[],
+    )
+    fb = FeatureBuilder(injury_index=idx)
+    fb.record(prior)  # learns player 101's Halfback position walk-forward
+    row = _injury_row(fb, later)
+    # Halfback weight (3.0) >> the default 1.0 for an unknown player.
+    assert row["injury_severity_diff"] == pytest.approx(POSITION_WEIGHTS["Halfback"])
+
+
+def test_missing_injury_data_zero_for_scraped_quiet_week() -> None:
+    from fantasy_coach.feature_engineering import FeatureBuilder, InjuryIndex
+    from fantasy_coach.injury import InjuryStatus
+
+    # The round was scraped (a report exists for some other team), but neither
+    # of these two teams has an injury — that's data, not a gap.
+    idx = InjuryIndex.from_records([_report(999, 30, InjuryStatus.OUT)])
+    match = _make_match_with_players([_player(1, "Halfback")], [_player(2, "Prop")])
+    row = _injury_row(FeatureBuilder(injury_index=idx), match)
+    assert row["missing_injury_data"] == 0.0
+    assert row["injury_severity_diff"] == 0.0
+
+
+def test_injury_severity_diff_is_capped() -> None:
+    from fantasy_coach.feature_engineering import (
+        INJURY_SEVERITY_DIFF_CAP,
+        FeatureBuilder,
+        InjuryIndex,
+    )
+    from fantasy_coach.injury import InjuryStatus
+
+    # 60 unknown-position OUT players on the home side ⇒ raw severity 60,
+    # clamped to the cap.
+    idx = InjuryIndex.from_records([_report(1000 + i, 10, InjuryStatus.OUT) for i in range(60)])
+    match = _make_match_with_players([_player(1, "Halfback")], [_player(2, "Prop")])
+    row = _injury_row(FeatureBuilder(injury_index=idx), match)
+    assert row["injury_severity_diff"] == pytest.approx(INJURY_SEVERITY_DIFF_CAP)
+
+
+def test_returning_status_carries_no_severity() -> None:
+    from fantasy_coach.feature_engineering import FeatureBuilder, InjuryIndex
+    from fantasy_coach.injury import InjuryStatus
+
+    # RETURNING is excluded from severity (its rust hypothesis didn't hold in
+    # the #269 ablation), but the round still counts as scraped.
+    idx = InjuryIndex.from_records([_report(101, 10, InjuryStatus.RETURNING)])
+    match = _make_match_with_players([_player(1, "Halfback")], [_player(2, "Prop")])
+    row = _injury_row(FeatureBuilder(injury_index=idx), match)
+    assert row["injury_severity_diff"] == 0.0
+    assert row["missing_injury_data"] == 0.0
+
+
+def test_active_injury_index_context_applies_to_bare_builder() -> None:
+    from fantasy_coach.feature_engineering import (
+        FeatureBuilder,
+        InjuryIndex,
+        active_injury_index,
+    )
+    from fantasy_coach.injury import InjuryStatus
+
+    idx = InjuryIndex.from_records([_report(101, 10, InjuryStatus.OUT)])
+    match = _make_match_with_players([_player(1, "Halfback")], [_player(2, "Prop")])
+    # A FeatureBuilder() constructed with no explicit index picks up the active one.
+    with active_injury_index(idx):
+        row = _injury_row(FeatureBuilder(), match)
+    assert row["injury_severity_diff"] == pytest.approx(1.0)
+    # Outside the context the fallback is gone again.
+    row_after = _injury_row(FeatureBuilder(), match)
+    assert row_after["injury_severity_diff"] == 0.0
+    assert row_after["missing_injury_data"] == 1.0


### PR DESCRIPTION
Closes #269. Part of #208.

Wires the scraped weekly NRL injury list (`injury_reports`, backfilled via Wayback+Gemini in #268) into the model as **`injury_severity_diff`** — a position-weighted *count* of a team's currently-listed players (OUT/SUSPENDED 1.0, TEST 0.5, 21-man 0.25; RETURNING excluded; injured player's position resolved from the walk-forward `player_ratings` book) — plus a **`missing_injury_data`** flag. This captures *health status* the binary team-list availability features (`key_absence_diff` / `player_strength_diff`) can't express.

`FEATURE_NAMES` goes 64 → 66.

## How the design was chosen (acceptance gate)

#208's gate is a net-positive walk-forward log-loss/Brier improvement. I ran an A/B (`scripts/ab_injury_backtest.py`, XGBoost, 2024–2025, identical data, with vs without injury):

| variant | accuracy | log_loss | brier |
|---------|----------|----------|-------|
| baseline | 0.6156 | 0.6858 | 0.2435 |
| #269 full 4-feature spec | −1.4pp | +0.008 ❌ | +0.004 ❌ |
| **shipped: position-weighted binary severity** | **+0.7pp** | **−0.0016 ✓** | **−0.0008 ✓** |

Key findings:
- The Gemini-estimated **`weeks_out`** was the noise source — dropping it (a binary count) is what flips the result net-positive.
- **`returning_player_count_diff`** was net-harmful (the "rust" hypothesis didn't hold) and **`late_withdrawal_diff`** carries ~no historical signal (the kickoff-hour watcher only runs live). Both are **deferred**; their data is still collected for a future revisit.
- In the retrained model, `injury_severity_diff` lands at **importance rank 20/66**.

## Plumbing
- `InjuryIndex` (keyed by `(season, round, team_id)`) supplied to `FeatureBuilder`. Because the eval harness / training CLIs build builders deep inside predictor classes that never see a repo, it's set as a process-level **active index** for the duration of a `train-xgboost`/`evaluate` run; `compute_predictions` passes it explicitly per round. A single static index is **leakage-safe** for walk-forward (scoring round R only reads `(season, R, team)` keys, scraped pre-kickoff).
- Neutral (`missing_injury_data=1.0`) when unset → default/library path and **pinned baseline metrics unchanged** (no re-pin needed).

## Tests
- 8 new injury-feature unit tests; full suite green (only pre-existing `pymc`/`optuna` skips).

## ⚠️ Deploy coordination
Appending to `FEATURE_NAMES` bumps the `load_model` schema — **the GCS XGBoost artefact (`gs://fantasy-coach-lcd-models/logistic/latest.joblib`) must be retrained to 66 features and re-uploaded in lockstep with this deploy**, and the upcoming round's `injury_reports` must be in Firestore, or precompute will build 66-feature rows against a 64-feature model. Follow-ups: Firestore injury backfill (2024–2026) + GCS model swap + scheduling the scraper (#267).

🤖 Generated with [Claude Code](https://claude.com/claude-code)